### PR TITLE
use Uniswap pair address to uniquely identify token pairs

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.6.12;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Factory.sol";
+import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol";
 
 /// @title Gnosis Protocol v2 Settlement Contract
 /// @author Gnosis Developers
@@ -22,7 +23,7 @@ contract GPv2Settlement {
     /// @dev A mapping from a token pair ID to a nonce. This represents the
     /// batch for token pair and is used to ensure orders can't be replayed
     /// in multiple batches.
-    mapping(bytes20 => uint256) public nonce;
+    mapping(IUniswapV2Pair => uint256) public nonce;
 
     /// @param uniswapFactory_ The Uniswap factory to act as the AMM for this
     /// GPv2 settlement contract.
@@ -90,17 +91,35 @@ contract GPv2Settlement {
         revert("not yet implemented");
     }
 
-    /// @dev Returns a unique ID for the specified token pair. Note that the
-    /// order in which the tokens are specified does not matter.
-    /// @param token0 The address one of the tokens of the pair.
-    /// @param token1 The address the other token of the pair.
-    /// @return The token ID unique to the pair.
-    function pairId(IERC20 token0, IERC20 token1)
+    /// @dev Returns a unique pair address for the specified tokens. Note that
+    /// the tokens must be in lexicographical order or else this call reverts.
+    /// This is required to ensure that the `token0` and `token1` are in the
+    /// same order as the Uniswap pair.
+    /// @param token0 The address one token in the pair.
+    /// @param token1 The address the other token in the pair.
+    /// @return The address of the Uniswap token pair.
+    function uniswapPairAddress(IERC20 token0, IERC20 token1)
         public
-        pure
-        returns (bytes20)
+        view
+        returns (IUniswapV2Pair)
     {
-        require(token0 != token1, "invalid pair");
-        return (bytes20(address(token0)) ^ bytes20(address(token1)));
+        require(
+            address(token0) != address(0) && address(token0) < address(token1),
+            "invalid pair"
+        );
+
+        // NOTE: The address of a Uniswap pair is deterministic as it is created
+        // with `CREATE2` instruction. This allows us get the pair address
+        // without requesting any chain data!
+        // See <https://uniswap.org/docs/v2/smart-contract-integration/getting-pair-addresses/>.
+        bytes32 pairAddressBytes = keccak256(
+            abi.encodePacked(
+                hex"ff",
+                address(uniswapFactory),
+                keccak256(abi.encodePacked(address(token0), address(token1))),
+                hex"96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f"
+            )
+        );
+        return IUniswapV2Pair(uint256(pairAddressBytes));
     }
 }

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -20,9 +20,9 @@ contract GPv2Settlement {
     /// well as trading surplus that cannot be directly settled in a batch.
     IUniswapV2Factory public immutable uniswapFactory;
 
-    /// @dev A mapping from a token pair ID to a nonce. This represents the
-    /// batch for token pair and is used to ensure orders can't be replayed
-    /// in multiple batches.
+    /// @dev A mapping from a Uniswap token pair address to its nonce. This
+    /// represents the current batch for that token pair and is used to ensure
+    /// orders can't be replayed in multiple batches.
     mapping(IUniswapV2Pair => uint256) public nonce;
 
     /// @param uniswapFactory_ The Uniswap factory to act as the AMM for this

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -1,5 +1,7 @@
 import { ethers, waffle } from "@nomiclabs/buidler";
+import IERC20 from "@openzeppelin/contracts/build/contracts/IERC20.json";
 import IUniswapV2Factory from "@uniswap/v2-core/build/IUniswapV2Factory.json";
+import UniswapV2Factory from "@uniswap/v2-core/build/UniswapV2Factory.json";
 import { expect } from "chai";
 import { Contract } from "ethers";
 
@@ -43,23 +45,69 @@ describe("GPv2Settlement", () => {
     });
   });
 
-  describe("pairId", () => {
-    it("should return the same ID regardless of token order", async () => {
+  describe("uniswapPairAddress", () => {
+    it("should match the on-chain Uniswap pair address", async () => {
+      // TODO(nlordell): This should move to be an integration test once they
+      // have been setup.
+
+      const tokenA = await waffle.deployMockContract(deployer, IERC20.abi);
+      const tokenB = await waffle.deployMockContract(deployer, IERC20.abi);
+      const [token0, token1] =
+        tokenA.address < tokenB.address ? [tokenA, tokenB] : [tokenB, tokenA];
+
+      const GPv2Settlement = await ethers.getContractFactory("GPv2Settlement");
+      for (const [tokenX, tokenY] of [
+        [token0, token1],
+        [token1, token0],
+      ]) {
+        const uniswapFactory = await waffle.deployContract(
+          deployer,
+          UniswapV2Factory,
+          [deployer.address],
+        );
+
+        await uniswapFactory.createPair(tokenX.address, tokenY.address);
+        const uniswapPairAddress = await uniswapFactory.getPair(
+          tokenX.address,
+          tokenY.address,
+        );
+
+        const settlement = await GPv2Settlement.deploy(uniswapFactory.address);
+
+        expect(
+          await settlement.uniswapPairAddress(token0.address, token1.address),
+        ).to.equal(uniswapPairAddress);
+      }
+    });
+
+    it("should revert if token order is inverted", async () => {
       const [token0, token1] = [
-        `0x${"42".repeat(20)}`,
-        `0x${"1337".repeat(10)}`,
+        `0x${"00".repeat(19)}0a`,
+        `0x${"00".repeat(19)}0b`,
       ];
 
-      expect(await settlement.pairId(token0, token1)).to.equal(
-        await settlement.pairId(token1, token0),
-      );
+      await expect(
+        settlement.uniswapPairAddress(token1, token0),
+      ).to.be.revertedWith("invalid pair");
     });
 
     it("should revert for pairs where both tokens are equal", async () => {
       const token = `0x${"42".repeat(20)}`;
-      await expect(settlement.pairId(token, token)).to.be.revertedWith(
-        "invalid pair",
-      );
+
+      await expect(
+        settlement.uniswapPairAddress(token, token),
+      ).to.be.revertedWith("invalid pair");
+    });
+
+    it("should revert for pairs where either token is address 0", async () => {
+      const token = `0x${"42".repeat(20)}`;
+
+      await expect(
+        settlement.uniswapPairAddress(token, ethers.constants.AddressZero),
+      ).to.be.revertedWith("invalid pair");
+      await expect(
+        settlement.uniswapPairAddress(ethers.constants.AddressZero, token),
+      ).to.be.revertedWith("invalid pair");
     });
   });
 });


### PR DESCRIPTION
This PR makes use of the fact that Uniswap token pair addresses are deterministic (because they use `CREATE2`). This means that we can compute a Uniswap pair address instead of reading it from storage with `SLOAD`.

### Test Plan

New unit test to make sure it works.
