### PR TITLE
Include type-hash field

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -25,6 +25,7 @@ contract GPv2Settlement {
 
         domainSeparator = keccak256(
             abi.encode(
+                // TODO(nlordell): Verify that these compile to constants.
                 keccak256(
                     "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
                 ),

--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -134,7 +134,6 @@ library GPv2Encoding {
         order.partiallyFillable =
             (flags >> ORDER_PARTIALLY_FILLABLE_BIT) & 0x01 == 0x01;
 
-        bytes32 orderTypeHash = ORDER_TYPE_HASH;
         bytes32 orderDigest;
 
         // NOTE: In order to avoid a memory allocation per call by using the
@@ -146,7 +145,7 @@ library GPv2Encoding {
             // type hash, which is temporarily stored in the slot reserved for
             // the `owner` field as well as 9 order fields to hash for a total
             // of `10 * sizeof(uint) = 320` bytes.
-            mstore(order, orderTypeHash)
+            mstore(order, ORDER_TYPE_HASH)
             orderDigest := keccak256(order, 320)
         }
 
@@ -184,6 +183,8 @@ library GPv2Encoding {
                 default {
                     mstore(
                         add(order, 320),
+                        // NOTE: Strings are left-padded, so add 0's to make it
+                        // right padded instead.
                         "\x00\x00\x00\x00\x19Ethereum Signed Message:\n64"
                     )
                     signingDigest := keccak256(add(order, 324), 92)

--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -39,6 +39,9 @@ library GPv2Encoding {
     uint256 internal constant ORDER_STRIDE = 204;
 
     /// @dev The order EIP-712 type hash.
+    ///
+    /// This type hash is computed as per the EIP-712 standard as the hash of
+    /// the `Order` struct fields: `keccak256("Order(...)")`.
     bytes32 internal constant ORDER_TYPE_HASH =
         0x70874c19b8f223ec3e4476223f761070db29e881be331cda28425f9079d3a76b;
 
@@ -123,80 +126,76 @@ library GPv2Encoding {
         );
         order.tip = abi.decode(encodedOrder[74:], (uint256));
         uint8 flags = uint8(encodedOrder[106]);
-        uint256 executedAmount = abi.decode(encodedOrder[107:], (uint256));
+        order.executedAmount = abi.decode(encodedOrder[107:], (uint256));
         uint8 v = uint8(encodedOrder[139]);
         bytes32 r = abi.decode(encodedOrder[140:], (bytes32));
         bytes32 s = abi.decode(encodedOrder[172:], (bytes32));
 
         order.sellToken = tokens[sellTokenIndex];
+        order.sellTokenIndex = sellTokenIndex;
         order.buyToken = tokens[buyTokenIndex];
+        order.buyTokenIndex = buyTokenIndex;
         order.kind = OrderKind((flags >> ORDER_KIND_BIT) & 0x1);
         order.partiallyFillable =
             (flags >> ORDER_PARTIALLY_FILLABLE_BIT) & 0x01 == 0x01;
 
+        // NOTE: In order to avoid allocating and copying 10 words of data per
+        // call, reuse the memory region reserved by the caller for the order
+        // result as input for computing the hash. Specifically, we use the slot
+        // reserved for the order `owner` for the order type hash. Since the
+        // owner is set later on, the type hash will be overwritten and we don't
+        // need to restore it ourselves. Furthermore, Structs are not packed in
+        // Solidity and there are 10 fields to hash for a total of
+        // `10 * sizeof(uint) = 320` bytes.
         bytes32 orderDigest;
-
-        // NOTE: In order to avoid a memory allocation per call by using the
-        // built-in `abi.encode`, we reuse the memory region reserved by the
-        // caller for the order result as input to compute the hash.
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            // NOTE: Structs are not packed in Solidity, and there is the order
-            // type hash, which is temporarily stored in the slot reserved for
-            // the `owner` field as well as 9 order fields to hash for a total
-            // of `10 * sizeof(uint) = 320` bytes.
             mstore(order, ORDER_TYPE_HASH)
             orderDigest := keccak256(order, 320)
         }
 
-        bytes32 signingDigest;
-
-        // NOTE: Now compute the digest that was used for signing. This is not
-        // the same as the order digest as it is dependant on the signature
-        // scheme being used. In both cases, the signing digest is computed from
-        // a prefix followed by the domain separator and finally the order
-        // the order digest:
-        // - If the order is signed using the EIP-712 sheme, then the prefix is
-        //   the 2-byte value 0x1901,
-        // - If the order is signed using generic message scheme, then the
-        //   prefix is the 28-byte "\x19Ethereum Signed Message\n64" where 64 is
-        //   the length the domain separator and order digest.
+        // NOTE: Solidity allocates, but does not free, memory when calling the
+        // ABI encoding methods as well as the `ecrecover` precompile. However,
+        // we can restore the free memory pointer to before we made allocations
+        // to effectively free the memory.
+        // <https://solidity.readthedocs.io/en/v0.7.4/internals/layout_in_memory.html>
+        uint256 freeMemoryPointer;
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            // NOTE: Use the region of memory dedicated to the last 4 order
-            // fields to compute the hash in order to prevent further memory
-            // allocations. This is safe as those words have not yet been set
-            // and their values are being stored in stack variables.
-            // Specifically we use:
-            // - `sellTokenIndex` field slot for the prefix (320 byte offset),
-            // - `buyTokenIndex` field slot for the domain separator (352 byte
-            //    offset),
-            // - `executedAmount` field slot for the order digest (384 byte
-            //    offset),
-            mstore(add(order, 352), domainSeparator)
-            mstore(add(order, 384), orderDigest)
-            switch and(v, 0x80)
-                case 0 {
-                    mstore(add(order, 320), 0x1901)
-                    signingDigest := keccak256(add(order, 350), 66)
-                }
-                default {
-                    mstore(
-                        add(order, 320),
-                        // NOTE: Strings are left-padded, so add 0's to make it
-                        // right padded instead.
-                        "\x00\x00\x00\x00\x19Ethereum Signed Message:\n64"
-                    )
-                    signingDigest := keccak256(add(order, 324), 92)
-                }
+            freeMemoryPointer := mload(0x40)
+        }
+
+        bytes32 signingDigest;
+        if (v & 0x80 == 0) {
+            // NOTE: The order is signed using the EIP-712 sheme, the signing
+            // hash is `"\x19\x01" || domainSeparator || orderDigest`.
+            signingDigest = keccak256(
+                abi.encodePacked("\x19\x01", domainSeparator, orderDigest)
+            );
+        } else {
+            // NOTE: The order is signed using generic message scheme, prefixed
+            // with `"\x19Ethereum Signed Message:\n64"` where 64 is length of
+            // the message being signed, which for Gnosis Protocol is
+            // `domainSeparator || orderDigest`.
+            signingDigest = keccak256(
+                abi.encodePacked(
+                    "\x19Ethereum Signed Message:\n64",
+                    domainSeparator,
+                    orderDigest
+                )
+            );
         }
 
         order.owner = ecrecover(signingDigest, v & 0x1f, r, s);
-        order.sellTokenIndex = sellTokenIndex;
-        order.buyTokenIndex = buyTokenIndex;
-        order.executedAmount = executedAmount;
         order.digest = orderDigest;
-
         require(order.owner != address(0), "GPv2: invalid signature");
+
+        // NOTE: Restore the free memory pointer. This is safe as the memory
+        // used can be discarded, and the memory pointed to by the free memory
+        // pointer **does not have to point to zero-ed out memory**.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            mstore(0x40, freeMemoryPointer)
+        }
     }
 }

--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -183,9 +183,11 @@ library GPv2Encoding {
             );
         }
 
-        order.owner = ecrecover(signingDigest, v & 0x1f, r, s);
+        address orderOwner = ecrecover(signingDigest, v & 0x1f, r, s);
+        require(orderOwner != address(0), "GPv2: invalid signature");
+
+        order.owner = orderOwner;
         order.digest = orderDigest;
-        require(order.owner != address(0), "GPv2: invalid signature");
 
         // NOTE: Restore the free memory pointer. This is safe as the memory
         // used can be discarded, and the memory pointed to by the free memory

--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -155,7 +155,7 @@ library GPv2Encoding {
         // ABI encoding methods as well as the `ecrecover` precompile. However,
         // we can restore the free memory pointer to before we made allocations
         // to effectively free the memory.
-        // <https://solidity.readthedocs.io/en/v0.7.4/internals/layout_in_memory.html>
+        // <https://solidity.readthedocs.io/en/v0.6.12/internals/layout_in_memory.html>
         uint256 freeMemoryPointer;
         // solhint-disable-next-line no-inline-assembly
         assembly {

--- a/src/contracts/test/GPv2EncodingTestInterface.sol
+++ b/src/contracts/test/GPv2EncodingTestInterface.sol
@@ -6,7 +6,12 @@ import "../libraries/GPv2Encoding.sol";
 
 contract GPv2EncodingTestInterface {
     bytes32 public constant DOMAIN_SEPARATOR =
-        keccak256(abi.encode(keccak256("EIP712Domain(string name)"), keccak256("test")));
+        keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name)"),
+                keccak256("test")
+            )
+        );
 
     function orderTypeHashTest() external pure returns (bytes32) {
         return (GPv2Encoding.ORDER_TYPE_HASH);

--- a/src/contracts/test/GPv2EncodingTestInterface.sol
+++ b/src/contracts/test/GPv2EncodingTestInterface.sol
@@ -6,7 +6,7 @@ import "../libraries/GPv2Encoding.sol";
 
 contract GPv2EncodingTestInterface {
     bytes32 public constant DOMAIN_SEPARATOR =
-        keccak256(abi.encode(keccak256("EIP712Domain()")));
+        keccak256(abi.encode(keccak256("EIP712Domain(string name)"), keccak256("test")));
 
     function orderTypeHashTest() external pure returns (bytes32) {
         return (GPv2Encoding.ORDER_TYPE_HASH);

--- a/src/contracts/test/GPv2EncodingTestInterface.sol
+++ b/src/contracts/test/GPv2EncodingTestInterface.sol
@@ -6,7 +6,11 @@ import "../libraries/GPv2Encoding.sol";
 
 contract GPv2EncodingTestInterface {
     bytes32 public constant DOMAIN_SEPARATOR =
-        0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f;
+        keccak256(abi.encode(keccak256("EIP712Domain()")));
+
+    function orderTypeHashTest() external pure returns (bytes32) {
+        return (GPv2Encoding.ORDER_TYPE_HASH);
+    }
 
     function decodeSignedOrdersTest(
         IERC20[] calldata tokens,
@@ -24,6 +28,8 @@ contract GPv2EncodingTestInterface {
         // solhint-disable no-inline-assembly
 
         uint256 stride = GPv2Encoding.ORDER_STRIDE;
+        bytes32 domainSeparator = DOMAIN_SEPARATOR;
+
         orders = new GPv2Encoding.Order[](orderCount);
 
         // NOTE: Solidity keeps a total memory count at address 0x40. Check
@@ -48,7 +54,7 @@ contract GPv2EncodingTestInterface {
             }
 
             GPv2Encoding.decodeSignedOrder(
-                DOMAIN_SEPARATOR,
+                domainSeparator,
                 tokens,
                 encodedOrder,
                 orders[i]

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -1,30 +1,10 @@
-import { ethers, BigNumberish, SignatureLike, Signer } from "ethers";
-
-/**
- * EIP-712 domain data used by GPv2.
- *
- * Note, that EIP-712 allows for an extra `salt` to be added to the domain that
- * isn't used.
- * <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-domainseparator>
- */
-export interface EIP712Domain {
-  /**
-   * The user readable name of signing domain.
-   */
-  name: string;
-  /**
-   * The current major version of the signing domain.
-   */
-  version: string;
-  /**
-   * The EIP-155 chain ID.
-   */
-  chainId: number;
-  /**
-   * The address of the contract that will verify the EIP-712 signature.
-   */
-  verifyingContract: string;
-}
+import {
+  ethers,
+  BigNumberish,
+  SignatureLike,
+  Signer,
+  TypedDataDomain,
+} from "ethers";
 
 /**
  * Return the Gnosis Protocol v2 domain used for signing.
@@ -36,7 +16,7 @@ export interface EIP712Domain {
 export function domain(
   chainId: number,
   verifyingContract: string,
-): EIP712Domain {
+): TypedDataDomain {
   return {
     name: "Gnosis Protocol",
     version: "v2",
@@ -130,7 +110,31 @@ export const enum OrderKind {
  */
 export const REPLAYABLE_NONCE = 0;
 
-const ORDER_STRIDE = 204;
+/**
+ * The EIP-712 type fields definition for a Gnosis Protocol v2 order.
+ */
+export const ORDER_TYPE_FIELDS = [
+  { name: "sellToken", type: "address" },
+  { name: "buyToken", type: "address" },
+  { name: "sellAmount", type: "uint256" },
+  { name: "buyAmount", type: "uint256" },
+  { name: "validTo", type: "uint32" },
+  { name: "nonce", type: "uint32" },
+  { name: "tip", type: "uint256" },
+  { name: "kind", type: "uint8" },
+  { name: "partiallyFillable", type: "bool" },
+];
+
+/**
+ * The EIP-712 type hash for a Gnosis Protocol v2 order.
+ */
+export const ORDER_TYPE_HASH = ethers.utils.keccak256(
+  ethers.utils.toUtf8Bytes(
+    `Order(${ORDER_TYPE_FIELDS.map(({ name, type }) => `${type} ${name}`).join(
+      ",",
+    )})`,
+  ),
+);
 
 function timestamp(time: number | Date): number {
   return typeof time === "number" ? time : ~~(time.getTime() / 1000);
@@ -140,6 +144,16 @@ function encodeOrderFlags(flags: OrderFlags): number {
   const kind = flags.kind === OrderKind.SELL ? 0x00 : 0x01;
   const partiallyFillable = flags.partiallyFillable ? 0x02 : 0x00;
   return kind | partiallyFillable;
+}
+
+function encodeSigningScheme(v: number, scheme: SigningScheme): number {
+  const ORDER_MESSAGE_SCHEME_FLAG = 0x80;
+  switch (scheme) {
+    case SigningScheme.TYPED_DATA:
+      return v;
+    case SigningScheme.MESSAGE:
+      return v | ORDER_MESSAGE_SCHEME_FLAG;
+  }
 }
 
 /**
@@ -155,10 +169,10 @@ export class OrderEncoder {
 
   /**
    * Creates a new order encoder instance.
-   * @param domainSeparator Domain separator used for signing orders to encode.
+   * @param domain Domain used for signing orders to encode.
    * See {@link signOrder} for more details.
    */
-  public constructor(public readonly domainSeparator: string) {}
+  public constructor(public readonly domain: TypedDataDomain) {}
 
   /**
    * Gets the array of token addresses used by the currently encoded orders.
@@ -186,6 +200,7 @@ export class OrderEncoder {
    * Gets the number of orders currently encoded.
    */
   public get orderCount(): number {
+    const ORDER_STRIDE = 204;
     // NOTE: `ORDER_STRIDE` multiplied by 2 as hex strings encode one byte in
     // 2 characters.
     return (this._encodedOrders.length - 2) / (ORDER_STRIDE * 2);
@@ -200,11 +215,14 @@ export class OrderEncoder {
    * @param order The order to encode.
    * @param executedAmount The executed trade amount for the order.
    * @param signature The signature for the order data.
+   * @param scheme The signing scheme to used to generate the specified
+   * signature. See {@link SigningScheme} for more details.
    */
   public encodeOrder(
     order: Order,
     executedAmount: BigNumberish,
     signature: SignatureLike,
+    scheme: SigningScheme,
   ): void {
     const sig = ethers.utils.splitSignature(signature);
     const encodedOrder = ethers.utils.solidityPack(
@@ -232,7 +250,7 @@ export class OrderEncoder {
         order.tip,
         encodeOrderFlags(order),
         executedAmount,
-        sig.v,
+        encodeSigningScheme(sig.v, scheme),
         sig.r,
         sig.s,
       ],
@@ -246,18 +264,18 @@ export class OrderEncoder {
    * @param owner The owner for the order used to sign.
    * @param order The order to compute the digest for.
    * @param executedAmount The executed trade amount for the order.
+   * @param scheme The signing scheme to use. See {@link SigningScheme} for more
+   * details.
    * @return Signature for the order.
    */
   public async signEncodeOrder(
+    scheme: SigningScheme,
     owner: Signer,
     order: Order,
     executedAmount: BigNumberish,
   ): Promise<void> {
-    if (!this.domainSeparator) {
-      throw new Error("domain separator not specified");
-    }
-    const signature = await signOrder(owner, this.domainSeparator, order);
-    this.encodeOrder(order, executedAmount, signature);
+    const signature = await signOrder(scheme, owner, this.domain, order);
+    this.encodeOrder(order, executedAmount, signature, scheme);
   }
 
   private tokenIndex(token: string): number {
@@ -283,52 +301,64 @@ export class OrderEncoder {
  * @return Hex-encoded 32-byte order digest.
  */
 export function hashOrder(order: Order): string {
-  return ethers.utils.keccak256(
-    ethers.utils.defaultAbiCoder.encode(
-      [
-        "address",
-        "address",
-        "uint256",
-        "uint256",
-        "uint32",
-        "uint32",
-        "uint256",
-        "uint8",
-        "bool",
-      ],
-      [
-        order.sellToken,
-        order.buyToken,
-        order.sellAmount,
-        order.buyAmount,
-        order.validTo,
-        order.nonce,
-        order.tip,
-        order.kind,
-        order.partiallyFillable,
-      ],
-    ),
+  return ethers.utils._TypedDataEncoder.hashStruct(
+    "Order",
+    { Order: ORDER_TYPE_FIELDS },
+    order,
   );
+}
+
+/**
+ * The signing scheme used to sign the order.
+ */
+export const enum SigningScheme {
+  /**
+   * The EIP-712 typed data signing scheme. This is the preferred scheme as it
+   * provides more infomation to wallets performing the signature on the data
+   * being signed.
+   *
+   * <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-domainseparator>
+   */
+  TYPED_DATA,
+  /**
+   * The generic message signing scheme.
+   */
+  MESSAGE,
 }
 
 /**
  * Returns the signature for the specified order.
  * @param owner The owner for the order used to sign.
- * @param domainSeparator The domain separator to add to the digest. This is
- * used by the smart contract to ensure order's can't be replayed across
- * different applications (domains), but also different deployments (as the
- * contract chain ID and address is used to salt the domain separator value).
+ * @param domain The domain to sign the order for. This is used by the smart
+ * contract to ensure order's can't be replayed across different applications,
+ * but also different deployments (as the contract chain ID and address are
+ * mixed into to the domain value).
  * @param order The order to sign.
+ * @param scheme The signing scheme to use. See {@link SigningScheme} for more
+ * details.
  * @return Hex-encoded signature for the order.
  */
 export function signOrder(
+  scheme: SigningScheme,
   owner: Signer,
-  domainSeparator: string,
+  domain: TypedDataDomain,
   order: Order,
 ): Promise<string> {
-  return owner.signMessage(
-    ethers.utils.arrayify(
-      ethers.utils.hexConcat([domainSeparator, hashOrder(order)]),
-    ),
-  );
+  switch (scheme) {
+    case SigningScheme.TYPED_DATA:
+      if (!owner._signTypedData) {
+        throw new Error("signer does not support signing typed data");
+      }
+      return owner._signTypedData(domain, { Order: ORDER_TYPE_FIELDS }, order);
+
+    case SigningScheme.MESSAGE:
+      return owner.signMessage(
+        ethers.utils.arrayify(
+          ethers.utils.hexConcat([
+            ethers.utils._TypedDataEncoder.hashDomain(domain),
+            hashOrder(order),
+          ]),
+        ),
+      );
+  }
 }

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -94,7 +94,7 @@ describe("GPv2Encoding", () => {
       // `ABIEncoderV2` structs.
       expect(decodedOrders.length).to.equal(1);
       expect(decodedOrders[0]).to.deep.equal([
-        await traders[0].getAddress(),
+        ORDER_TYPE_HASH,
         order.sellToken,
         order.buyToken,
         order.sellAmount,
@@ -108,6 +108,7 @@ describe("GPv2Encoding", () => {
         encoder.tokens.indexOf(order.buyToken),
         executedAmount,
         hashOrder(order),
+        await traders[0].getAddress(),
       ]);
     });
 
@@ -124,7 +125,8 @@ describe("GPv2Encoding", () => {
       );
 
       const traderAddress = await traders[0].getAddress();
-      for (const [owner] of decodedOrders) {
+      for (const decodedOrder of decodedOrders) {
+        const owner = decodedOrder.slice(-1).pop();
         expect(owner).to.equal(traderAddress);
       }
     });

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -232,7 +232,7 @@ describe("GPv2Encoding", () => {
       ).to.be.reverted;
     });
 
-    it("should allocate minimal memory", async () => {
+    it("should not allocate additional memory", async () => {
       // NOTE: We want to make sure that calls to `decodeOrder` does not require
       // additional memory allocations to save on memory per orders.
       //todo
@@ -255,13 +255,7 @@ describe("GPv2Encoding", () => {
         encoder.orderCount,
         encoder.encodedOrders,
       );
-
-      // NOTE: Currently, the `ecrecover` call requires 32 bytes of memory to
-      // be allocated per call. This is because `STATICCALL` writes the output
-      // to memory, and the compiler does not seem to optimize the extra memory
-      // copy away (despite the result being saved immediately to memory). In
-      // the future, we can optimize this away with some `assembly`.
-      expect(mem.toNumber()).to.equal(64);
+      expect(mem.toNumber()).to.equal(0);
     });
   });
 });

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -2,7 +2,13 @@ import { expect } from "chai";
 import { Contract, BigNumber } from "ethers";
 import { ethers, waffle } from "hardhat";
 
-import { OrderKind, OrderEncoder, hashOrder } from "../src/ts";
+import {
+  ORDER_TYPE_HASH,
+  OrderEncoder,
+  OrderKind,
+  SigningScheme,
+  hashOrder,
+} from "../src/ts";
 
 function fillBytes(count: number, byte: number): string {
   return ethers.utils.hexlify([...Array(count)].map(() => byte));
@@ -15,8 +21,20 @@ function fillUint(bits: number, byte: number): BigNumber {
 describe("GPv2Encoding", () => {
   const [, ...traders] = waffle.provider.getWallets();
 
+  const testDomain = {};
+  const sampleOrder = {
+    sellToken: fillBytes(20, 0x01),
+    buyToken: fillBytes(20, 0x02),
+    sellAmount: ethers.utils.parseEther("42"),
+    buyAmount: ethers.utils.parseEther("13.37"),
+    validTo: 0xffffffff,
+    nonce: 0,
+    tip: ethers.constants.WeiPerEther,
+    kind: OrderKind.SELL,
+    partiallyFillable: false,
+  };
+
   let encoding: Contract;
-  let domainSeparator: string;
 
   beforeEach(async () => {
     const GPv2Encoding = await ethers.getContractFactory(
@@ -24,7 +42,20 @@ describe("GPv2Encoding", () => {
     );
 
     encoding = await GPv2Encoding.deploy();
-    domainSeparator = await encoding.DOMAIN_SEPARATOR();
+  });
+
+  describe("DOMAIN_SEPARATOR", () => {
+    it("should match the test domain hash", async () => {
+      expect(await encoding.DOMAIN_SEPARATOR()).to.equal(
+        ethers.utils._TypedDataEncoder.hashDomain(testDomain),
+      );
+    });
+  });
+
+  describe("ORDER_TYPE_HASH", () => {
+    it("should be match the EIP-712 order type hash", async () => {
+      expect(await encoding.orderTypeHashTest()).to.equal(ORDER_TYPE_HASH);
+    });
   });
 
   describe("decodeSignedOrder", () => {
@@ -45,8 +76,13 @@ describe("GPv2Encoding", () => {
       };
       const executedAmount = fillUint(256, 0x08);
 
-      const encoder = new OrderEncoder(domainSeparator);
-      await encoder.signEncodeOrder(traders[0], order, executedAmount);
+      const encoder = new OrderEncoder(testDomain);
+      await encoder.signEncodeOrder(
+        SigningScheme.TYPED_DATA,
+        traders[0],
+        order,
+        executedAmount,
+      );
 
       const [decodedOrders] = await encoding.decodeSignedOrdersTest(
         encoder.tokens,
@@ -58,6 +94,7 @@ describe("GPv2Encoding", () => {
       // `ABIEncoderV2` structs.
       expect(decodedOrders.length).to.equal(1);
       expect(decodedOrders[0]).to.deep.equal([
+        await traders[0].getAddress(),
         order.sellToken,
         order.buyToken,
         order.sellAmount,
@@ -71,43 +108,25 @@ describe("GPv2Encoding", () => {
         encoder.tokens.indexOf(order.buyToken),
         executedAmount,
         hashOrder(order),
-        await traders[0].getAddress(),
       ]);
     });
 
-    it("should allocate minimal memory", async () => {
-      // NOTE: We want to make sure that calls to `decodeOrder` does not require
-      // additional memory allocations to save on memory per orders.
-      //todo
-      const encoder = new OrderEncoder(domainSeparator);
-      await encoder.signEncodeOrder(
-        traders[0],
-        {
-          sellToken: ethers.constants.AddressZero,
-          buyToken: ethers.constants.AddressZero,
-          sellAmount: ethers.utils.parseEther("42"),
-          buyAmount: ethers.utils.parseEther("13.37"),
-          validTo: 0xffffffff,
-          nonce: 0,
-          tip: ethers.constants.WeiPerEther,
-          kind: OrderKind.SELL,
-          partiallyFillable: false,
-        },
-        0,
-      );
+    it("should recover signing address for all supported schemes", async () => {
+      const encoder = new OrderEncoder(testDomain);
+      for (const scheme of [SigningScheme.TYPED_DATA, SigningScheme.MESSAGE]) {
+        await encoder.signEncodeOrder(scheme, traders[0], sampleOrder, 0);
+      }
 
-      const [, mem] = await encoding.decodeSignedOrdersTest(
+      const [decodedOrders] = await encoding.decodeSignedOrdersTest(
         encoder.tokens,
         encoder.orderCount,
         encoder.encodedOrders,
       );
 
-      // NOTE: Currently, the `ecrecover` call requires 32 bytes of memory to
-      // be allocated per call. This is because `STATICCALL` writes the output
-      // to memory, and the compiler does not seem to optimize the extra memory
-      // copy away (despite the result being saved immediately to memory). In
-      // the future, we can optimize this away with some `assembly`.
-      expect(mem.toNumber()).to.equal(32);
+      const traderAddress = await traders[0].getAddress();
+      for (const [owner] of decodedOrders) {
+        expect(owner).to.equal(traderAddress);
+      }
     });
 
     it("should revert if order bytes are too short.", async () => {
@@ -126,21 +145,10 @@ describe("GPv2Encoding", () => {
       ).to.be.revertedWith("malformed order data");
     });
 
-    const sampleOrder = {
-      sellToken: fillBytes(20, 0x01),
-      buyToken: fillBytes(20, 0x02),
-      sellAmount: ethers.utils.parseEther("42"),
-      buyAmount: ethers.utils.parseEther("13.37"),
-      validTo: 0xffffffff,
-      nonce: 0,
-      tip: ethers.constants.WeiPerEther,
-      kind: OrderKind.SELL,
-      partiallyFillable: false,
-    };
-
     it("should revert for invalid order signatures", async () => {
-      const encoder = new OrderEncoder(domainSeparator);
+      const encoder = new OrderEncoder(testDomain);
       await encoder.signEncodeOrder(
+        SigningScheme.TYPED_DATA,
         traders[0],
         sampleOrder,
         sampleOrder.sellAmount,
@@ -163,13 +171,15 @@ describe("GPv2Encoding", () => {
     it("should revert for invalid sell token indices", async () => {
       const lastToken = fillBytes(20, 0x03);
 
-      const encoder = new OrderEncoder(domainSeparator);
+      const encoder = new OrderEncoder(testDomain);
       await encoder.signEncodeOrder(
+        SigningScheme.TYPED_DATA,
         traders[0],
         sampleOrder,
         sampleOrder.sellAmount,
       );
       await encoder.signEncodeOrder(
+        SigningScheme.TYPED_DATA,
         traders[1],
         {
           ...sampleOrder,
@@ -193,13 +203,15 @@ describe("GPv2Encoding", () => {
     it("should revert for invalid sell token indices", async () => {
       const lastToken = fillBytes(20, 0x03);
 
-      const encoder = new OrderEncoder(domainSeparator);
+      const encoder = new OrderEncoder(testDomain);
       await encoder.signEncodeOrder(
+        SigningScheme.TYPED_DATA,
         traders[0],
         sampleOrder,
         sampleOrder.sellAmount,
       );
       await encoder.signEncodeOrder(
+        SigningScheme.TYPED_DATA,
         traders[1],
         {
           ...sampleOrder,
@@ -218,6 +230,38 @@ describe("GPv2Encoding", () => {
           encoder.encodedOrders,
         ),
       ).to.be.reverted;
+    });
+
+    it("should allocate minimal memory", async () => {
+      // NOTE: We want to make sure that calls to `decodeOrder` does not require
+      // additional memory allocations to save on memory per orders.
+      //todo
+      const encoder = new OrderEncoder(testDomain);
+      await encoder.signEncodeOrder(
+        SigningScheme.TYPED_DATA,
+        traders[0],
+        sampleOrder,
+        0,
+      );
+      await encoder.signEncodeOrder(
+        SigningScheme.MESSAGE,
+        traders[1],
+        sampleOrder,
+        0,
+      );
+
+      const [, mem] = await encoding.decodeSignedOrdersTest(
+        encoder.tokens,
+        encoder.orderCount,
+        encoder.encodedOrders,
+      );
+
+      // NOTE: Currently, the `ecrecover` call requires 32 bytes of memory to
+      // be allocated per call. This is because `STATICCALL` writes the output
+      // to memory, and the compiler does not seem to optimize the extra memory
+      // copy away (despite the result being saved immediately to memory). In
+      // the future, we can optimize this away with some `assembly`.
+      expect(mem.toNumber()).to.equal(64);
     });
   });
 });

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -235,7 +235,6 @@ describe("GPv2Encoding", () => {
     it("should not allocate additional memory", async () => {
       // NOTE: We want to make sure that calls to `decodeOrder` does not require
       // additional memory allocations to save on memory per orders.
-      //todo
       const encoder = new OrderEncoder(testDomain);
       await encoder.signEncodeOrder(
         SigningScheme.TYPED_DATA,

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -21,7 +21,7 @@ function fillUint(bits: number, byte: number): BigNumber {
 describe("GPv2Encoding", () => {
   const [, ...traders] = waffle.provider.getWallets();
 
-  const testDomain = {};
+  const testDomain = { name: "test" };
   const sampleOrder = {
     sellToken: fillBytes(20, 0x01),
     buyToken: fillBytes(20, 0x02),

--- a/typings/ethers/index.d.ts
+++ b/typings/ethers/index.d.ts
@@ -1,5 +1,5 @@
 /**
- * Additional typings for Ethers.js
+ * Additional typings extensions for Ethers.js.
  */
 
 import { ethers } from "ethers";
@@ -7,9 +7,26 @@ import { ethers } from "ethers";
 declare module "ethers" {
   /**
    * A signature-like type.
-   *
-   * Note this type definition is included here as it is not re-exported by the
-   * main `ethers` package.
    */
   export type SignatureLike = Parameters<typeof ethers.utils.splitSignature>[0];
+
+  /**
+   * EIP-712 typed data domain.
+   */
+  export type TypedDataDomain = Parameters<
+    typeof ethers.utils._TypedDataEncoder.hashDomain
+  >[0];
+
+  interface Signer {
+    /**
+     * Signs the typed data value with types data structure for domain using the
+     * EIP-712 specification.
+     */
+    _signTypedData?: (
+      domain: TypedDataDomain,
+      types: Record<string, Array<TypedDataField>>,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      value: Record<string, any>,
+    ) => Promise<string>;
+  }
 }

--- a/typings/ethers/index.d.ts
+++ b/typings/ethers/index.d.ts
@@ -3,6 +3,7 @@
  */
 
 import { ethers } from "ethers";
+import { ethers } from "hardhat";
 
 declare module "ethers" {
   /**
@@ -22,11 +23,6 @@ declare module "ethers" {
      * Signs the typed data value with types data structure for domain using the
      * EIP-712 specification.
      */
-    _signTypedData?: (
-      domain: TypedDataDomain,
-      types: Record<string, Array<TypedDataField>>,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      value: Record<string, any>,
-    ) => Promise<string>;
+    _signTypedData?: typeof ethers.VoidSigner.prototype._signTypedData;
   }
 }


### PR DESCRIPTION
This PR adds a `typeHash` field to the order struct in order to improve readability. The added 32-bytes of allocation are minimal and in the grand scheme of things don't have a serious affect on the overall gas cost (as this allocation should happen only once).

Personally, I prefer the implementation in #145 and I find the use of the `order` slot for the type hash a nice optimization that doesn't incur a large maintenance burden. That being said I have been thinking about and looking at this code a lot so I think it is better to deffer to others to see what they think is easier to understand and maintain.

My main argument for using the `order` field for the `ORDER_TYPE_HASH` as is done currently is that the order struct layout is sensitive to the signing scheme regardless of whether or not we include a `typeHash` field or not, as their layout needs to directly match what is being hashed for the signature. So modifying the `Order` struct will likely require going deeper into the `decodeOrder` hashing code regardless of whether or not the type hash has a dedicated field or not.

### Test Plan

Unit tests adjusted for new field still pass.
