### PR TITLE
Add eth_signTypedData support

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -7,16 +7,11 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 /// @author Gnosis Developers
 contract GPv2Settlement {
     /// @dev The domain separator used for signing orders that gets mixed in
-    /// making signatures for different domains incompatible.
-    string private constant DOMAIN_SEPARATOR = "GPv2";
-
-    /// @dev Replay protection that is mixed with the order data for signing.
-    /// This is done in order to avoid chain and domain replay protection, so
-    /// that signed orders are only valid for specific GPv2 contracts.
-    ///
-    /// The replay protection is defined as the Keccak-256 hash of `"GPv2"`
-    /// followed by the chain ID and finally the contract address.
-    bytes32 public immutable replayProtection;
+    /// making signatures for different domains incompatible. This domain
+    /// separator is computed following the EIP-712 standard and has replay
+    /// protection mixed in so that signed orders are only valid for specific
+    /// GPv2 contracts.
+    bytes32 internal immutable domainSeparator;
 
     constructor() public {
         uint256 chainId;
@@ -28,8 +23,16 @@ contract GPv2Settlement {
             chainId := chainid()
         }
 
-        replayProtection = keccak256(
-            abi.encode(DOMAIN_SEPARATOR, chainId, address(this))
+        domainSeparator = keccak256(
+            abi.encode(
+                keccak256(
+                    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                ),
+                keccak256("Gnosis Protocol"),
+                keccak256("v2"),
+                chainId,
+                address(this)
+            )
         );
     }
 

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -25,6 +25,7 @@ contract GPv2Settlement {
 
         domainSeparator = keccak256(
             abi.encode(
+                // TODO(nlordell): Verify that these compile to constants.
                 keccak256(
                     "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
                 ),

--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -134,7 +134,6 @@ library GPv2Encoding {
         order.partiallyFillable =
             (flags >> ORDER_PARTIALLY_FILLABLE_BIT) & 0x01 == 0x01;
 
-        bytes32 orderTypeHash = ORDER_TYPE_HASH;
         bytes32 orderDigest;
 
         // NOTE: In order to avoid a memory allocation per call by using the
@@ -146,7 +145,7 @@ library GPv2Encoding {
             // type hash, which is temporarily stored in the slot reserved for
             // the `owner` field as well as 9 order fields to hash for a total
             // of `10 * sizeof(uint) = 320` bytes.
-            mstore(order, orderTypeHash)
+            mstore(order, ORDER_TYPE_HASH)
             orderDigest := keccak256(order, 320)
         }
 
@@ -184,6 +183,8 @@ library GPv2Encoding {
                 default {
                     mstore(
                         add(order, 320),
+                        // NOTE: Strings are left-padded, so add 0's to make it
+                        // right padded instead.
                         "\x00\x00\x00\x00\x19Ethereum Signed Message:\n64"
                     )
                     signingDigest := keccak256(add(order, 324), 92)

--- a/src/contracts/test/GPv2EncodingTestInterface.sol
+++ b/src/contracts/test/GPv2EncodingTestInterface.sol
@@ -6,7 +6,11 @@ import "../libraries/GPv2Encoding.sol";
 
 contract GPv2EncodingTestInterface {
     bytes32 public constant DOMAIN_SEPARATOR =
-        0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f;
+        keccak256(abi.encode(keccak256("EIP712Domain()")));
+
+    function orderTypeHashTest() external pure returns (bytes32) {
+        return (GPv2Encoding.ORDER_TYPE_HASH);
+    }
 
     function decodeSignedOrdersTest(
         IERC20[] calldata tokens,
@@ -24,6 +28,8 @@ contract GPv2EncodingTestInterface {
         // solhint-disable no-inline-assembly
 
         uint256 stride = GPv2Encoding.ORDER_STRIDE;
+        bytes32 domainSeparator = DOMAIN_SEPARATOR;
+
         orders = new GPv2Encoding.Order[](orderCount);
 
         // NOTE: Solidity keeps a total memory count at address 0x40. Check
@@ -48,7 +54,7 @@ contract GPv2EncodingTestInterface {
             }
 
             GPv2Encoding.decodeSignedOrder(
-                DOMAIN_SEPARATOR,
+                domainSeparator,
                 tokens,
                 encodedOrder,
                 orders[i]

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -4,7 +4,8 @@ pragma experimental ABIEncoderV2;
 
 import "../GPv2Settlement.sol";
 
-// solhint-disable-next-line no-empty-blocks
 contract GPv2SettlementTestInterface is GPv2Settlement {
-
+    function domainSeparatorTest() public view returns (bytes32) {
+        return domainSeparator;
+    }
 }

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,6 +1,35 @@
 import { ethers, BigNumberish, Signature, SignatureLike, Wallet } from "ethers";
 
 /**
+ * EIP-712 domain data used by GPv2.
+ *
+ * Note, that EIP-712 allows for an extra `salt` to be added to the domain that
+ * isn't used.
+ * <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-domainseparator>
+ */
+export interface EIP712Domain {
+  name: string;
+  version: string;
+  chainId: number;
+  verifyingContract: string;
+}
+
+/**
+ * Return the Gnosis Protocol v2 domain used for EIP-712 signing.
+ */
+export function domain(
+  chainId: number,
+  verifyingContract: string,
+): EIP712Domain {
+  return {
+    name: "Gnosis Protocol",
+    version: "v2",
+    chainId,
+    verifyingContract,
+  };
+}
+
+/**
  * Gnosis Protocol v2 order data.
  */
 export interface Order {

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -8,9 +8,21 @@ import { ethers, BigNumberish, Signature, SignatureLike, Wallet } from "ethers";
  * <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-domainseparator>
  */
 export interface EIP712Domain {
+  /**
+   * The user readable name of signing domain.
+   */
   name: string;
+  /**
+   * The current major version of the signing domain.
+   */
   version: string;
+  /**
+   * The EIP-155 chain ID.
+   */
   chainId: number;
+  /**
+   * The address of the contract that will verify the EIP-712 signature.
+   */
   verifyingContract: string;
 }
 

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,4 +1,4 @@
-import { ethers, BigNumberish, Signature, SignatureLike, Wallet } from "ethers";
+import { ethers, BigNumberish, SignatureLike, Signer } from "ethers";
 
 /**
  * EIP-712 domain data used by GPv2.
@@ -152,7 +152,7 @@ export class OrderEncoder {
   /**
    * Creates a new order encoder instance.
    * @param domainSeparator Domain separator used for signing orders to encode.
-   * See {@link hashOrder} for more details.
+   * See {@link signOrder} for more details.
    */
   public constructor(public readonly domainSeparator: string) {}
 
@@ -244,15 +244,15 @@ export class OrderEncoder {
    * @param executedAmount The executed trade amount for the order.
    * @return Signature for the order.
    */
-  public signEncodeOrder(
-    owner: Wallet,
+  public async signEncodeOrder(
+    owner: Signer,
     order: Order,
     executedAmount: BigNumberish,
-  ): void {
+  ): Promise<void> {
     if (!this.domainSeparator) {
       throw new Error("domain separator not specified");
     }
-    const signature = signOrder(owner, this.domainSeparator, order);
+    const signature = await signOrder(owner, this.domainSeparator, order);
     this.encodeOrder(order, executedAmount, signature);
   }
 
@@ -275,18 +275,13 @@ export class OrderEncoder {
 
 /**
  * Compute the 32-byte digest for the specified order.
- * @param domainSeparator The domain separator to add to the digest. This is
- * used by the smart contract to ensure order's can't be replayed across
- * different applications (domains), but also different deployments (as the
- * contract chain ID and address is used to salt the domain separator value).
  * @param order The order to compute the digest for.
  * @return Hex-encoded 32-byte order digest.
  */
-export function hashOrder(domainSeparator: string, order: Order): string {
+export function hashOrder(order: Order): string {
   return ethers.utils.keccak256(
     ethers.utils.defaultAbiCoder.encode(
       [
-        "bytes32",
         "address",
         "address",
         "uint256",
@@ -298,7 +293,6 @@ export function hashOrder(domainSeparator: string, order: Order): string {
         "bool",
       ],
       [
-        domainSeparator,
         order.sellToken,
         order.buyToken,
         order.sellAmount,
@@ -316,22 +310,21 @@ export function hashOrder(domainSeparator: string, order: Order): string {
 /**
  * Returns the signature for the specified order.
  * @param owner The owner for the order used to sign.
- * @param domainSeparator The domain separator to add to the digest used for
- * signing. See {@link hashOrder} for more details.
+ * @param domainSeparator The domain separator to add to the digest. This is
+ * used by the smart contract to ensure order's can't be replayed across
+ * different applications (domains), but also different deployments (as the
+ * contract chain ID and address is used to salt the domain separator value).
  * @param order The order to sign.
- * @return Signature for the order.
+ * @return Hex-encoded signature for the order.
  */
 export function signOrder(
-  owner: Wallet,
+  owner: Signer,
   domainSeparator: string,
   order: Order,
-): Signature {
-  const digest = hashOrder(domainSeparator, order);
-  // NOTE: We need to sign directly with the signing key here on an Ethers.js
-  // wallet and not the `Signer` API, as the latter uses the `"\x19Ethereum
-  // Signed Message:\n" + len(message)` prefix. This is likely to change in the
-  // future as wallets generally don't provide a method for doing this as it is
-  // considered unsafe.
-  // <https://github.com/gnosis/oba-contracts/issues/129>
-  return owner._signingKey().signDigest(digest);
+): Promise<string> {
+  return owner.signMessage(
+    ethers.utils.arrayify(
+      ethers.utils.hexConcat([domainSeparator, hashOrder(order)]),
+    ),
+  );
 }

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,38 +1,22 @@
-import { ethers, BigNumberish, SignatureLike, Signer } from "ethers";
+import {
+  ethers,
+  BigNumberish,
+  SignatureLike,
+  Signer,
+  TypedDataDomain,
+} from "ethers";
 
 /**
- * EIP-712 domain data used by GPv2.
- *
- * Note, that EIP-712 allows for an extra `salt` to be added to the domain that
- * isn't used.
- * <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-domainseparator>
- */
-export interface EIP712Domain {
-  /**
-   * The user readable name of signing domain.
-   */
-  name: string;
-  /**
-   * The current major version of the signing domain.
-   */
-  version: string;
-  /**
-   * The EIP-155 chain ID.
-   */
-  chainId: number;
-  /**
-   * The address of the contract that will verify the EIP-712 signature.
-   */
-  verifyingContract: string;
-}
-
-/**
- * Return the Gnosis Protocol v2 domain used for EIP-712 signing.
+ * Return the Gnosis Protocol v2 domain used for signing.
+ * @param chainId The EIP-155 chain ID.
+ * @param verifyingContract The address of the contract that will verify the
+ * signature.
+ * @return An EIP-712 compatible typed domain data.
  */
 export function domain(
   chainId: number,
   verifyingContract: string,
-): EIP712Domain {
+): TypedDataDomain {
   return {
     name: "Gnosis Protocol",
     version: "v2",
@@ -126,7 +110,31 @@ export const enum OrderKind {
  */
 export const REPLAYABLE_NONCE = 0;
 
-const ORDER_STRIDE = 204;
+/**
+ * The EIP-712 type fields definition for a Gnosis Protocol v2 order.
+ */
+export const ORDER_TYPE_FIELDS = [
+  { name: "sellToken", type: "address" },
+  { name: "buyToken", type: "address" },
+  { name: "sellAmount", type: "uint256" },
+  { name: "buyAmount", type: "uint256" },
+  { name: "validTo", type: "uint32" },
+  { name: "nonce", type: "uint32" },
+  { name: "tip", type: "uint256" },
+  { name: "kind", type: "uint8" },
+  { name: "partiallyFillable", type: "bool" },
+];
+
+/**
+ * The EIP-712 type hash for a Gnosis Protocol v2 order.
+ */
+export const ORDER_TYPE_HASH = ethers.utils.keccak256(
+  ethers.utils.toUtf8Bytes(
+    `Order(${ORDER_TYPE_FIELDS.map(({ name, type }) => `${type} ${name}`).join(
+      ",",
+    )})`,
+  ),
+);
 
 function timestamp(time: number | Date): number {
   return typeof time === "number" ? time : ~~(time.getTime() / 1000);
@@ -136,6 +144,16 @@ function encodeOrderFlags(flags: OrderFlags): number {
   const kind = flags.kind === OrderKind.SELL ? 0x00 : 0x01;
   const partiallyFillable = flags.partiallyFillable ? 0x02 : 0x00;
   return kind | partiallyFillable;
+}
+
+function encodeSigningScheme(v: number, scheme: SigningScheme): number {
+  const ORDER_MESSAGE_SCHEME_FLAG = 0x80;
+  switch (scheme) {
+    case SigningScheme.TYPED_DATA:
+      return v;
+    case SigningScheme.MESSAGE:
+      return v | ORDER_MESSAGE_SCHEME_FLAG;
+  }
 }
 
 /**
@@ -151,10 +169,10 @@ export class OrderEncoder {
 
   /**
    * Creates a new order encoder instance.
-   * @param domainSeparator Domain separator used for signing orders to encode.
+   * @param domain Domain used for signing orders to encode.
    * See {@link signOrder} for more details.
    */
-  public constructor(public readonly domainSeparator: string) {}
+  public constructor(public readonly domain: TypedDataDomain) {}
 
   /**
    * Gets the array of token addresses used by the currently encoded orders.
@@ -182,6 +200,7 @@ export class OrderEncoder {
    * Gets the number of orders currently encoded.
    */
   public get orderCount(): number {
+    const ORDER_STRIDE = 204;
     // NOTE: `ORDER_STRIDE` multiplied by 2 as hex strings encode one byte in
     // 2 characters.
     return (this._encodedOrders.length - 2) / (ORDER_STRIDE * 2);
@@ -196,11 +215,14 @@ export class OrderEncoder {
    * @param order The order to encode.
    * @param executedAmount The executed trade amount for the order.
    * @param signature The signature for the order data.
+   * @param scheme The signing scheme to used to generate the specified
+   * signature. See {@link SigningScheme} for more details.
    */
   public encodeOrder(
     order: Order,
     executedAmount: BigNumberish,
     signature: SignatureLike,
+    scheme: SigningScheme,
   ): void {
     const sig = ethers.utils.splitSignature(signature);
     const encodedOrder = ethers.utils.solidityPack(
@@ -228,7 +250,7 @@ export class OrderEncoder {
         order.tip,
         encodeOrderFlags(order),
         executedAmount,
-        sig.v,
+        encodeSigningScheme(sig.v, scheme),
         sig.r,
         sig.s,
       ],
@@ -242,18 +264,18 @@ export class OrderEncoder {
    * @param owner The owner for the order used to sign.
    * @param order The order to compute the digest for.
    * @param executedAmount The executed trade amount for the order.
+   * @param scheme The signing scheme to use. See {@link SigningScheme} for more
+   * details.
    * @return Signature for the order.
    */
   public async signEncodeOrder(
+    scheme: SigningScheme,
     owner: Signer,
     order: Order,
     executedAmount: BigNumberish,
   ): Promise<void> {
-    if (!this.domainSeparator) {
-      throw new Error("domain separator not specified");
-    }
-    const signature = await signOrder(owner, this.domainSeparator, order);
-    this.encodeOrder(order, executedAmount, signature);
+    const signature = await signOrder(scheme, owner, this.domain, order);
+    this.encodeOrder(order, executedAmount, signature, scheme);
   }
 
   private tokenIndex(token: string): number {
@@ -279,52 +301,64 @@ export class OrderEncoder {
  * @return Hex-encoded 32-byte order digest.
  */
 export function hashOrder(order: Order): string {
-  return ethers.utils.keccak256(
-    ethers.utils.defaultAbiCoder.encode(
-      [
-        "address",
-        "address",
-        "uint256",
-        "uint256",
-        "uint32",
-        "uint32",
-        "uint256",
-        "uint8",
-        "bool",
-      ],
-      [
-        order.sellToken,
-        order.buyToken,
-        order.sellAmount,
-        order.buyAmount,
-        order.validTo,
-        order.nonce,
-        order.tip,
-        order.kind,
-        order.partiallyFillable,
-      ],
-    ),
+  return ethers.utils._TypedDataEncoder.hashStruct(
+    "Order",
+    { Order: ORDER_TYPE_FIELDS },
+    order,
   );
+}
+
+/**
+ * The signing scheme used to sign the order.
+ */
+export const enum SigningScheme {
+  /**
+   * The EIP-712 typed data signing scheme. This is the preferred scheme as it
+   * provides more infomation to wallets performing the signature on the data
+   * being signed.
+   *
+   * <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-domainseparator>
+   */
+  TYPED_DATA,
+  /**
+   * The generic message signing scheme.
+   */
+  MESSAGE,
 }
 
 /**
  * Returns the signature for the specified order.
  * @param owner The owner for the order used to sign.
- * @param domainSeparator The domain separator to add to the digest. This is
- * used by the smart contract to ensure order's can't be replayed across
- * different applications (domains), but also different deployments (as the
- * contract chain ID and address is used to salt the domain separator value).
+ * @param domain The domain to sign the order for. This is used by the smart
+ * contract to ensure order's can't be replayed across different applications,
+ * but also different deployments (as the contract chain ID and address are
+ * mixed into to the domain value).
  * @param order The order to sign.
+ * @param scheme The signing scheme to use. See {@link SigningScheme} for more
+ * details.
  * @return Hex-encoded signature for the order.
  */
 export function signOrder(
+  scheme: SigningScheme,
   owner: Signer,
-  domainSeparator: string,
+  domain: TypedDataDomain,
   order: Order,
 ): Promise<string> {
-  return owner.signMessage(
-    ethers.utils.arrayify(
-      ethers.utils.hexConcat([domainSeparator, hashOrder(order)]),
-    ),
-  );
+  switch (scheme) {
+    case SigningScheme.TYPED_DATA:
+      if (!owner._signTypedData) {
+        throw new Error("signer does not support signing typed data");
+      }
+      return owner._signTypedData(domain, { Order: ORDER_TYPE_FIELDS }, order);
+
+    case SigningScheme.MESSAGE:
+      return owner.signMessage(
+        ethers.utils.arrayify(
+          ethers.utils.hexConcat([
+            ethers.utils._TypedDataEncoder.hashDomain(domain),
+            hashOrder(order),
+          ]),
+        ),
+      );
+  }
 }

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -2,7 +2,13 @@ import { expect } from "chai";
 import { Contract, BigNumber } from "ethers";
 import { ethers, waffle } from "hardhat";
 
-import { OrderKind, OrderEncoder, hashOrder } from "../src/ts";
+import {
+  ORDER_TYPE_HASH,
+  OrderEncoder,
+  OrderKind,
+  SigningScheme,
+  hashOrder,
+} from "../src/ts";
 
 function fillBytes(count: number, byte: number): string {
   return ethers.utils.hexlify([...Array(count)].map(() => byte));
@@ -15,8 +21,20 @@ function fillUint(bits: number, byte: number): BigNumber {
 describe("GPv2Encoding", () => {
   const [, ...traders] = waffle.provider.getWallets();
 
+  const testDomain = {};
+  const sampleOrder = {
+    sellToken: fillBytes(20, 0x01),
+    buyToken: fillBytes(20, 0x02),
+    sellAmount: ethers.utils.parseEther("42"),
+    buyAmount: ethers.utils.parseEther("13.37"),
+    validTo: 0xffffffff,
+    nonce: 0,
+    tip: ethers.constants.WeiPerEther,
+    kind: OrderKind.SELL,
+    partiallyFillable: false,
+  };
+
   let encoding: Contract;
-  let domainSeparator: string;
 
   beforeEach(async () => {
     const GPv2Encoding = await ethers.getContractFactory(
@@ -24,7 +42,20 @@ describe("GPv2Encoding", () => {
     );
 
     encoding = await GPv2Encoding.deploy();
-    domainSeparator = await encoding.DOMAIN_SEPARATOR();
+  });
+
+  describe("DOMAIN_SEPARATOR", () => {
+    it("should match the test domain hash", async () => {
+      expect(await encoding.DOMAIN_SEPARATOR()).to.equal(
+        ethers.utils._TypedDataEncoder.hashDomain(testDomain),
+      );
+    });
+  });
+
+  describe("ORDER_TYPE_HASH", () => {
+    it("should be match the EIP-712 order type hash", async () => {
+      expect(await encoding.orderTypeHashTest()).to.equal(ORDER_TYPE_HASH);
+    });
   });
 
   describe("decodeSignedOrder", () => {
@@ -45,8 +76,13 @@ describe("GPv2Encoding", () => {
       };
       const executedAmount = fillUint(256, 0x08);
 
-      const encoder = new OrderEncoder(domainSeparator);
-      await encoder.signEncodeOrder(traders[0], order, executedAmount);
+      const encoder = new OrderEncoder(testDomain);
+      await encoder.signEncodeOrder(
+        SigningScheme.TYPED_DATA,
+        traders[0],
+        order,
+        executedAmount,
+      );
 
       const [decodedOrders] = await encoding.decodeSignedOrdersTest(
         encoder.tokens,
@@ -58,6 +94,7 @@ describe("GPv2Encoding", () => {
       // `ABIEncoderV2` structs.
       expect(decodedOrders.length).to.equal(1);
       expect(decodedOrders[0]).to.deep.equal([
+        await traders[0].getAddress(),
         order.sellToken,
         order.buyToken,
         order.sellAmount,
@@ -71,43 +108,25 @@ describe("GPv2Encoding", () => {
         encoder.tokens.indexOf(order.buyToken),
         executedAmount,
         hashOrder(order),
-        await traders[0].getAddress(),
       ]);
     });
 
-    it("should allocate minimal memory", async () => {
-      // NOTE: We want to make sure that calls to `decodeOrder` does not require
-      // additional memory allocations to save on memory per orders.
-      //todo
-      const encoder = new OrderEncoder(domainSeparator);
-      await encoder.signEncodeOrder(
-        traders[0],
-        {
-          sellToken: ethers.constants.AddressZero,
-          buyToken: ethers.constants.AddressZero,
-          sellAmount: ethers.utils.parseEther("42"),
-          buyAmount: ethers.utils.parseEther("13.37"),
-          validTo: 0xffffffff,
-          nonce: 0,
-          tip: ethers.constants.WeiPerEther,
-          kind: OrderKind.SELL,
-          partiallyFillable: false,
-        },
-        0,
-      );
+    it("should recover signing address for all supported schemes", async () => {
+      const encoder = new OrderEncoder(testDomain);
+      for (const scheme of [SigningScheme.TYPED_DATA, SigningScheme.MESSAGE]) {
+        await encoder.signEncodeOrder(scheme, traders[0], sampleOrder, 0);
+      }
 
-      const [, mem] = await encoding.decodeSignedOrdersTest(
+      const [decodedOrders] = await encoding.decodeSignedOrdersTest(
         encoder.tokens,
         encoder.orderCount,
         encoder.encodedOrders,
       );
 
-      // NOTE: Currently, the `ecrecover` call requires 32 bytes of memory to
-      // be allocated per call. This is because `STATICCALL` writes the output
-      // to memory, and the compiler does not seem to optimize the extra memory
-      // copy away (despite the result being saved immediately to memory). In
-      // the future, we can optimize this away with some `assembly`.
-      expect(mem.toNumber()).to.equal(32);
+      const traderAddress = await traders[0].getAddress();
+      for (const [owner] of decodedOrders) {
+        expect(owner).to.equal(traderAddress);
+      }
     });
 
     it("should revert if order bytes are too short.", async () => {
@@ -126,21 +145,10 @@ describe("GPv2Encoding", () => {
       ).to.be.revertedWith("malformed order data");
     });
 
-    const sampleOrder = {
-      sellToken: fillBytes(20, 0x01),
-      buyToken: fillBytes(20, 0x02),
-      sellAmount: ethers.utils.parseEther("42"),
-      buyAmount: ethers.utils.parseEther("13.37"),
-      validTo: 0xffffffff,
-      nonce: 0,
-      tip: ethers.constants.WeiPerEther,
-      kind: OrderKind.SELL,
-      partiallyFillable: false,
-    };
-
     it("should revert for invalid order signatures", async () => {
-      const encoder = new OrderEncoder(domainSeparator);
+      const encoder = new OrderEncoder(testDomain);
       await encoder.signEncodeOrder(
+        SigningScheme.TYPED_DATA,
         traders[0],
         sampleOrder,
         sampleOrder.sellAmount,
@@ -163,13 +171,15 @@ describe("GPv2Encoding", () => {
     it("should revert for invalid sell token indices", async () => {
       const lastToken = fillBytes(20, 0x03);
 
-      const encoder = new OrderEncoder(domainSeparator);
+      const encoder = new OrderEncoder(testDomain);
       await encoder.signEncodeOrder(
+        SigningScheme.TYPED_DATA,
         traders[0],
         sampleOrder,
         sampleOrder.sellAmount,
       );
       await encoder.signEncodeOrder(
+        SigningScheme.TYPED_DATA,
         traders[1],
         {
           ...sampleOrder,
@@ -193,13 +203,15 @@ describe("GPv2Encoding", () => {
     it("should revert for invalid sell token indices", async () => {
       const lastToken = fillBytes(20, 0x03);
 
-      const encoder = new OrderEncoder(domainSeparator);
+      const encoder = new OrderEncoder(testDomain);
       await encoder.signEncodeOrder(
+        SigningScheme.TYPED_DATA,
         traders[0],
         sampleOrder,
         sampleOrder.sellAmount,
       );
       await encoder.signEncodeOrder(
+        SigningScheme.TYPED_DATA,
         traders[1],
         {
           ...sampleOrder,
@@ -218,6 +230,38 @@ describe("GPv2Encoding", () => {
           encoder.encodedOrders,
         ),
       ).to.be.reverted;
+    });
+
+    it("should allocate minimal memory", async () => {
+      // NOTE: We want to make sure that calls to `decodeOrder` does not require
+      // additional memory allocations to save on memory per orders.
+      //todo
+      const encoder = new OrderEncoder(testDomain);
+      await encoder.signEncodeOrder(
+        SigningScheme.TYPED_DATA,
+        traders[0],
+        sampleOrder,
+        0,
+      );
+      await encoder.signEncodeOrder(
+        SigningScheme.MESSAGE,
+        traders[1],
+        sampleOrder,
+        0,
+      );
+
+      const [, mem] = await encoding.decodeSignedOrdersTest(
+        encoder.tokens,
+        encoder.orderCount,
+        encoder.encodedOrders,
+      );
+
+      // NOTE: Currently, the `ecrecover` call requires 32 bytes of memory to
+      // be allocated per call. This is because `STATICCALL` writes the output
+      // to memory, and the compiler does not seem to optimize the extra memory
+      // copy away (despite the result being saved immediately to memory). In
+      // the future, we can optimize this away with some `assembly`.
+      expect(mem.toNumber()).to.equal(64);
     });
   });
 });

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -140,7 +140,11 @@ describe("GPv2Encoding", () => {
 
     it("should revert for invalid order signatures", async () => {
       const encoder = new OrderEncoder(domainSeparator);
-      await encoder.signEncodeOrder(traders[0], sampleOrder, sampleOrder.sellAmount);
+      await encoder.signEncodeOrder(
+        traders[0],
+        sampleOrder,
+        sampleOrder.sellAmount,
+      );
 
       // NOTE: `v` must be either `27` or `28`, so just set it to something else
       // to generate an invalid signature.
@@ -160,7 +164,11 @@ describe("GPv2Encoding", () => {
       const lastToken = fillBytes(20, 0x03);
 
       const encoder = new OrderEncoder(domainSeparator);
-      await encoder.signEncodeOrder(traders[0], sampleOrder, sampleOrder.sellAmount);
+      await encoder.signEncodeOrder(
+        traders[0],
+        sampleOrder,
+        sampleOrder.sellAmount,
+      );
       await encoder.signEncodeOrder(
         traders[1],
         {
@@ -186,7 +194,11 @@ describe("GPv2Encoding", () => {
       const lastToken = fillBytes(20, 0x03);
 
       const encoder = new OrderEncoder(domainSeparator);
-      await encoder.signEncodeOrder(traders[0], sampleOrder, sampleOrder.sellAmount);
+      await encoder.signEncodeOrder(
+        traders[0],
+        sampleOrder,
+        sampleOrder.sellAmount,
+      );
       await encoder.signEncodeOrder(
         traders[1],
         {

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -46,7 +46,7 @@ describe("GPv2Encoding", () => {
       const executedAmount = fillUint(256, 0x08);
 
       const encoder = new OrderEncoder(domainSeparator);
-      encoder.signEncodeOrder(traders[0], order, executedAmount);
+      await encoder.signEncodeOrder(traders[0], order, executedAmount);
 
       const [decodedOrders] = await encoding.decodeSignedOrdersTest(
         encoder.tokens,
@@ -58,7 +58,6 @@ describe("GPv2Encoding", () => {
       // `ABIEncoderV2` structs.
       expect(decodedOrders.length).to.equal(1);
       expect(decodedOrders[0]).to.deep.equal([
-        await traders[0].getAddress(),
         order.sellToken,
         order.buyToken,
         order.sellAmount,
@@ -68,10 +67,11 @@ describe("GPv2Encoding", () => {
         order.tip,
         order.kind,
         order.partiallyFillable,
-        executedAmount,
         encoder.tokens.indexOf(order.sellToken),
         encoder.tokens.indexOf(order.buyToken),
-        hashOrder(domainSeparator, order),
+        executedAmount,
+        hashOrder(order),
+        await traders[0].getAddress(),
       ]);
     });
 
@@ -80,7 +80,7 @@ describe("GPv2Encoding", () => {
       // additional memory allocations to save on memory per orders.
       //todo
       const encoder = new OrderEncoder(domainSeparator);
-      encoder.signEncodeOrder(
+      await encoder.signEncodeOrder(
         traders[0],
         {
           sellToken: ethers.constants.AddressZero,
@@ -140,7 +140,7 @@ describe("GPv2Encoding", () => {
 
     it("should revert for invalid order signatures", async () => {
       const encoder = new OrderEncoder(domainSeparator);
-      encoder.signEncodeOrder(traders[0], sampleOrder, sampleOrder.sellAmount);
+      await encoder.signEncodeOrder(traders[0], sampleOrder, sampleOrder.sellAmount);
 
       // NOTE: `v` must be either `27` or `28`, so just set it to something else
       // to generate an invalid signature.
@@ -160,8 +160,8 @@ describe("GPv2Encoding", () => {
       const lastToken = fillBytes(20, 0x03);
 
       const encoder = new OrderEncoder(domainSeparator);
-      encoder.signEncodeOrder(traders[0], sampleOrder, sampleOrder.sellAmount);
-      encoder.signEncodeOrder(
+      await encoder.signEncodeOrder(traders[0], sampleOrder, sampleOrder.sellAmount);
+      await encoder.signEncodeOrder(
         traders[1],
         {
           ...sampleOrder,
@@ -186,8 +186,8 @@ describe("GPv2Encoding", () => {
       const lastToken = fillBytes(20, 0x03);
 
       const encoder = new OrderEncoder(domainSeparator);
-      encoder.signEncodeOrder(traders[0], sampleOrder, sampleOrder.sellAmount);
-      encoder.signEncodeOrder(
+      await encoder.signEncodeOrder(traders[0], sampleOrder, sampleOrder.sellAmount);
+      await encoder.signEncodeOrder(
         traders[1],
         {
           ...sampleOrder,

--- a/typings/ethers/index.d.ts
+++ b/typings/ethers/index.d.ts
@@ -1,5 +1,5 @@
 /**
- * Additional typings for Ethers.js
+ * Additional typings extensions for Ethers.js.
  */
 
 import { ethers } from "ethers";
@@ -7,9 +7,26 @@ import { ethers } from "ethers";
 declare module "ethers" {
   /**
    * A signature-like type.
-   *
-   * Note this type definition is included here as it is not re-exported by the
-   * main `ethers` package.
    */
   export type SignatureLike = Parameters<typeof ethers.utils.splitSignature>[0];
+
+  /**
+   * EIP-712 typed data domain.
+   */
+  export type TypedDataDomain = Parameters<
+    typeof ethers.utils._TypedDataEncoder.hashDomain
+  >[0];
+
+  interface Signer {
+    /**
+     * Signs the typed data value with types data structure for domain using the
+     * EIP-712 specification.
+     */
+    _signTypedData?: (
+      domain: TypedDataDomain,
+      types: Record<string, Array<TypedDataField>>,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      value: Record<string, any>,
+    ) => Promise<string>;
+  }
 }

--- a/typings/ethers/index.d.ts
+++ b/typings/ethers/index.d.ts
@@ -3,6 +3,7 @@
  */
 
 import { ethers } from "ethers";
+import { ethers } from "hardhat";
 
 declare module "ethers" {
   /**
@@ -22,11 +23,6 @@ declare module "ethers" {
      * Signs the typed data value with types data structure for domain using the
      * EIP-712 specification.
      */
-    _signTypedData?: (
-      domain: TypedDataDomain,
-      types: Record<string, Array<TypedDataField>>,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      value: Record<string, any>,
-    ) => Promise<string>;
+    _signTypedData?: typeof ethers.VoidSigner.prototype._signTypedData;
   }
 }


### PR DESCRIPTION
Fixes #131 and #98 

This PR adds `eth_signTypedData` support to the contract and TS encoding library. It makes use of some assembly magic in order to avoid unnecessary memory allocations by taking advantage of the memory that is already reserved for decoding the order.

### Test Plan

New test cases added!
