### PR TITLE
Fee claiming function

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -85,4 +85,20 @@ contract GPv2Settlement {
         require(encodedOrderRefunds.length == 0, "not yet implemented");
         revert("not yet implemented");
     }
+
+    // solhint-enable
+
+    modifier onlyOwner {
+        // TODO - replace with with call to AccessControl contract
+        require(true, "GPv2: not an owner");
+        _;
+    }
+
+    function transferBalanceTo(
+        IERC20 token,
+        address receiver,
+        uint256 amount
+    ) external onlyOwner {
+        token.transfer(receiver, amount);
+    }
 }

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -1,9 +1,11 @@
+import IERC20 from "@openzeppelin/contracts/build/contracts/IERC20.json";
 import { expect } from "chai";
 import { Contract } from "ethers";
 import { ethers, waffle } from "hardhat";
 
 describe("GPv2Settlement", () => {
   let settlement: Contract;
+  const [deployer, owner] = waffle.provider.getWallets();
 
   beforeEach(async () => {
     const GPv2Settlement = await ethers.getContractFactory(
@@ -36,5 +38,34 @@ describe("GPv2Settlement", () => {
         await settlement2.replayProtection(),
       );
     });
+  });
+
+  describe("transferBalanceTo", () => {
+    it("allows owner to transfer requested amount of token out of settlement contract", async () => {
+      const token = await waffle.deployMockContract(deployer, IERC20.abi);
+      await token.mock.transfer.withArgs(owner.address, 1337).returns(true);
+
+      await expect(
+        settlement.transferBalanceTo(token.address, owner.address, 1337),
+      ).to.not.be.reverted;
+    });
+
+    it("reverts on failed token transfer", async () => {
+      const token = await waffle.deployMockContract(deployer, IERC20.abi);
+      await token.mock.transfer.withArgs(owner.address, 1337).reverts();
+
+      await expect(
+        settlement.transferBalanceTo(token.address, owner.address, 1337),
+      ).to.be.reverted;
+    });
+
+    // TODO - once SafeERC20 Exists, this test should pass.
+    // it("allows owner to transfer requested amount of token out of settlement contract", async () => {
+    //   const token = await waffle.deployMockContract(deployer, IERC20.abi);
+    //   await token.mock.transfer.withArgs(owner.address, 1337).returns(false);
+    //   await expect(
+    //     settlement.transferBalanceTo(token.address, owner.address, 1337),
+    //   ).to.be.reverted;
+    // });
   });
 });


### PR DESCRIPTION

Fixes #17

At this moment, we introduce a function `transferBalanceTo` which accepts a list of token addresses and receiver address. The function then transfers its balance of each listed token to the receiver address. This is, of course, restricted by the "onlyOwner" modifier which remains unimplemented, but will be taken care of in a separate PR via the introduction of an `AccessControl` contract in #120.

### Test Plan

Unit tests.
