### PR TITLE
implement order decoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "lint:ts": "eslint --max-warnings 0 .",
     "fmt:sol": "prettier 'src/contracts/**/*.sol' -w"
   },
+  "dependencies": {
+    "ethers": "^5.0.19"
+  },
   "devDependencies": {
     "@nomiclabs/buidler": "^1.4.8",
     "@nomiclabs/buidler-ethers": "^2.0.2",
@@ -29,7 +32,6 @@
     "eslint-plugin-no-only-tests": "^2.4.0",
     "eslint-plugin-prettier": "^3.1.4",
     "ethereum-waffle": "^3.2.0",
-    "ethers": "^5.0.19",
     "prettier": "^2.1.2",
     "prettier-plugin-solidity": "^1.0.0-alpha.59",
     "solhint": "^3.3.1",

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -13,7 +13,7 @@ contract GPv2Settlement {
     string private constant DOMAIN_SEPARATOR = "GPv2";
 
     /// @dev The stride of an encoded order.
-    uint256 private constant ORDER_STRIDE = 130;
+    uint256 private constant ORDER_STRIDE = 126;
 
     /// @dev Replay protection that is mixed with the order data for signing.
     /// This is done in order to avoid chain and domain replay protection, so
@@ -79,11 +79,10 @@ contract GPv2Settlement {
     /// struct Order {
     ///     sellAmount:     uint112,
     ///     buyAmount:      uint112,
-    ///     executedAmount: uint112,
-    ///     tip:            uint112,
-    ///     nonce:          uint32,
     ///     validTo:        uint32,
+    ///     tip:            uint112,
     ///     flags:          uint8,
+    ///     executedAmount: uint112,
     ///     signature: {
     ///         v:          uint8,
     ///         r:          bytes32,
@@ -178,5 +177,49 @@ contract GPv2Settlement {
         // cannot realistically overflow by adding one at a time, as that would
         // take 2^256 transactions to achieve!
         nonces[pair] = nonce;
+    }
+
+    /// @dev Decodes an order from calldata bytes returning order parameters.
+    /// @param encodedOrder The order as encoded calldata bytes.
+    function decodeOrder(bytes calldata encodedOrder)
+        internal
+        pure
+        returns (
+            uint112 sellAmount,
+            uint112 buyAmount,
+            uint32 validTo,
+            uint112 tip,
+            uint8 flags,
+            uint112 executedAmount,
+            uint8 v,
+            bytes32 r,
+            bytes32 s
+        )
+    {
+        // NOTE: This is currently unnecessarily gas inefficient. Specifically,
+        // there is a potentially extrenuous check to the encoded order length
+        // (this can be verified once for the total encoded orders length).
+        // Additionally, Solidity generates bounds checks for each `abi.decode`
+        // and slice operation. Unfortunately using `assmebly { calldataload }`
+        // is quite ugly here since there is no mechanism to get calldata
+        // offsets (like there is for memory offsets) without manual
+        // computation, which is brittle as changes to the `settle` function
+        // signature would require manual adjustments to the computation. Once
+        // gas benchmarking is set up, we can evaluate if it is worth the extra
+        // effort.
+
+        require(encodedOrder.length == ORDER_STRIDE, "malformed order data");
+
+        sellAmount = uint112(abi.decode(encodedOrder[0:], (uint256)) >> 144);
+        buyAmount = uint112(abi.decode(encodedOrder[14:], (uint256)) >> 144);
+        validTo = uint32(abi.decode(encodedOrder[28:], (uint256)) >> 224);
+        tip = uint112(abi.decode(encodedOrder[32:], (uint256)) >> 144);
+        flags = uint8(abi.decode(encodedOrder[46:], (uint256)) >> 248);
+        executedAmount = uint112(
+            abi.decode(encodedOrder[47:], (uint256)) >> 144
+        );
+        v = uint8(abi.decode(encodedOrder[61:], (uint256)) >> 248);
+        r = bytes32(abi.decode(encodedOrder[62:], (uint256)));
+        s = bytes32(abi.decode(encodedOrder[94:], (uint256)));
     }
 }

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -214,11 +214,11 @@ contract GPv2Settlement {
         buyAmount = uint112(abi.decode(encodedOrder[14:], (uint256)) >> 144);
         validTo = uint32(abi.decode(encodedOrder[28:], (uint256)) >> 224);
         tip = uint112(abi.decode(encodedOrder[32:], (uint256)) >> 144);
-        flags = uint8(abi.decode(encodedOrder[46:], (uint256)) >> 248);
+        flags = uint8(encodedOrder[46]);
         executedAmount = uint112(
             abi.decode(encodedOrder[47:], (uint256)) >> 144
         );
-        v = uint8(abi.decode(encodedOrder[61:], (uint256)) >> 248);
+        v = uint8(encodedOrder[61]);
         r = bytes32(abi.decode(encodedOrder[62:], (uint256)));
         s = bytes32(abi.decode(encodedOrder[94:], (uint256)));
     }

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -197,7 +197,7 @@ contract GPv2Settlement {
         )
     {
         // NOTE: This is currently unnecessarily gas inefficient. Specifically,
-        // there is a potentially extrenuous check to the encoded order length
+        // there is a potentially extraneuous check to the encoded order length
         // (this can be verified once for the total encoded orders length).
         // Additionally, Solidity generates bounds checks for each `abi.decode`
         // and slice operation. Unfortunately using `assmebly { calldataload }`

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -207,7 +207,7 @@ contract GPv2Settlement {
         )
     {
         // NOTE: This is currently unnecessarily gas inefficient. Specifically,
-        // there is a potentially extraneuous check to the encoded order length
+        // there is a potentially extraneous check to the encoded order length
         // (this can be verified once for the total encoded orders length).
         // Additionally, Solidity generates bounds checks for each `abi.decode`
         // and slice operation. Unfortunately using `assmebly { calldataload }`

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 pragma solidity ^0.6.12;
+pragma experimental ABIEncoderV2;
 
 import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Factory.sol";
 import "../GPv2Settlement.sol";
@@ -23,5 +24,68 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
         returns (uint256)
     {
         return fetchIncrementNonce(pair);
+    }
+
+    struct Order {
+        uint112 sellAmount;
+        uint112 buyAmount;
+        uint32 validTo;
+        uint112 tip;
+        uint8 flags;
+        uint112 executedAmount;
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+    }
+
+    function decodeOrderTest(bytes calldata encodedOrder)
+        external
+        pure
+        returns (Order memory result)
+    {
+        (
+            uint112 sellAmount,
+            uint112 buyAmount,
+            uint32 validTo,
+            uint112 tip,
+            uint8 flags,
+            uint112 executedAmount,
+            uint8 v,
+            bytes32 r,
+            bytes32 s
+        ) = decodeOrder(encodedOrder);
+
+        result.sellAmount = sellAmount;
+        result.buyAmount = buyAmount;
+        result.validTo = validTo;
+        result.tip = tip;
+        result.flags = flags;
+        result.executedAmount = executedAmount;
+        result.v = v;
+        result.r = r;
+        result.s = s;
+    }
+
+    function decodeOrderMemoryTest(bytes calldata encodedOrder)
+        external
+        pure
+        returns (uint256 mem)
+    {
+        // solhint-disable no-inline-assembly
+
+        // NOTE: Solidity keeps a total memory count at address 0x40. Check
+        // before and after decoding an order to compute memory usage growth per
+        // call to `decodeOrder`.
+        assembly {
+            mem := mload(0x40)
+        }
+
+        decodeOrder(encodedOrder);
+
+        assembly {
+            mem := sub(mload(0x40), mem)
+        }
+
+        // solhint-enable
     }
 }

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -94,7 +94,7 @@ function timestamp(time: number | Date): number {
  * @param order The order data to be encoded.
  * @param executedAmount The amount of the order that is actually traded.
  * @param signature The signature for the order data.
- * @return A hex-string representing the encded executed order.
+ * @return A hex-string representing the encoded executed order.
  */
 export function encodeExecutedOrder(
   order: Order,

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,0 +1,135 @@
+import { ethers, BigNumberish, SignatureLike } from "ethers";
+
+/**
+ * Gnosis Protocol v2 order data.
+ */
+export interface Order {
+  /** Sell token address. */
+  sellToken: string;
+  /** Buy token address. */
+  buyToken: string;
+
+  /**
+   * The order sell amount.
+   *
+   * For fill or kill sell orders, this amount represents the exact sell amount
+   * that will be executed in the trade. For fill or kill buy orders, this
+   * amount represents the maximum sell amount that can be executed. For partial
+   * fill orders, this represents a component of the limit price fraction.
+   */
+  sellAmount: BigNumberish;
+  /**
+   * The order buy amount.
+   *
+   * For fill or kill sell orders, this amount represents the minimum buy amount
+   * that can be executed in the trade. For fill or kill buy orders, this amount
+   * represents the exact buy amount that will be executed. For partial fill
+   * orders, this represents a component of the limit price fraction.
+   */
+  buyAmount: BigNumberish;
+
+  /** The timestamp this order is valid until */
+  validTo: number | Date;
+  /**
+   * The nonce this order is valid for.
+   *
+   * Specifying a value of {@link REPLAYABLE_NONCE} indicates that this order
+   * can be replayed in any batch. This can be used for setting up passive
+   * trading strategies where orders are valid forever.
+   */
+  nonce: number;
+
+  /**
+   * Additional fee to give to the protocol.
+   *
+   * This tip is used to offset solution submission gas costs so orders that
+   * aren't economically viable (i.e. small orders that do not generate enough
+   * fees) still get executed.
+   */
+  tip: BigNumberish;
+
+  /** Additional order flags. See {@link OrderFlags}. */
+  flags: OrderFlags;
+}
+
+/**
+ * Order flags for enabling certain order features. By default, all orders are
+ * fill-or-kill sell orders.
+ */
+export enum OrderFlags {
+  /** Specifies the order is a sell order */
+  SELL_ORDER = 0x00,
+  /** Specifies the order is a buy order */
+  BUY_ORDER = 0x01,
+  /** Specifies the order is partially fillable */
+  PARTIAL_FILL = 0x02,
+
+  /** The mask for reserved values that must be 0. */
+  RESERVED_MASK = 0xfc,
+}
+
+/**
+ * Reserved nonce value used to indicate that an order can be replayed in any
+ * batch.
+ */
+export const REPLAYABLE_NONCE = 0;
+
+/**
+ * Additional order flags used to efficiently encode order information. These
+ * flags are added at encoding time but not included in the signature.
+ */
+export enum OrderEncodingFlags {
+  /** Encode that the nonce should be {@link REPLAYABLE_NONCE} */
+  REPLAYABLE_NONCE = 0x80,
+}
+
+function timestamp(time: number | Date): number {
+  return typeof time === "number" ? time : ~~(time.getTime() / 1000);
+}
+
+/**
+ * Encodes an executed order, that is an order with its executed traded amount
+ * and signature. This data is exactly what the settlement contract expects
+ * per order in order to settle a batch.
+ * @param order The order data to be encoded.
+ * @param executedAmount The amount of the order that is actually traded.
+ * @param signature The signature for the order data.
+ * @return A hex-string representing the encded executed order.
+ */
+export function encodeExecutedOrder(
+  order: Order,
+  executedAmount: BigNumberish,
+  signature: SignatureLike,
+): string {
+  // NOTE: The nonce is encoded as a bit in the flags. This is done to save 4
+  // bytes per order as the nonce can only be the current nonce or 0 for the
+  // order to be valid.
+  const encodingFlags =
+    order.nonce === 0 ? OrderEncodingFlags.REPLAYABLE_NONCE : 0;
+  const sig = ethers.utils.splitSignature(signature);
+
+  return ethers.utils.solidityPack(
+    [
+      "uint112",
+      "uint112",
+      "uint32",
+      "uint112",
+      "uint8",
+      "uint112",
+      "uint8",
+      "bytes32",
+      "bytes32",
+    ],
+    [
+      order.sellAmount,
+      order.buyAmount,
+      timestamp(order.validTo),
+      order.tip,
+      order.flags | encodingFlags,
+      executedAmount,
+      sig.v,
+      sig.r,
+      sig.s,
+    ],
+  );
+}

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -8,7 +8,6 @@ export interface Order {
   sellToken: string;
   /** Buy token address. */
   buyToken: string;
-
   /**
    * The order sell amount.
    *
@@ -27,7 +26,6 @@ export interface Order {
    * orders, this represents a component of the limit price fraction.
    */
   buyAmount: BigNumberish;
-
   /** The timestamp this order is valid until */
   validTo: number | Date;
   /**
@@ -38,7 +36,6 @@ export interface Order {
    * trading strategies where orders are valid forever.
    */
   nonce: number;
-
   /**
    * Additional fee to give to the protocol.
    *
@@ -47,7 +44,6 @@ export interface Order {
    * fees) still get executed.
    */
   tip: BigNumberish;
-
   /** Additional order flags. See {@link OrderFlags}. */
   flags: OrderFlags;
 }

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -183,7 +183,7 @@ describe("GPv2Settlement", () => {
     const executedAmount = fillUint(112, 6);
     const signature = ethers.utils.splitSignature(`${fillBytes(64, 0)}01`);
 
-    it("should round trip encoded executed order data", async () => {
+    it("should round-trip encode executed order data", async () => {
       const encodedOrder = encodeExecutedOrder(
         order,
         executedAmount,

--- a/typings/ethers/index.d.ts
+++ b/typings/ethers/index.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Additional typings for Ethers.js
+ */
+
+import { ethers } from "ethers";
+
+declare module "ethers" {
+  /**
+   * A signature-like type.
+   *
+   * Note this type definition is included here as it is not re-exported by the
+   * main `ethers` package.
+   */
+  export type SignatureLike = Parameters<typeof ethers.utils.splitSignature>[0];
+}


### PR DESCRIPTION
Fixed #95

This PR implements order decoding in a mostly gas efficient way. Specifically:
- Orders are tightly packed to save on call data costs (see #30 for rational behind this)
- Order decoding does not allocate memory - this is important as memory costs grow quadratically so it would be nice if the memory complexity was not `O(n)`. 

### Test Plan

Added new unit tests. In order to verify that my assumptions about solidity memory are correct, I made the following change to the `decodeOrder` function:

```diff
diff --git a/src/contracts/GPv2Settlement.sol b/src/contracts/GPv2Settlement.sol
index 89b0dba..34af9df 100644
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -210,6 +210,8 @@ contract GPv2Settlement {
 
         require(encodedOrder.length == ORDER_STRIDE, "malformed order data");
 
+        bytes memory foo = new bytes(10);
+
         sellAmount = uint112(abi.decode(encodedOrder[0:], (uint256)) >> 144);
         buyAmount = uint112(abi.decode(encodedOrder[14:], (uint256)) >> 144);
         validTo = uint32(abi.decode(encodedOrder[28:], (uint256)) >> 224);
```

And ran the memory test again:
```
  GPv2Settlement
    decodeOrder
      1) should not allocate memory


  0 passing (808ms)
  1 failing

  1) GPv2Settlement
       decodeOrder
         should not allocate memory:

      AssertionError: Expected "64" to be equal 0
      + expected - actual

       {
      -  "_hex": "0x00"
      +  "_hex": "0x40"
         "_isBigNumber": true
       }

      at Context.<anonymous> (test/GPv2Settlement.test.ts:230:17)
      at processTicksAndRejections (internal/process/task_queues.js:97:5)
```
