### PR TITLE
add pre-computed replay protection

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -9,10 +9,18 @@ import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Factory.sol";
 contract GPv2Settlement {
     /// @dev The domain separator used for signing orders that gets mixed in
     /// making signatures for different domains incompatible.
-    bytes32 public constant DOMAIN_SEPARATOR = keccak256("GPv2");
+    bytes4 private constant DOMAIN_SEPARATOR = "GPv2";
 
     /// @dev The stride of an encoded order.
     uint256 private constant ORDER_STRIDE = 130;
+
+    /// @dev Replay protection that is mixed with the order data for signing.
+    /// This is done in order to avoid chain and domain replay protection, so
+    /// that signed orders are only valid for specific GPv2 contracts.
+    ///
+    /// The replay protection is defined as the Keccak-256 hash of `"GPv2"`
+    /// followed by the chain ID and finally the contract address.
+    bytes32 public immutable replayProtection;
 
     /// @dev The Uniswap factory. This is used as the AMM that GPv2 settles with
     /// and is responsible for determining the range of the settlement price as
@@ -27,6 +35,16 @@ contract GPv2Settlement {
     /// @param uniswapFactory_ The Uniswap factory to act as the AMM for this
     /// GPv2 settlement contract.
     constructor(IUniswapV2Factory uniswapFactory_) public {
+        // NOTE: Currently, the only way to get the chain ID in solidity is
+        // using assembly.
+        uint256 chainId;
+        assembly {
+            chainId := chainid()
+        }
+
+        replayProtection = keccak256(
+            abi.encodePacked(DOMAIN_SEPARATOR, uint64(chainId), address(this))
+        );
         uniswapFactory = uniswapFactory_;
     }
 

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -35,15 +35,17 @@ contract GPv2Settlement {
     /// @param uniswapFactory_ The Uniswap factory to act as the AMM for this
     /// GPv2 settlement contract.
     constructor(IUniswapV2Factory uniswapFactory_) public {
+        uint256 chainId;
+
         // NOTE: Currently, the only way to get the chain ID in solidity is
         // using assembly.
-        uint256 chainId;
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             chainId := chainid()
         }
 
         replayProtection = keccak256(
-            abi.encodePacked(DOMAIN_SEPARATOR, uint64(chainId), address(this))
+            abi.encodePacked(DOMAIN_SEPARATOR, chainId, address(this))
         );
         uniswapFactory = uniswapFactory_;
     }

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -9,7 +9,7 @@ import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Factory.sol";
 contract GPv2Settlement {
     /// @dev The domain separator used for signing orders that gets mixed in
     /// making signatures for different domains incompatible.
-    bytes4 private constant DOMAIN_SEPARATOR = "GPv2";
+    string private constant DOMAIN_SEPARATOR = "GPv2";
 
     /// @dev The stride of an encoded order.
     uint256 private constant ORDER_STRIDE = 130;
@@ -45,7 +45,7 @@ contract GPv2Settlement {
         }
 
         replayProtection = keccak256(
-            abi.encodePacked(DOMAIN_SEPARATOR, chainId, address(this))
+            abi.encode(DOMAIN_SEPARATOR, chainId, address(this))
         );
         uniswapFactory = uniswapFactory_;
     }

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -22,11 +22,22 @@ describe("GPv2Settlement", () => {
   describe("replayProtection", () => {
     it("should have a well defined replay protection signature mixer", async () => {
       const { chainId } = await waffle.provider.getNetwork();
+      expect(chainId).to.not.equal(ethers.constants.Zero);
+
       expect(await settlement.replayProtection()).to.equal(
         ethers.utils.solidityKeccak256(
-          ["string", "uint64", "address"],
+          ["string", "uint256", "address"],
           ["GPv2", chainId, settlement.address],
         ),
+      );
+    });
+
+    it("should have a different replay protection for each deployment", async () => {
+      const GPv2Settlement = await ethers.getContractFactory("GPv2Settlement");
+      const settlement2 = await GPv2Settlement.deploy(uniswapFactory.address);
+
+      expect(await settlement.replayProtection()).to.not.equal(
+        await settlement2.replayProtection(),
       );
     });
   });

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -25,9 +25,11 @@ describe("GPv2Settlement", () => {
       expect(chainId).to.not.equal(ethers.constants.Zero);
 
       expect(await settlement.replayProtection()).to.equal(
-        ethers.utils.solidityKeccak256(
-          ["string", "uint256", "address"],
-          ["GPv2", chainId, settlement.address],
+        ethers.utils.keccak256(
+          ethers.utils.defaultAbiCoder.encode(
+            ["string", "uint256", "address"],
+            ["GPv2", chainId, settlement.address],
+          ),
         ),
       );
     });

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -3,7 +3,7 @@ import IUniswapV2Factory from "@uniswap/v2-core/build/IUniswapV2Factory.json";
 import { expect } from "chai";
 import { Contract } from "ethers";
 
-describe.only("GPv2Settlement", () => {
+describe("GPv2Settlement", () => {
   const [deployer] = waffle.provider.getWallets();
 
   let settlement: Contract;

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -3,7 +3,7 @@ import IUniswapV2Factory from "@uniswap/v2-core/build/IUniswapV2Factory.json";
 import { expect } from "chai";
 import { Contract } from "ethers";
 
-describe("GPv2Settlement", () => {
+describe.only("GPv2Settlement", () => {
   const [deployer] = waffle.provider.getWallets();
 
   let settlement: Contract;
@@ -19,10 +19,14 @@ describe("GPv2Settlement", () => {
     settlement = await GPv2Settlement.deploy(uniswapFactory.address);
   });
 
-  describe("DOMAIN_SEPARATOR", () => {
-    it("should have a well defined domain separator", async () => {
-      expect(await settlement.DOMAIN_SEPARATOR()).to.equal(
-        ethers.utils.id("GPv2"),
+  describe("replayProtection", () => {
+    it("should have a well defined replay protection signature mixer", async () => {
+      const { chainId } = await waffle.provider.getNetwork();
+      expect(await settlement.replayProtection()).to.equal(
+        ethers.utils.solidityKeccak256(
+          ["string", "uint64", "address"],
+          ["GPv2", chainId, settlement.address],
+        ),
       );
     });
   });


### PR DESCRIPTION
Fixes #33 

This is just a suggestion, but we could pre-compute a replay protection signature mixer from a domain separator, chain ID and address. This way, we have some data orders get hashed with that is unique per chain, per contract, and has some GPv2 specific domain data.

@fedgiac maybe this is a bad idea, I just thought it would make signature verification a tiny bit cheaper by reducing the amount of data being hashed to get verified. 

### Test Plan

Added new unit tests.