### PR TITLE
Make use of ESLint import plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2020,
   },
-  plugins: ["@typescript-eslint", "prettier"],
+  plugins: ["@typescript-eslint", "import", "prettier"],
   extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
@@ -16,4 +16,15 @@ module.exports = {
     "prettier/@typescript-eslint",
   ],
   ignorePatterns: ["build/", "node_modules/", "!.prettierrc.js"],
+  rules: {
+    "import/order": [
+      "error",
+      {
+        "newlines-between": "always",
+        alphabetize: {
+          order: "asc",
+        },
+      },
+    ],
+  },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,8 @@ module.exports = {
   plugins: ["@typescript-eslint", "import", "prettier"],
   extends: [
     "eslint:recommended",
+    "plugin:import/recommended",
+    "plugin:import/typescript",
     "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended",
     "prettier/@typescript-eslint",

--- a/src/js/orders.spec.ts
+++ b/src/js/orders.spec.ts
@@ -1,6 +1,6 @@
 import abi from "ethereumjs-abi";
-import { utils, Wallet, Contract, BigNumber } from "ethers";
 import { ecsign } from "ethereumjs-util";
+import { utils, Wallet, Contract, BigNumber } from "ethers";
 
 export const DOMAIN_SEPARATOR =
   "0x24a654ed47680d6a76f087ec92b3a0f0fe4c9c82c26bff3bb22dffe0f120c7f0";

--- a/test/PreAMMBatcher-e2e.ts
+++ b/test/PreAMMBatcher-e2e.ts
@@ -1,13 +1,15 @@
 import { use, expect } from "chai";
-import { BigNumber, Contract, Wallet } from "ethers";
 import { deployContract, MockProvider, solidity } from "ethereum-waffle";
-import PreAMMBatcher from "../build/PreAMMBatcher.json";
-import UniswapV2Pair from "../node_modules/@uniswap/v2-core/build/UniswapV2Pair.json";
-import UniswapV2Factory from "../node_modules/@uniswap/v2-core/build/UniswapV2Factory.json";
+import { BigNumber, Contract, Wallet } from "ethers";
 
 import ERC20 from "../build/ERC20Mintable.json";
+import PreAMMBatcher from "../build/PreAMMBatcher.json";
+import UniswapV2Factory from "../node_modules/@uniswap/v2-core/build/UniswapV2Factory.json";
+import UniswapV2Pair from "../node_modules/@uniswap/v2-core/build/UniswapV2Pair.json";
 import { Order } from "../src/js/orders.spec";
+
 import { generateTestCase } from "./resources/index";
+import { TestCase } from "./resources/models";
 import {
   baseTestInput,
   fourOrderTestInput,
@@ -16,8 +18,6 @@ import {
   noSolutionTestInput,
   switchTokenTestInput,
 } from "./resources/testExamples";
-
-import { TestCase } from "./resources/models";
 
 use(solidity);
 

--- a/test/PreAMMBatcher.spec.ts
+++ b/test/PreAMMBatcher.spec.ts
@@ -1,17 +1,18 @@
 import { use, expect } from "chai";
-import { Contract, utils } from "ethers";
 import {
   deployContract,
   deployMockContract,
   MockProvider,
   solidity,
 } from "ethereum-waffle";
-import PreAMMBatcher from "../build/PreAMMBatcher.json";
-import UniswapV2Pair from "../node_modules/@uniswap/v2-core/build/UniswapV2Pair.json";
-import UniswapV2Factory from "../node_modules/@uniswap/v2-core/build/UniswapV2Factory.json";
+import { Contract, utils } from "ethers";
 
 import ERC20 from "../build/ERC20Mintable.json";
+import PreAMMBatcher from "../build/PreAMMBatcher.json";
+import UniswapV2Factory from "../node_modules/@uniswap/v2-core/build/UniswapV2Factory.json";
+import UniswapV2Pair from "../node_modules/@uniswap/v2-core/build/UniswapV2Pair.json";
 import { Order, DOMAIN_SEPARATOR } from "../src/js/orders.spec";
+
 import { baseTestInput } from "./resources/testExamples";
 
 use(solidity);

--- a/test/resources/index.ts
+++ b/test/resources/index.ts
@@ -1,6 +1,7 @@
-import { Fraction, TestCaseInput, Solution, TestCase } from "./models";
 import { BigNumber } from "ethers";
 import _ from "lodash";
+
+import { Fraction, TestCaseInput, Solution, TestCase } from "./models";
 
 export const solveTestCase = function (
   testCaseInput: TestCaseInput,

--- a/test/resources/testExamples.ts
+++ b/test/resources/testExamples.ts
@@ -1,6 +1,8 @@
-import { TestCaseInput } from "./models";
 import { Contract, Wallet, utils } from "ethers";
+
 import { Order } from "../../src/js/orders.spec";
+
+import { TestCaseInput } from "./models";
 
 export const baseTestInput = function (
   token0: Contract,


### PR DESCRIPTION
I noticed when editing the `package.json` file that we depend on `eslint-plugin-import` but don't actually use it. This PR adds it to the plugin list and sets up a rule for ordering the imports :smile:.

Note that all code modifications were automatically done by `yarn lint:fix`.

### Test Plan

We lint the code on CI