### PR TITLE
Add order validity

### DIFF
--- a/src/contracts/PreAMMBatcher.sol
+++ b/src/contracts/PreAMMBatcher.sol
@@ -109,10 +109,13 @@ contract PreAMMBatcher {
         view
         returns (bool)
     {
+        // Zero velidFrom is a sentinel value signaling that the order has unlimited validity.
+        // validUntil can then be set to zero to save on gas costs.
         // solhint-disable not-rely-on-time
         return
-            (order.validUntil >= block.timestamp) &&
-            (order.validFrom <= block.timestamp);
+            order.validFrom == 0 ||
+            ((order.validUntil >= block.timestamp) &&
+                (order.validFrom <= block.timestamp));
         // solhint-enable not-rely-on-time
     }
 

--- a/src/contracts/PreAMMBatcher.sol
+++ b/src/contracts/PreAMMBatcher.sol
@@ -109,13 +109,10 @@ contract PreAMMBatcher {
         view
         returns (bool)
     {
-        // Zero velidFrom is a sentinel value signaling that the order has unlimited validity.
-        // validUntil can then be set to zero to save on gas costs.
         // solhint-disable not-rely-on-time
         return
-            order.validFrom == 0 ||
-            ((order.validUntil >= block.timestamp) &&
-                (order.validFrom <= block.timestamp));
+            (order.validUntil >= block.timestamp) &&
+            (order.validFrom <= block.timestamp);
         // solhint-enable not-rely-on-time
     }
 

--- a/src/contracts/PreAMMBatcher.sol
+++ b/src/contracts/PreAMMBatcher.sol
@@ -109,11 +109,11 @@ contract PreAMMBatcher {
         view
         returns (bool)
     {
+        // solhint-disable not-rely-on-time
         return
-            // solhint-disable-next-line not-rely-on-time
             (order.validUntil >= block.timestamp) &&
-            // solhint-disable-next-line not-rely-on-time
             (order.validFrom <= block.timestamp);
+        // solhint-enable not-rely-on-time
     }
 
     function orderChecks(

--- a/src/contracts/test/PreAMMBatcherTestInterface.sol
+++ b/src/contracts/test/PreAMMBatcherTestInterface.sol
@@ -18,7 +18,7 @@ contract PreAMMBatcherTestInterface is PreAMMBatcher {
     function orderChecksTest(
         Order[] memory sellOrderToken0,
         Order[] memory sellOrderToken1
-    ) public pure {
+    ) public view {
         super.orderChecks(sellOrderToken0, sellOrderToken1);
     }
 }

--- a/src/js/orders.spec.ts
+++ b/src/js/orders.spec.ts
@@ -9,6 +9,8 @@ export declare type SmartContractOrder = {
   sellToken: string;
   buyToken: string;
   owner: string;
+  validFrom: BigNumber;
+  validUntil: BigNumber;
   nonce: BigNumber;
 };
 export class Order {
@@ -17,6 +19,8 @@ export class Order {
   sellToken: Contract;
   buyToken: Contract;
   wallet: Wallet;
+  validFrom: BigNumber;
+  validUntil: BigNumber;
   nonce: BigNumber;
 
   constructor(
@@ -25,6 +29,8 @@ export class Order {
     sellToken: Contract,
     buyToken: Contract,
     wallet: Wallet,
+    validFrom: BigNumber | number,
+    validUntil: BigNumber | number,
     nonce: BigNumber | number,
   ) {
     this.sellAmount = BigNumber.from(sellAmount);
@@ -32,6 +38,8 @@ export class Order {
     this.sellToken = sellToken;
     this.buyToken = buyToken;
     this.wallet = wallet;
+    this.validFrom = BigNumber.from(validFrom);
+    this.validUntil = BigNumber.from(validUntil);
     this.nonce = BigNumber.from(nonce);
   }
 
@@ -46,6 +54,8 @@ export class Order {
         "address",
         "address",
         "address",
+        "uint32",
+        "uint32",
         "uint8",
         "uint8",
         "bytes32",
@@ -57,6 +67,8 @@ export class Order {
         this.sellToken.address,
         this.buyToken.address,
         this.wallet.address,
+        this.validFrom.toString(),
+        this.validUntil.toString(),
         this.nonce.toString(),
         v,
         r,
@@ -73,18 +85,10 @@ export class Order {
       sellToken: this.sellToken.address,
       buyToken: this.buyToken.address,
       owner: this.wallet.address,
+      validFrom: this.validFrom,
+      validUntil: this.validUntil,
       nonce: this.nonce,
     };
-  }
-
-  asArray(): [string, string, string, string, string] {
-    return [
-      this.sellAmount.toString(),
-      this.buyAmount.toString(),
-      this.sellToken.address,
-      this.buyToken.address,
-      this.wallet.address,
-    ];
   }
 
   getOrderDigest(): string {
@@ -97,6 +101,8 @@ export class Order {
           "address",
           "address",
           "address",
+          "uint32",
+          "uint32",
           "uint8",
         ],
         [
@@ -106,6 +112,8 @@ export class Order {
           this.sellToken.address,
           this.buyToken.address,
           this.wallet.address,
+          this.validFrom.toString(),
+          this.validUntil.toString(),
           this.nonce.toString(),
         ],
       ),
@@ -119,6 +127,8 @@ export class Order {
       this.sellToken,
       this.buyToken,
       this.wallet,
+      this.validFrom,
+      this.validUntil,
       this.nonce,
     );
   }

--- a/test/PreAMMBatcher.test.ts
+++ b/test/PreAMMBatcher.test.ts
@@ -130,6 +130,7 @@ describe("PreAMMBatcher: Unit Tests", () => {
           ),
         ).to.not.be.reverted;
       });
+
       it("fails if sell order for token 0 is expired", async () => {
         const testCaseInput = baseTestInput(
           token0,
@@ -148,6 +149,7 @@ describe("PreAMMBatcher: Unit Tests", () => {
           ),
         ).to.be.revertedWith("token0 order not currently valid");
       });
+
       it("fails if sell order for token 1 is expired", async () => {
         const testCaseInput = baseTestInput(
           token0,
@@ -166,6 +168,7 @@ describe("PreAMMBatcher: Unit Tests", () => {
           ),
         ).to.be.revertedWith("token1 order not currently valid");
       });
+
       it("fails if sell order for token 0 is not valid yet", async () => {
         const testCaseInput = baseTestInput(
           token0,
@@ -184,6 +187,7 @@ describe("PreAMMBatcher: Unit Tests", () => {
           ),
         ).to.be.revertedWith("token0 order not currently valid");
       });
+
       it("fails if sell order for token 1 is not yet valid", async () => {
         const testCaseInput = baseTestInput(
           token0,
@@ -203,6 +207,7 @@ describe("PreAMMBatcher: Unit Tests", () => {
         ).to.be.revertedWith("token1 order not currently valid");
       });
     });
+
     it("runs as expected in generic setting", async () => {
       const testCaseInput = baseTestInput(
         token0,

--- a/test/PreAMMBatcher.test.ts
+++ b/test/PreAMMBatcher.test.ts
@@ -7,7 +7,7 @@ import { Contract, BigNumber } from "ethers";
 
 import { Order, DOMAIN_SEPARATOR } from "../src/js/orders.spec";
 
-import { orderAlwaysValid } from "./resources/orderCreation";
+import { indefiniteOrder } from "./resources/orderCreation";
 import { baseTestInput } from "./resources/testExamples";
 
 describe("PreAMMBatcher: Unit Tests", () => {
@@ -361,9 +361,9 @@ describe("PreAMMBatcher: Unit Tests", () => {
 
     it("returns expected values for generic sorted order set", async () => {
       const sortedOrders = [
-        orderAlwaysValid(1, 1, token0, token1, traderWallet1, 1),
-        orderAlwaysValid(1, 2, token0, token1, traderWallet1, 2),
-        orderAlwaysValid(1, 3, token0, token1, traderWallet1, 3),
+        indefiniteOrder(1, 1, token0, token1, traderWallet1, 1),
+        indefiniteOrder(1, 2, token0, token1, traderWallet1, 2),
+        indefiniteOrder(1, 3, token0, token1, traderWallet1, 3),
       ];
 
       expect(
@@ -397,8 +397,8 @@ describe("PreAMMBatcher: Unit Tests", () => {
 
     it("returns expected values for same two orders", async () => {
       const sortedOrders = [
-        orderAlwaysValid(1, 1, token0, token1, traderWallet1, 1),
-        orderAlwaysValid(1, 1, token0, token1, traderWallet1, 2),
+        indefiniteOrder(1, 1, token0, token1, traderWallet1, 1),
+        indefiniteOrder(1, 1, token0, token1, traderWallet1, 2),
       ];
       expect(
         await batchTester.isSortedByLimitPriceTest(
@@ -416,9 +416,9 @@ describe("PreAMMBatcher: Unit Tests", () => {
 
     it("returns expected values for generic unsorted set of orders", async () => {
       const unsortedOrders = [
-        orderAlwaysValid(1, 2, token0, token1, traderWallet1, 1),
-        orderAlwaysValid(1, 1, token0, token1, traderWallet1, 2),
-        orderAlwaysValid(1, 3, token0, token1, traderWallet1, 3),
+        indefiniteOrder(1, 2, token0, token1, traderWallet1, 1),
+        indefiniteOrder(1, 1, token0, token1, traderWallet1, 2),
+        indefiniteOrder(1, 3, token0, token1, traderWallet1, 3),
       ];
       expect(
         await batchTester.isSortedByLimitPriceTest(
@@ -454,7 +454,7 @@ describe("PreAMMBatcher: Unit Tests", () => {
     it("returns expected values for singleton order set", async () => {
       // Single Orderset is vacuously sorted
       const singleOrder = [
-        orderAlwaysValid(1, 1, token0, token1, traderWallet1, 1),
+        indefiniteOrder(1, 1, token0, token1, traderWallet1, 1),
       ];
       expect(
         await batchTester.isSortedByLimitPriceTest(
@@ -474,8 +474,8 @@ describe("PreAMMBatcher: Unit Tests", () => {
       const maxUint = ethers.constants.MaxUint256;
 
       const overflowingPair = [
-        orderAlwaysValid(2, maxUint, token0, token1, traderWallet1, 1),
-        orderAlwaysValid(1, maxUint, token0, token1, traderWallet1, 1),
+        indefiniteOrder(2, maxUint, token0, token1, traderWallet1, 1),
+        indefiniteOrder(1, maxUint, token0, token1, traderWallet1, 1),
       ];
       await expect(
         batchTester.isSortedByLimitPriceTest(

--- a/test/PreAMMBatcher.test.ts
+++ b/test/PreAMMBatcher.test.ts
@@ -139,7 +139,6 @@ describe("PreAMMBatcher: Unit Tests", () => {
           [traderWallet2],
         );
         const now = (await waffle.provider.getBlock("latest")).timestamp;
-        testCaseInput.sellOrdersToken0[0].validFrom = BigNumber.from(1);
         testCaseInput.sellOrdersToken0[0].validUntil = BigNumber.from(now - 60);
 
         await expect(
@@ -159,7 +158,6 @@ describe("PreAMMBatcher: Unit Tests", () => {
           [traderWallet2],
         );
         const now = (await waffle.provider.getBlock("latest")).timestamp;
-        testCaseInput.sellOrdersToken1[0].validFrom = BigNumber.from(1);
         testCaseInput.sellOrdersToken1[0].validUntil = BigNumber.from(now - 60);
 
         await expect(
@@ -180,9 +178,6 @@ describe("PreAMMBatcher: Unit Tests", () => {
         );
         const now = (await waffle.provider.getBlock("latest")).timestamp;
         testCaseInput.sellOrdersToken0[0].validFrom = BigNumber.from(now + 60);
-        testCaseInput.sellOrdersToken0[0].validUntil = BigNumber.from(
-          2 ** 32 - 1,
-        );
 
         await expect(
           batchTester.orderChecksTest(
@@ -202,9 +197,6 @@ describe("PreAMMBatcher: Unit Tests", () => {
         );
         const now = (await waffle.provider.getBlock("latest")).timestamp;
         testCaseInput.sellOrdersToken1[0].validFrom = BigNumber.from(now + 60);
-        testCaseInput.sellOrdersToken1[0].validUntil = BigNumber.from(
-          2 ** 32 - 1,
-        );
 
         await expect(
           batchTester.orderChecksTest(

--- a/test/PreAMMBatcher.test.ts
+++ b/test/PreAMMBatcher.test.ts
@@ -139,6 +139,7 @@ describe("PreAMMBatcher: Unit Tests", () => {
           [traderWallet2],
         );
         const now = (await waffle.provider.getBlock("latest")).timestamp;
+        testCaseInput.sellOrdersToken0[0].validFrom = BigNumber.from(1);
         testCaseInput.sellOrdersToken0[0].validUntil = BigNumber.from(now - 60);
 
         await expect(
@@ -158,6 +159,7 @@ describe("PreAMMBatcher: Unit Tests", () => {
           [traderWallet2],
         );
         const now = (await waffle.provider.getBlock("latest")).timestamp;
+        testCaseInput.sellOrdersToken1[0].validFrom = BigNumber.from(1);
         testCaseInput.sellOrdersToken1[0].validUntil = BigNumber.from(now - 60);
 
         await expect(
@@ -178,6 +180,9 @@ describe("PreAMMBatcher: Unit Tests", () => {
         );
         const now = (await waffle.provider.getBlock("latest")).timestamp;
         testCaseInput.sellOrdersToken0[0].validFrom = BigNumber.from(now + 60);
+        testCaseInput.sellOrdersToken0[0].validUntil = BigNumber.from(
+          2 ** 32 - 1,
+        );
 
         await expect(
           batchTester.orderChecksTest(
@@ -197,6 +202,9 @@ describe("PreAMMBatcher: Unit Tests", () => {
         );
         const now = (await waffle.provider.getBlock("latest")).timestamp;
         testCaseInput.sellOrdersToken1[0].validFrom = BigNumber.from(now + 60);
+        testCaseInput.sellOrdersToken1[0].validUntil = BigNumber.from(
+          2 ** 32 - 1,
+        );
 
         await expect(
           batchTester.orderChecksTest(

--- a/test/PreAMMBatcher.test.ts
+++ b/test/PreAMMBatcher.test.ts
@@ -3,10 +3,11 @@ import ERC20 from "@openzeppelin/contracts/build/contracts/IERC20.json";
 import UniswapV2Factory from "@uniswap/v2-core/build/UniswapV2Factory.json";
 import UniswapV2Pair from "@uniswap/v2-core/build/UniswapV2Pair.json";
 import { expect } from "chai";
-import { Contract } from "ethers";
+import { Contract, BigNumber } from "ethers";
 
 import { Order, DOMAIN_SEPARATOR } from "../src/js/orders.spec";
 
+import { orderAlwaysValid } from "./resources/orderCreation";
 import { baseTestInput } from "./resources/testExamples";
 
 describe("PreAMMBatcher: Unit Tests", () => {
@@ -107,6 +108,101 @@ describe("PreAMMBatcher: Unit Tests", () => {
   });
 
   describe("orderChecks()", () => {
+    describe("order validity period", () => {
+      it("succeeds if order is within validity period", async () => {
+        const testCaseInput = baseTestInput(
+          token0,
+          token1,
+          [traderWallet1],
+          [traderWallet2],
+        );
+        const now = (await waffle.provider.getBlock("latest")).timestamp;
+        testCaseInput.sellOrdersToken0[0].validFrom = BigNumber.from(now - 60);
+        testCaseInput.sellOrdersToken0[0].validUntil = BigNumber.from(now + 60);
+        testCaseInput.sellOrdersToken1[0].validFrom = BigNumber.from(now - 60);
+        testCaseInput.sellOrdersToken1[0].validUntil = BigNumber.from(now + 60);
+
+        await expect(
+          batchTester.orderChecksTest(
+            [testCaseInput.sellOrdersToken0[0].getSmartContractOrder()],
+            [testCaseInput.sellOrdersToken1[0].getSmartContractOrder()],
+            { gasLimit: 6000000 },
+          ),
+        ).to.not.be.reverted;
+      });
+      it("fails if sell order for token 0 is expired", async () => {
+        const testCaseInput = baseTestInput(
+          token0,
+          token1,
+          [traderWallet1],
+          [traderWallet2],
+        );
+        const now = (await waffle.provider.getBlock("latest")).timestamp;
+        testCaseInput.sellOrdersToken0[0].validUntil = BigNumber.from(now - 60);
+
+        await expect(
+          batchTester.orderChecksTest(
+            [testCaseInput.sellOrdersToken0[0].getSmartContractOrder()],
+            [testCaseInput.sellOrdersToken1[0].getSmartContractOrder()],
+            { gasLimit: 6000000 },
+          ),
+        ).to.be.revertedWith("token0 order not currently valid");
+      });
+      it("fails if sell order for token 1 is expired", async () => {
+        const testCaseInput = baseTestInput(
+          token0,
+          token1,
+          [traderWallet1],
+          [traderWallet2],
+        );
+        const now = (await waffle.provider.getBlock("latest")).timestamp;
+        testCaseInput.sellOrdersToken1[0].validUntil = BigNumber.from(now - 60);
+
+        await expect(
+          batchTester.orderChecksTest(
+            [testCaseInput.sellOrdersToken0[0].getSmartContractOrder()],
+            [testCaseInput.sellOrdersToken1[0].getSmartContractOrder()],
+            { gasLimit: 6000000 },
+          ),
+        ).to.be.revertedWith("token1 order not currently valid");
+      });
+      it("fails if sell order for token 0 is not valid yet", async () => {
+        const testCaseInput = baseTestInput(
+          token0,
+          token1,
+          [traderWallet1],
+          [traderWallet2],
+        );
+        const now = (await waffle.provider.getBlock("latest")).timestamp;
+        testCaseInput.sellOrdersToken0[0].validFrom = BigNumber.from(now + 60);
+
+        await expect(
+          batchTester.orderChecksTest(
+            [testCaseInput.sellOrdersToken0[0].getSmartContractOrder()],
+            [testCaseInput.sellOrdersToken1[0].getSmartContractOrder()],
+            { gasLimit: 6000000 },
+          ),
+        ).to.be.revertedWith("token0 order not currently valid");
+      });
+      it("fails if sell order for token 1 is not yet valid", async () => {
+        const testCaseInput = baseTestInput(
+          token0,
+          token1,
+          [traderWallet1],
+          [traderWallet2],
+        );
+        const now = (await waffle.provider.getBlock("latest")).timestamp;
+        testCaseInput.sellOrdersToken1[0].validFrom = BigNumber.from(now + 60);
+
+        await expect(
+          batchTester.orderChecksTest(
+            [testCaseInput.sellOrdersToken0[0].getSmartContractOrder()],
+            [testCaseInput.sellOrdersToken1[0].getSmartContractOrder()],
+            { gasLimit: 6000000 },
+          ),
+        ).to.be.revertedWith("token1 order not currently valid");
+      });
+    });
     it("runs as expected in generic setting", async () => {
       const testCaseInput = baseTestInput(
         token0,
@@ -139,7 +235,7 @@ describe("PreAMMBatcher: Unit Tests", () => {
           [testCaseInput.sellOrdersToken1[0].getSmartContractOrder()],
           { gasLimit: 6000000 },
         ),
-      ).to.revertedWith("invalid token1 order sell token");
+      ).to.be.revertedWith("invalid token1 order sell token");
     });
   });
 
@@ -260,9 +356,9 @@ describe("PreAMMBatcher: Unit Tests", () => {
 
     it("returns expected values for generic sorted order set", async () => {
       const sortedOrders = [
-        new Order(1, 1, token0, token1, traderWallet1, 1),
-        new Order(1, 2, token0, token1, traderWallet1, 2),
-        new Order(1, 3, token0, token1, traderWallet1, 3),
+        orderAlwaysValid(1, 1, token0, token1, traderWallet1, 1),
+        orderAlwaysValid(1, 2, token0, token1, traderWallet1, 2),
+        orderAlwaysValid(1, 3, token0, token1, traderWallet1, 3),
       ];
 
       expect(
@@ -296,8 +392,8 @@ describe("PreAMMBatcher: Unit Tests", () => {
 
     it("returns expected values for same two orders", async () => {
       const sortedOrders = [
-        new Order(1, 1, token0, token1, traderWallet1, 1),
-        new Order(1, 1, token0, token1, traderWallet1, 2),
+        orderAlwaysValid(1, 1, token0, token1, traderWallet1, 1),
+        orderAlwaysValid(1, 1, token0, token1, traderWallet1, 2),
       ];
       expect(
         await batchTester.isSortedByLimitPriceTest(
@@ -315,9 +411,9 @@ describe("PreAMMBatcher: Unit Tests", () => {
 
     it("returns expected values for generic unsorted set of orders", async () => {
       const unsortedOrders = [
-        new Order(1, 2, token0, token1, traderWallet1, 1),
-        new Order(1, 1, token0, token1, traderWallet1, 2),
-        new Order(1, 3, token0, token1, traderWallet1, 3),
+        orderAlwaysValid(1, 2, token0, token1, traderWallet1, 1),
+        orderAlwaysValid(1, 1, token0, token1, traderWallet1, 2),
+        orderAlwaysValid(1, 3, token0, token1, traderWallet1, 3),
       ];
       expect(
         await batchTester.isSortedByLimitPriceTest(
@@ -352,7 +448,9 @@ describe("PreAMMBatcher: Unit Tests", () => {
 
     it("returns expected values for singleton order set", async () => {
       // Single Orderset is vacuously sorted
-      const singleOrder = [new Order(1, 1, token0, token1, traderWallet1, 1)];
+      const singleOrder = [
+        orderAlwaysValid(1, 1, token0, token1, traderWallet1, 1),
+      ];
       expect(
         await batchTester.isSortedByLimitPriceTest(
           singleOrder.map((x) => x.getSmartContractOrder()),
@@ -371,8 +469,8 @@ describe("PreAMMBatcher: Unit Tests", () => {
       const maxUint = ethers.constants.MaxUint256;
 
       const overflowingPair = [
-        new Order(2, maxUint, token0, token1, traderWallet1, 1),
-        new Order(1, maxUint, token0, token1, traderWallet1, 1),
+        orderAlwaysValid(2, maxUint, token0, token1, traderWallet1, 1),
+        orderAlwaysValid(1, maxUint, token0, token1, traderWallet1, 1),
       ];
       await expect(
         batchTester.isSortedByLimitPriceTest(

--- a/test/PreAMMBatcher.test.ts
+++ b/test/PreAMMBatcher.test.ts
@@ -539,9 +539,9 @@ describe("PreAMMBatcher: Unit Tests", () => {
   describe("removeLastElement()", () => {
     it("returns list of orders with top removed for generic list", async () => {
       const orders = [
-        new Order(1, 1, token0, token1, traderWallet1, 1),
-        new Order(1, 2, token0, token1, traderWallet1, 2),
-        new Order(1, 3, token0, token1, traderWallet1, 3),
+        indefiniteOrder(1, 1, token0, token1, traderWallet1, 1),
+        indefiniteOrder(1, 2, token0, token1, traderWallet1, 2),
+        indefiniteOrder(1, 3, token0, token1, traderWallet1, 3),
       ].map((x) => x.getSmartContractOrder());
 
       const expectedResult = orders.slice(0, orders.length - 1);

--- a/test/resources/orderCreation.ts
+++ b/test/resources/orderCreation.ts
@@ -2,7 +2,7 @@ import { Wallet, Contract, BigNumber } from "ethers";
 
 import { Order } from "../../src/js/orders.spec";
 
-export const orderAlwaysValid = function (
+export function orderAlwaysValid(
   sellAmount: BigNumber | number,
   buyAmount: BigNumber | number,
   sellToken: Contract,

--- a/test/resources/orderCreation.ts
+++ b/test/resources/orderCreation.ts
@@ -1,0 +1,26 @@
+import { Wallet, Contract, BigNumber } from "ethers";
+
+import { Order } from "../../src/js/orders.spec";
+
+export const orderAlwaysValid = function (
+  sellAmount: BigNumber | number,
+  buyAmount: BigNumber | number,
+  sellToken: Contract,
+  buyToken: Contract,
+  wallet: Wallet,
+  nonce: BigNumber | number,
+): Order {
+  const beginningOfTime = 0;
+  const endOfTime = 2 ** 32 - 1;
+
+  return new Order(
+    sellAmount,
+    buyAmount,
+    sellToken,
+    buyToken,
+    wallet,
+    beginningOfTime,
+    endOfTime,
+    nonce,
+  );
+};

--- a/test/resources/orderCreation.ts
+++ b/test/resources/orderCreation.ts
@@ -10,8 +10,10 @@ export const orderAlwaysValid = function (
   wallet: Wallet,
   nonce: BigNumber | number,
 ): Order {
-  const beginningOfTime = 0;
-  const endOfTime = 2 ** 32 - 1;
+  const orderValidFrom = 0;
+  // if validFrom is zero, then the following value is ignored.
+  // we set it to zero to save on gas.
+  const orderValidUntil = 0;
 
   return new Order(
     sellAmount,
@@ -19,8 +21,8 @@ export const orderAlwaysValid = function (
     sellToken,
     buyToken,
     wallet,
-    beginningOfTime,
-    endOfTime,
+    orderValidFrom,
+    orderValidUntil,
     nonce,
   );
 };

--- a/test/resources/orderCreation.ts
+++ b/test/resources/orderCreation.ts
@@ -2,7 +2,7 @@ import { Wallet, Contract, BigNumber } from "ethers";
 
 import { Order } from "../../src/js/orders.spec";
 
-export function orderAlwaysValid(
+export function indefiniteOrder(
   sellAmount: BigNumber | number,
   buyAmount: BigNumber | number,
   sellToken: Contract,
@@ -23,4 +23,4 @@ export function orderAlwaysValid(
     endOfTime,
     nonce,
   );
-};
+}

--- a/test/resources/orderCreation.ts
+++ b/test/resources/orderCreation.ts
@@ -10,10 +10,8 @@ export const orderAlwaysValid = function (
   wallet: Wallet,
   nonce: BigNumber | number,
 ): Order {
-  const orderValidFrom = 0;
-  // if validFrom is zero, then the following value is ignored.
-  // we set it to zero to save on gas.
-  const orderValidUntil = 0;
+  const beginningOfTime = 0;
+  const endOfTime = 2 ** 32 - 1;
 
   return new Order(
     sellAmount,
@@ -21,8 +19,8 @@ export const orderAlwaysValid = function (
     sellToken,
     buyToken,
     wallet,
-    orderValidFrom,
-    orderValidUntil,
+    beginningOfTime,
+    endOfTime,
     nonce,
   );
 };

--- a/test/resources/testExamples.ts
+++ b/test/resources/testExamples.ts
@@ -1,8 +1,7 @@
 import { Contract, Wallet, utils } from "ethers";
 
-import { Order } from "../../src/js/orders.spec";
-
 import { TestCaseInput } from "./models";
+import { orderAlwaysValid } from "./orderCreation";
 
 export const baseTestInput = function (
   token0: Contract,
@@ -14,7 +13,7 @@ export const baseTestInput = function (
     fundingAMMToken0: utils.parseEther("10"),
     fundingAMMToken1: utils.parseEther("10"),
     sellOrdersToken0: [
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("1"),
         utils.parseEther("0.9"),
         token0,
@@ -24,7 +23,7 @@ export const baseTestInput = function (
       ),
     ],
     sellOrdersToken1: [
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("0.9"),
         utils.parseEther("0.90111"),
         token1,
@@ -46,7 +45,7 @@ export const fourOrderTestInput = function (
     fundingAMMToken0: utils.parseEther("10"),
     fundingAMMToken1: utils.parseEther("10"),
     sellOrdersToken0: [
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("1"),
         utils.parseEther("0.9"),
         token0,
@@ -54,7 +53,7 @@ export const fourOrderTestInput = function (
         tradersToken0[0],
         1,
       ),
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("0.5"),
         utils.parseEther("0.45"),
         token0,
@@ -64,7 +63,7 @@ export const fourOrderTestInput = function (
       ),
     ],
     sellOrdersToken1: [
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("0.9"),
         utils.parseEther("0.90111"),
         token1,
@@ -72,7 +71,7 @@ export const fourOrderTestInput = function (
         tradersToken1[0],
         1,
       ),
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("0.45"),
         utils.parseEther("0.45"),
         token1,
@@ -94,7 +93,7 @@ export const oneOrderSellingToken0IsOmittedTestInput = function (
     fundingAMMToken0: utils.parseEther("10"),
     fundingAMMToken1: utils.parseEther("10"),
     sellOrdersToken0: [
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("10.1"),
         utils.parseEther("9.7"),
         token0,
@@ -102,7 +101,7 @@ export const oneOrderSellingToken0IsOmittedTestInput = function (
         tradersToken0[0],
         1,
       ),
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("5"), // <--- this order would can not be traded fully against uniswap
         utils.parseEther("4.91"),
         token0,
@@ -112,7 +111,7 @@ export const oneOrderSellingToken0IsOmittedTestInput = function (
       ),
     ],
     sellOrdersToken1: [
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("10"),
         utils.parseEther("9"),
         token1,
@@ -134,7 +133,7 @@ export const noSolutionTestInput = function (
     fundingAMMToken0: utils.parseEther("10"),
     fundingAMMToken1: utils.parseEther("10"),
     sellOrdersToken0: [
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("10"),
         utils.parseEther("9.7"),
         token0,
@@ -142,7 +141,7 @@ export const noSolutionTestInput = function (
         tradersToken0[0],
         1,
       ),
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("5"),
         utils.parseEther("4.9"),
         token0,
@@ -152,7 +151,7 @@ export const noSolutionTestInput = function (
       ),
     ],
     sellOrdersToken1: [
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("3"),
         utils.parseEther("2"),
         token1,
@@ -160,7 +159,7 @@ export const noSolutionTestInput = function (
         tradersToken1[0],
         1,
       ),
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("3"),
         utils.parseEther("2.5"),
         token1,
@@ -168,7 +167,7 @@ export const noSolutionTestInput = function (
         tradersToken1[1],
         2,
       ),
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("3"),
         utils.parseEther("2.6"),
         token1,
@@ -191,7 +190,7 @@ export const oneOrderSellingToken1IsOmittedTestInput = function (
     fundingAMMToken1: utils.parseEther("10"),
 
     sellOrdersToken0: [
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("10"),
         utils.parseEther("9"),
         token1,
@@ -199,7 +198,7 @@ export const oneOrderSellingToken1IsOmittedTestInput = function (
         tradersToken0[0],
         1,
       ),
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("3"),
         utils.parseEther("2.5"),
         token1,
@@ -207,7 +206,7 @@ export const oneOrderSellingToken1IsOmittedTestInput = function (
         tradersToken0[1],
         2,
       ),
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("3"),
         utils.parseEther("2.5"),
         token1,
@@ -215,7 +214,7 @@ export const oneOrderSellingToken1IsOmittedTestInput = function (
         tradersToken0[2],
         3,
       ),
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("3"), // <--- this order would can not be traded fully against uniswap
         utils.parseEther("2.99"),
         token1,
@@ -225,7 +224,7 @@ export const oneOrderSellingToken1IsOmittedTestInput = function (
       ),
     ],
     sellOrdersToken1: [
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("10"),
         utils.parseEther("9.7"),
         token0,
@@ -233,7 +232,7 @@ export const oneOrderSellingToken1IsOmittedTestInput = function (
         tradersToken1[0],
         1,
       ),
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("5"),
         utils.parseEther("4.9"),
         token0,
@@ -255,7 +254,7 @@ export const switchTokenTestInput = function (
     fundingAMMToken0: utils.parseEther("10"),
     fundingAMMToken1: utils.parseEther("10"),
     sellOrdersToken0: [
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("10"),
         utils.parseEther("9.7"),
         token0,
@@ -263,7 +262,7 @@ export const switchTokenTestInput = function (
         tradersToken0[0],
         1,
       ),
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("5"),
         utils.parseEther("4.9"),
         token0,
@@ -273,7 +272,7 @@ export const switchTokenTestInput = function (
       ),
     ],
     sellOrdersToken1: [
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("10"),
         utils.parseEther("9"),
         token1,
@@ -281,7 +280,7 @@ export const switchTokenTestInput = function (
         tradersToken1[0],
         1,
       ),
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("3"),
         utils.parseEther("2.5"),
         token1,
@@ -289,7 +288,7 @@ export const switchTokenTestInput = function (
         tradersToken1[1],
         2,
       ),
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("3"),
         utils.parseEther("2.6"),
         token1,
@@ -297,7 +296,7 @@ export const switchTokenTestInput = function (
         tradersToken1[2],
         3,
       ),
-      new Order(
+      orderAlwaysValid(
         utils.parseEther("3"),
         utils.parseEther("2.9"),
         token1,

--- a/test/resources/testExamples.ts
+++ b/test/resources/testExamples.ts
@@ -1,7 +1,7 @@
 import { Contract, Wallet, utils } from "ethers";
 
 import { TestCaseInput } from "./models";
-import { orderAlwaysValid } from "./orderCreation";
+import { indefiniteOrder } from "./orderCreation";
 
 export const baseTestInput = function (
   token0: Contract,
@@ -13,7 +13,7 @@ export const baseTestInput = function (
     fundingAMMToken0: utils.parseEther("10"),
     fundingAMMToken1: utils.parseEther("10"),
     sellOrdersToken0: [
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("1"),
         utils.parseEther("0.9"),
         token0,
@@ -23,7 +23,7 @@ export const baseTestInput = function (
       ),
     ],
     sellOrdersToken1: [
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("0.9"),
         utils.parseEther("0.90111"),
         token1,
@@ -45,7 +45,7 @@ export const fourOrderTestInput = function (
     fundingAMMToken0: utils.parseEther("10"),
     fundingAMMToken1: utils.parseEther("10"),
     sellOrdersToken0: [
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("1"),
         utils.parseEther("0.9"),
         token0,
@@ -53,7 +53,7 @@ export const fourOrderTestInput = function (
         tradersToken0[0],
         1,
       ),
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("0.5"),
         utils.parseEther("0.45"),
         token0,
@@ -63,7 +63,7 @@ export const fourOrderTestInput = function (
       ),
     ],
     sellOrdersToken1: [
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("0.9"),
         utils.parseEther("0.90111"),
         token1,
@@ -71,7 +71,7 @@ export const fourOrderTestInput = function (
         tradersToken1[0],
         1,
       ),
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("0.45"),
         utils.parseEther("0.45"),
         token1,
@@ -93,7 +93,7 @@ export const oneOrderSellingToken0IsOmittedTestInput = function (
     fundingAMMToken0: utils.parseEther("10"),
     fundingAMMToken1: utils.parseEther("10"),
     sellOrdersToken0: [
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("10.1"),
         utils.parseEther("9.7"),
         token0,
@@ -101,7 +101,7 @@ export const oneOrderSellingToken0IsOmittedTestInput = function (
         tradersToken0[0],
         1,
       ),
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("5"), // <--- this order would can not be traded fully against uniswap
         utils.parseEther("4.91"),
         token0,
@@ -111,7 +111,7 @@ export const oneOrderSellingToken0IsOmittedTestInput = function (
       ),
     ],
     sellOrdersToken1: [
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("10"),
         utils.parseEther("9"),
         token1,
@@ -133,7 +133,7 @@ export const noSolutionTestInput = function (
     fundingAMMToken0: utils.parseEther("10"),
     fundingAMMToken1: utils.parseEther("10"),
     sellOrdersToken0: [
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("10"),
         utils.parseEther("9.7"),
         token0,
@@ -141,7 +141,7 @@ export const noSolutionTestInput = function (
         tradersToken0[0],
         1,
       ),
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("5"),
         utils.parseEther("4.9"),
         token0,
@@ -151,7 +151,7 @@ export const noSolutionTestInput = function (
       ),
     ],
     sellOrdersToken1: [
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("3"),
         utils.parseEther("2"),
         token1,
@@ -159,7 +159,7 @@ export const noSolutionTestInput = function (
         tradersToken1[0],
         1,
       ),
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("3"),
         utils.parseEther("2.5"),
         token1,
@@ -167,7 +167,7 @@ export const noSolutionTestInput = function (
         tradersToken1[1],
         2,
       ),
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("3"),
         utils.parseEther("2.6"),
         token1,
@@ -190,7 +190,7 @@ export const oneOrderSellingToken1IsOmittedTestInput = function (
     fundingAMMToken1: utils.parseEther("10"),
 
     sellOrdersToken0: [
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("10"),
         utils.parseEther("9"),
         token1,
@@ -198,7 +198,7 @@ export const oneOrderSellingToken1IsOmittedTestInput = function (
         tradersToken0[0],
         1,
       ),
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("3"),
         utils.parseEther("2.5"),
         token1,
@@ -206,7 +206,7 @@ export const oneOrderSellingToken1IsOmittedTestInput = function (
         tradersToken0[1],
         2,
       ),
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("3"),
         utils.parseEther("2.5"),
         token1,
@@ -214,7 +214,7 @@ export const oneOrderSellingToken1IsOmittedTestInput = function (
         tradersToken0[2],
         3,
       ),
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("3"), // <--- this order would can not be traded fully against uniswap
         utils.parseEther("2.99"),
         token1,
@@ -224,7 +224,7 @@ export const oneOrderSellingToken1IsOmittedTestInput = function (
       ),
     ],
     sellOrdersToken1: [
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("10"),
         utils.parseEther("9.7"),
         token0,
@@ -232,7 +232,7 @@ export const oneOrderSellingToken1IsOmittedTestInput = function (
         tradersToken1[0],
         1,
       ),
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("5"),
         utils.parseEther("4.9"),
         token0,
@@ -254,7 +254,7 @@ export const switchTokenTestInput = function (
     fundingAMMToken0: utils.parseEther("10"),
     fundingAMMToken1: utils.parseEther("10"),
     sellOrdersToken0: [
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("10"),
         utils.parseEther("9.7"),
         token0,
@@ -262,7 +262,7 @@ export const switchTokenTestInput = function (
         tradersToken0[0],
         1,
       ),
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("5"),
         utils.parseEther("4.9"),
         token0,
@@ -272,7 +272,7 @@ export const switchTokenTestInput = function (
       ),
     ],
     sellOrdersToken1: [
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("10"),
         utils.parseEther("9"),
         token1,
@@ -280,7 +280,7 @@ export const switchTokenTestInput = function (
         tradersToken1[0],
         1,
       ),
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("3"),
         utils.parseEther("2.5"),
         token1,
@@ -288,7 +288,7 @@ export const switchTokenTestInput = function (
         tradersToken1[1],
         2,
       ),
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("3"),
         utils.parseEther("2.6"),
         token1,
@@ -296,7 +296,7 @@ export const switchTokenTestInput = function (
         tradersToken1[2],
         3,
       ),
-      orderAlwaysValid(
+      indefiniteOrder(
         utils.parseEther("3"),
         utils.parseEther("2.9"),
         token1,


### PR DESCRIPTION
Fixes #6.

Orders are valid from and until the given dates in seconds.

### Test Plan

New unit tests were added to test success and failure cases. The old tests have been changed to use orders with a very long validity period.

Using `uint32` is enough to store reasonable timestamps.
```
$ date --date="@$((2**32-1))"
Sun 07 Feb 2106 07:28:15 AM CET
```