### PR TITLE
Use OpenZeppelin preset ERC20 mintable contract

### DIFF
--- a/test/PreAMMBatcher-e2e.ts
+++ b/test/PreAMMBatcher-e2e.ts
@@ -1,8 +1,8 @@
+import ERC20 from "@openzeppelin/contracts/build/contracts/ERC20PresetMinterPauser.json";
 import { use, expect } from "chai";
 import { deployContract, MockProvider, solidity } from "ethereum-waffle";
 import { BigNumber, Contract, Wallet } from "ethers";
 
-import ERC20 from "../build/artifacts/ERC20Mintable.json";
 import PreAMMBatcher from "../build/artifacts/PreAMMBatcher.json";
 import UniswapV2Factory from "../node_modules/@uniswap/v2-core/build/UniswapV2Factory.json";
 import UniswapV2Pair from "../node_modules/@uniswap/v2-core/build/UniswapV2Pair.json";


### PR DESCRIPTION
This PR removes the `test/ERC20Mintable.sol` contract and just uses the OpenZeppelin one.

### Test PLan

Tests still pass without modification.