### PR TITLE
use EIP-712 domain separator

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -7,16 +7,11 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 /// @author Gnosis Developers
 contract GPv2Settlement {
     /// @dev The domain separator used for signing orders that gets mixed in
-    /// making signatures for different domains incompatible.
-    string private constant DOMAIN_SEPARATOR = "GPv2";
-
-    /// @dev Replay protection that is mixed with the order data for signing.
-    /// This is done in order to avoid chain and domain replay protection, so
-    /// that signed orders are only valid for specific GPv2 contracts.
-    ///
-    /// The replay protection is defined as the Keccak-256 hash of `"GPv2"`
-    /// followed by the chain ID and finally the contract address.
-    bytes32 public immutable replayProtection;
+    /// making signatures for different domains incompatible. This domain
+    /// separator is computed following the EIP-712 standard and has replay
+    /// protection mixed in so that signed orders are only valid for specific
+    /// GPv2 contracts.
+    bytes32 internal immutable domainSeparator;
 
     constructor() public {
         uint256 chainId;
@@ -28,8 +23,16 @@ contract GPv2Settlement {
             chainId := chainid()
         }
 
-        replayProtection = keccak256(
-            abi.encode(DOMAIN_SEPARATOR, chainId, address(this))
+        domainSeparator = keccak256(
+            abi.encode(
+                keccak256(
+                    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                ),
+                keccak256("Gnosis Protocol"),
+                keccak256("v2"),
+                chainId,
+                address(this)
+            )
         );
     }
 

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -4,7 +4,8 @@ pragma experimental ABIEncoderV2;
 
 import "../GPv2Settlement.sol";
 
-// solhint-disable-next-line no-empty-blocks
 contract GPv2SettlementTestInterface is GPv2Settlement {
-
+    function domainSeparatorTest() public view returns (bytes32) {
+        return domainSeparator;
+    }
 }

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,6 +1,35 @@
 import { ethers, BigNumberish, Signature, SignatureLike, Wallet } from "ethers";
 
 /**
+ * EIP-712 domain data used by GPv2.
+ *
+ * Note, that EIP-712 allows for an extra `salt` to be added to the domain that
+ * isn't used.
+ * <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-domainseparator>
+ */
+export interface EIP712Domain {
+  name: string;
+  version: string;
+  chainId: number;
+  verifyingContract: string;
+}
+
+/**
+ * Return the Gnosis Protocol v2 domain used for EIP-712 signing.
+ */
+export function domain(
+  chainId: number,
+  verifyingContract: string,
+): EIP712Domain {
+  return {
+    name: "Gnosis Protocol",
+    version: "v2",
+    chainId,
+    verifyingContract,
+  };
+}
+
+/**
  * Gnosis Protocol v2 order data.
  */
 export interface Order {

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -8,9 +8,21 @@ import { ethers, BigNumberish, Signature, SignatureLike, Wallet } from "ethers";
  * <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-domainseparator>
  */
 export interface EIP712Domain {
+  /**
+   * The user readable name of signing domain.
+   */
   name: string;
+  /**
+   * The current major version of the signing domain.
+   */
   version: string;
+  /**
+   * The EIP-155 chain ID.
+   */
   chainId: number;
+  /**
+   * The address of the contract that will verify the EIP-712 signature.
+   */
   verifyingContract: string;
 }
 

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -27,7 +27,11 @@ export interface EIP712Domain {
 }
 
 /**
- * Return the Gnosis Protocol v2 domain used for EIP-712 signing.
+ * Return the Gnosis Protocol v2 domain used for signing.
+ * @param chainId The EIP-155 chain ID.
+ * @param verifyingContract The address of the contract that will verify the
+ * signature.
+ * @return An EIP-712 compatible typed domain data.
  */
 export function domain(
   chainId: number,


### PR DESCRIPTION
This PR changes the current replay protection method to instead use an [EIP-712 domain separator](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-domainseparator). This will allow us to take advantage of EIP-712 typed data signing, while still falling back to using a `eth_signMessage` where it is not supported by using the same domain separator which mixes in replay protection.

### Test Plan

Adjusted unit tests for new domain separator/replay protection mechanism.
