### PR TITLE
build on main and not master

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
 
 jobs:


### PR DESCRIPTION
Currently we aren't running CI on `main` branch. This PR fixes that.

### Test Plan

CI should run on `main` branch after this gets merged.
