### PR TITLE
Add Mergify rules to repository

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: Node.js CI
 
 on:
@@ -12,19 +9,17 @@ jobs:
   test:
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x]
         os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}    
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - run: npm install yarn
-
       - id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ matrix.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -34,4 +29,3 @@ jobs:
       - run: yarn build
       - run: yarn lint
       - run: yarn test
-   

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,9 +2,7 @@ pull_request_rules:
   - name: Merge approved and green PRs with `merge when green` label
     conditions:
       - "#approved-reviews-by>=1"
-      - status-success=test (10.x, ubuntu-latest)
       - status-success=test (12.x, ubuntu-latest)
-      - status-success=test (14.x, ubuntu-latest)
       - base=main
       - label=merge when green
     actions:
@@ -15,9 +13,7 @@ pull_request_rules:
   - name: Automatic merge for Dependabot pull requests
     conditions:
       - author~=^dependabot(|-preview)\[bot\]$
-      - status-success=test (10.x, ubuntu-latest)
       - status-success=test (12.x, ubuntu-latest)
-      - status-success=test (14.x, ubuntu-latest)
       - base=main
     actions:
       merge:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,26 @@
+pull_request_rules:
+  - name: Merge approved and green PRs with `merge when green` label
+    conditions:
+      - "#approved-reviews-by>=1"
+      - status-success=test (10.x, ubuntu-latest)
+      - status-success=test (12.x, ubuntu-latest)
+      - status-success=test (14.x, ubuntu-latest)
+      - base=main
+      - label=merge when green
+    actions:
+      merge:
+        method: squash
+        strict: smart+fasttrack
+        commit_message: title+body
+  - name: Automatic merge for Dependabot pull requests
+    conditions:
+      - author~=^dependabot(|-preview)\[bot\]$
+      - status-success=test (10.x, ubuntu-latest)
+      - status-success=test (12.x, ubuntu-latest)
+      - status-success=test (14.x, ubuntu-latest)
+      - base=main
+    actions:
+      merge:
+        method: squash
+        strict: smart+fasttrack
+        commit_message: title+body


### PR DESCRIPTION
This PR adds a Mergify rules to the `oba-contracts` so that we can use `merge when green` feature. It also automatically merges successful dependabot PRs.

### Test Plan

I can't test this for now, as it would require enabling Mergify for this repo, which can only be done by Gnosis organization administrators. I will ask dev-ops to enable this for me :smile: 