### PR TITLE
[Testing] removeTopElement

### DIFF
--- a/src/contracts/PreAMMBatcher.sol
+++ b/src/contracts/PreAMMBatcher.sol
@@ -412,7 +412,7 @@ contract PreAMMBatcher {
         pure
         returns (Order[] memory)
     {
-        require(orders.length > 0, "Can't remove elements from an empty list");
+        require(orders.length > 0, "Can't remove from empty list");
         // delete orders[orders.length - 1];
         // return orders;
         Order[] memory newOrders = new Order[](orders.length - 1);

--- a/src/contracts/PreAMMBatcher.sol
+++ b/src/contracts/PreAMMBatcher.sol
@@ -299,7 +299,7 @@ contract PreAMMBatcher {
                 // take violated order with highest bid out
                 return
                     calculateSettlementPrice(
-                        removeTopElement(sellOrderToken0),
+                        removeLastElement(sellOrderToken0),
                         sellOrderToken1,
                         uniswapPool
                     );
@@ -315,7 +315,7 @@ contract PreAMMBatcher {
                 return
                     calculateSettlementPrice(
                         sellOrderToken0,
-                        removeTopElement(sellOrderToken1),
+                        removeLastElement(sellOrderToken1),
                         uniswapPool
                     );
             }
@@ -406,11 +406,12 @@ contract PreAMMBatcher {
         }
     }
 
-    function removeTopElement(Order[] memory orders)
-        public
+    function removeLastElement(Order[] memory orders)
+        internal
         pure
         returns (Order[] memory)
     {
+        require(orders.length > 0, "Can't remove elements from an empty list");
         // delete orders[orders.length - 1];
         // return orders;
         Order[] memory newOrders = new Order[](orders.length - 1);

--- a/src/contracts/test/PreAMMBatcherTestInerface.sol
+++ b/src/contracts/test/PreAMMBatcherTestInerface.sol
@@ -20,4 +20,12 @@ contract PreAMMBatcherTestInterface is PreAMMBatcher {
     ) public pure {
         super.orderChecks(sellOrderToken0, sellOrderToken1);
     }
+
+    function removeLastElementTest(Order[] memory orders)
+        public
+        pure
+        returns (Order[] memory)
+    {
+        return super.removeLastElement(orders);
+    }
 }

--- a/src/contracts/test/PreAMMBatcherTestInterface.sol
+++ b/src/contracts/test/PreAMMBatcherTestInterface.sol
@@ -28,6 +28,7 @@ contract PreAMMBatcherTestInterface is PreAMMBatcher {
         returns (Order[] memory)
     {
         return super.removeLastElement(orders);
+    }
 
     function inverseTest(Fraction memory f)
         public

--- a/src/js/orders.spec.ts
+++ b/src/js/orders.spec.ts
@@ -77,13 +77,14 @@ export class Order {
     };
   }
 
-  asArray(): [string, string, string, string, string] {
+  asArray(): [string, string, string, string, string, string] {
     return [
       this.sellAmount.toString(),
       this.buyAmount.toString(),
       this.sellToken.address,
       this.buyToken.address,
       this.wallet.address,
+      this.nonce.toString(),
     ];
   }
 

--- a/src/js/orders.spec.ts
+++ b/src/js/orders.spec.ts
@@ -77,7 +77,7 @@ export class Order {
     };
   }
 
-  asArray(): [string, string, string, string, string, string] {
+  asTuple(): [string, string, string, string, string, string] {
     return [
       this.sellAmount.toString(),
       this.buyAmount.toString(),

--- a/test/PreAMMBatcher.test.ts
+++ b/test/PreAMMBatcher.test.ts
@@ -406,6 +406,7 @@ describe("PreAMMBatcher: Unit Tests", () => {
       ).to.be.revertedWith("SafeMath: multiplication overflow");
     });
   });
+
   describe("removeLastElement()", () => {
     it("returns list of orders with top removed for generic list", async () => {
       const orders = [
@@ -456,6 +457,7 @@ describe("PreAMMBatcher: Unit Tests", () => {
         );
       }
     });
+
     it("reverts on empty list of orders", async () => {
       const orders: Order[] = [];
       await expect(

--- a/test/PreAMMBatcher.test.ts
+++ b/test/PreAMMBatcher.test.ts
@@ -2,10 +2,14 @@ import { ethers, waffle } from "@nomiclabs/buidler";
 import ERC20 from "@openzeppelin/contracts/build/contracts/IERC20.json";
 import UniswapV2Factory from "@uniswap/v2-core/build/UniswapV2Factory.json";
 import UniswapV2Pair from "@uniswap/v2-core/build/UniswapV2Pair.json";
-import { expect } from "chai";
+import { expect, assert } from "chai";
 import { Contract } from "ethers";
 
-import { Order, DOMAIN_SEPARATOR } from "../src/js/orders.spec";
+import {
+  Order,
+  DOMAIN_SEPARATOR,
+  SmartContractOrder,
+} from "../src/js/orders.spec";
 
 import { baseTestInput } from "./resources/testExamples";
 
@@ -400,6 +404,65 @@ describe("PreAMMBatcher: Unit Tests", () => {
           DESCENDING,
         ),
       ).to.be.revertedWith("SafeMath: multiplication overflow");
+    });
+  });
+  describe("removeLastElement()", () => {
+    it("returns list of orders with top removed for generic list", async () => {
+      const orders = [
+        new Order(1, 1, token0, token1, traderWallet1, 1),
+        new Order(1, 2, token0, token1, traderWallet1, 2),
+        new Order(1, 3, token0, token1, traderWallet1, 3),
+      ].map((x) => x.getSmartContractOrder());
+
+      const expectedResult = orders.slice(0, orders.length - 1);
+      const result: SmartContractOrder[] = await batchTester.removeLastElementTest(
+        orders,
+      );
+
+      assert.equal(
+        result.length,
+        expectedResult.length,
+        "Resulting list length is incorrect",
+      );
+
+      for (let i = 0; i < result.length; i++) {
+        assert(
+          result[i].sellAmount.eq(expectedResult[i].sellAmount),
+          `Resulting sellAmount disagrees at index ${i}`,
+        );
+        assert(
+          result[i].buyAmount.eq(expectedResult[i].buyAmount),
+          `Resulting buyAmount disagrees at index ${i}`,
+        );
+        assert.equal(
+          result[i].sellToken,
+          expectedResult[i].sellToken,
+          `Resulting sellToken disagrees at index ${i}`,
+        );
+        assert.equal(
+          result[i].buyToken,
+          expectedResult[i].buyToken,
+          `Resulting buyToken disagrees at index ${i}`,
+        );
+        assert.equal(
+          result[i].owner,
+          expectedResult[i].owner,
+          `Resulting owner disagrees at index ${i}`,
+        );
+        assert.equal(
+          result[i].nonce,
+          expectedResult[i].nonce,
+          `Resulting nonce disagrees at index ${i}`,
+        );
+      }
+    });
+    it("reverts on empty list of orders", async () => {
+      const orders: Order[] = [];
+      await expect(
+        batchTester.removeLastElementTest(
+          orders.map((x) => x.getSmartContractOrder()),
+        ),
+      ).to.be.revertedWith("Can't remove elements from an empty list");
     });
   });
 });

--- a/test/PreAMMBatcher.test.ts
+++ b/test/PreAMMBatcher.test.ts
@@ -464,7 +464,7 @@ describe("PreAMMBatcher: Unit Tests", () => {
         batchTester.removeLastElementTest(
           orders.map((x) => x.getSmartContractOrder()),
         ),
-      ).to.be.revertedWith("Can't remove elements from an empty list");
+      ).to.be.revertedWith("Can't remove from empty list");
     });
   });
 });


### PR DESCRIPTION
Making `removeTopElement` internal to the contract and unit testing its functionality. Wondering if I should see if we can make `SmartContractOrder` types comparable to remove the loop and assertions on each attribute.