### PR TITLE
Refactor order struct into trade and order

### DIFF
--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -6,14 +6,14 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 /// @title Gnosis Protocol v2 Encoding Library.
 /// @author Gnosis Developers
 library GPv2Encoding {
-    /// @dev A struct representing an executed order that can be used for
-    /// settling a batch.
+    /// @dev A struct representing an order.
     ///
-    /// The memory layout for an order is very important for optimizations for
-    /// recovering the order address. Specifically, the first 10 fields are
-    /// ordered precisely to allow hashing to occur in place.
+    /// Note that this struct contains all order parameters that are signed by a
+    /// user for submitting to GP. Additionally, we use an extra field for the
+    /// order's type hash in order to allow for effecient in-place EIP-712
+    /// struct hashing.
     struct Order {
-        address owner;
+        bytes32 typeHash;
         IERC20 sellToken;
         IERC20 buyToken;
         uint256 sellAmount;
@@ -23,23 +23,13 @@ library GPv2Encoding {
         uint256 tip;
         OrderKind kind;
         bool partiallyFillable;
-        uint8 sellTokenIndex;
-        uint8 buyTokenIndex;
-        uint256 executedAmount;
-        bytes32 digest;
     }
 
     /// @dev An enum describing an order kind, either a buy or a sell order.
     enum OrderKind {Sell, Buy}
 
-    /// @dev The stride of an encoded order.
-    uint256 internal constant ORDER_STRIDE = 204;
-
-    /// @dev The order EIP-712 type hash.
-    ///
-    /// Note that this type hash does not include all fields like `owner` and
-    /// `*TokenIndex`. This is because these fields are not signed but a part of
-    /// the encoded order data and are useful to the settlement contract.
+    /// @dev The order EIP-712 type hash for the [`Order`] struct (excluding the
+    /// extra `typeHash` field).
     bytes32 internal constant ORDER_TYPE_HASH =
         // TODO: Replace this with the pre-computed value once the contract is
         // ready to be deployed.
@@ -47,21 +37,35 @@ library GPv2Encoding {
             "Order(address sellToken,address buyToken,uint256 sellAmount,uint256 buyAmount,uint32 validTo,uint32 nonce,uint256 tip,uint8 kind,bool partiallyFillable)"
         );
 
+    /// @dev A struct representing a trade to be executed as part a batch
+    /// settlement.
+    struct Trade {
+        Order order;
+        uint8 sellTokenIndex;
+        uint8 buyTokenIndex;
+        uint256 executedAmount;
+        bytes32 digest;
+        address owner;
+    }
+
+    /// @dev The stride of an encoded trade.
+    uint256 internal constant TRADE_STRIDE = 204;
+
     /// @dev Bit position for the [`OrderKind`] encoded in the flags.
     uint8 internal constant ORDER_KIND_BIT = 0;
     /// @dev Bit position for the `partiallyFillable` value encoded in the
     /// flags.
     uint8 internal constant ORDER_PARTIALLY_FILLABLE_BIT = 1;
 
-    /// @dev Decodes a signed order from calldata bytes into memory.
+    /// @dev Decodes a trade with a signed order from calldata into memory.
     ///
-    /// Orders are tightly packed and compress some data such as buy and sell
-    /// tokens in order to reduce calldata size and associated gas costs. As
-    /// such it is not identical to the decoded [`Order`] and contains the
+    /// Trades are tightly packed and compress some data such as the order's buy
+    /// and sell tokens to reduce calldata size and associated gas costs. As
+    /// such it is not identical to the decoded [`Trade`] and contains the
     /// following fields:
     ///
     /// ```
-    /// struct EncodedOrder {
+    /// struct EncodedTrade {
     ///     uint8 sellTokenIndex;
     ///     uint8 buyTokenIndex;
     ///     uint256 sellAmount;
@@ -87,21 +91,20 @@ library GPv2Encoding {
     ///   there are only two possible values `v` can have: 27 or 28, which only
     ///   take up the lower 5 bits of the `uint8`.
     ///
-    /// @param domainSeparator The domain separator used for hashing and signing
-    /// the order.
-    /// @param tokens The list of tokens included in the settlement. The encoded
-    /// token indices part of the order map to tokens in this array.
-    /// @param encodedOrder The order as encoded calldata bytes.
-    /// @param order The memory location to decode the order to.
-    function decodeSignedOrder(
+    /// @param domainSeparator The domain separator used for signing the order.
+    /// @param tokens The list of tokens included in the settlement. The token
+    /// indices in the encoded order parameters map to tokens in this array.
+    /// @param encodedTrade The trade as encoded calldata bytes.
+    /// @param trade The memory location to decode trade to.
+    function decodeTrade(
         bytes32 domainSeparator,
         IERC20[] calldata tokens,
-        bytes calldata encodedOrder,
-        Order memory order
+        bytes calldata encodedTrade,
+        Trade memory trade
     ) internal pure {
         // NOTE: This is currently unnecessarily gas inefficient. Specifically,
-        // there is a potentially extraneous check to the encoded order length
-        // (this can be verified once for the total encoded orders length).
+        // there is a potentially extraneous check to the encoded trade length
+        // (this can be verified once for the total encoded trades length).
         // Additionally, Solidity generates bounds checks for each `abi.decode`
         // and slice operation. Unfortunately using `assmebly { calldataload }`
         // is quite ugly here since there is no mechanism to get calldata
@@ -112,59 +115,57 @@ library GPv2Encoding {
         // effort.
 
         require(
-            encodedOrder.length == ORDER_STRIDE,
-            "GPv2: malformed order data"
+            encodedTrade.length == TRADE_STRIDE,
+            "GPv2: malformed trade data"
         );
 
-        uint8 sellTokenIndex = uint8(encodedOrder[0]);
-        uint8 buyTokenIndex = uint8(encodedOrder[1]);
-        order.sellAmount = abi.decode(encodedOrder[2:], (uint256));
-        order.buyAmount = abi.decode(encodedOrder[34:], (uint256));
-        order.validTo = uint32(
-            abi.decode(encodedOrder[66:], (uint256)) >> (256 - 32)
+        uint8 sellTokenIndex = uint8(encodedTrade[0]);
+        uint8 buyTokenIndex = uint8(encodedTrade[1]);
+        trade.order.sellAmount = abi.decode(encodedTrade[2:], (uint256));
+        trade.order.buyAmount = abi.decode(encodedTrade[34:], (uint256));
+        trade.order.validTo = uint32(
+            abi.decode(encodedTrade[66:], (uint256)) >> (256 - 32)
         );
-        order.nonce = uint32(
-            abi.decode(encodedOrder[70:], (uint256)) >> (256 - 32)
+        trade.order.nonce = uint32(
+            abi.decode(encodedTrade[70:], (uint256)) >> (256 - 32)
         );
-        order.tip = abi.decode(encodedOrder[74:], (uint256));
-        uint8 flags = uint8(encodedOrder[106]);
-        order.executedAmount = abi.decode(encodedOrder[107:], (uint256));
-        uint8 v = uint8(encodedOrder[139]);
-        bytes32 r = abi.decode(encodedOrder[140:], (bytes32));
-        bytes32 s = abi.decode(encodedOrder[172:], (bytes32));
+        trade.order.tip = abi.decode(encodedTrade[74:], (uint256));
+        uint8 flags = uint8(encodedTrade[106]);
+        trade.executedAmount = abi.decode(encodedTrade[107:], (uint256));
+        uint8 v = uint8(encodedTrade[139]);
+        bytes32 r = abi.decode(encodedTrade[140:], (bytes32));
+        bytes32 s = abi.decode(encodedTrade[172:], (bytes32));
 
-        order.sellToken = tokens[sellTokenIndex];
-        order.sellTokenIndex = sellTokenIndex;
-        order.buyToken = tokens[buyTokenIndex];
-        order.buyTokenIndex = buyTokenIndex;
-        order.kind = OrderKind((flags >> ORDER_KIND_BIT) & 0x1);
-        order.partiallyFillable =
+        trade.order.typeHash = ORDER_TYPE_HASH;
+        trade.order.sellToken = tokens[sellTokenIndex];
+        trade.order.buyToken = tokens[buyTokenIndex];
+        trade.order.kind = OrderKind((flags >> ORDER_KIND_BIT) & 0x1);
+        trade.order.partiallyFillable =
             (flags >> ORDER_PARTIALLY_FILLABLE_BIT) & 0x01 == 0x01;
 
-        // NOTE: In order to avoid a memory allocation per call by using the
-        // built-in `abi.encode`, we reuse the memory region reserved by the
-        // caller for the order result as input to compute the hash, using the
-        // memory slot reserved for the order `owner` for the order type hash
-        // which is required by EIP-712 as a prefix to the order data.
-        // Furthermore structs are not packed in Solidity, and there is the
-        // order type hash prefix followed by the 9 order fields to hash for a
-        // total of `10 * sizeof(uint) = 320` bytes.
+        trade.sellTokenIndex = sellTokenIndex;
+        trade.buyTokenIndex = buyTokenIndex;
+
+        // NOTE: In order to avoid memory allocation and copying of the order
+        // parameters, use the memory region reserved by the caller for the
+        // order result to effeciently compute the hash in place. Furthermore,
+        // structs are not packed in Solidity, and there are 10 [`Order`] fields
+        // to hash for a total of `10 * sizeof(uint) = 320` bytes. This digest
+        // is a EIP-712 struct hash for the [`Order`] parameters.
         bytes32 orderDigest;
-        // TODO: This temporary stack variable is required as the compiler does
-        // not support non-literal constants in inline assembly. This should be
-        // removed once the constant is replaced with a pre-computed value for
-        // deployment.
-        bytes32 orderTypeHash = ORDER_TYPE_HASH;
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            mstore(order, orderTypeHash)
+            let order := mload(trade)
             orderDigest := keccak256(order, 320)
         }
 
-        // NOTE: Solidity allocates, but does not free, memory when calling the
-        // ABI encoding methods as well as the `ecrecover` precompile. However,
-        // we can restore the free memory pointer to before we made allocations
-        // to effectively free the memory.
+        // NOTE: Solidity allocates, but does not free, memory when:
+        // - calling the ABI encoding methods
+        // - calling the `ecrecover` precompile.
+        // However, we can restore the free memory pointer to before we made
+        // allocations to effectively free the memory. This is safe as the
+        // memory used can be discarded, and the memory pointed to by the free
+        // memory pointer **does not have to point to zero-ed out memory**.
         // <https://solidity.readthedocs.io/en/v0.6.12/internals/layout_in_memory.html>
         uint256 freeMemoryPointer;
         // solhint-disable-next-line no-inline-assembly
@@ -195,15 +196,13 @@ library GPv2Encoding {
             );
         }
 
-        address orderOwner = ecrecover(signingDigest, v & 0x1f, r, s);
-        require(orderOwner != address(0), "GPv2: invalid signature");
+        address owner = ecrecover(signingDigest, v & 0x1f, r, s);
+        require(owner != address(0), "GPv2: invalid signature");
 
-        order.owner = orderOwner;
-        order.digest = orderDigest;
+        trade.digest = orderDigest;
+        trade.owner = owner;
 
-        // NOTE: Restore the free memory pointer. This is safe as the memory
-        // used can be discarded, and the memory pointed to by the free memory
-        // pointer **does not have to point to zero-ed out memory**.
+        // NOTE: Restore the free memory pointer to free temporary memory.
         // solhint-disable-next-line no-inline-assembly
         assembly {
             mstore(0x40, freeMemoryPointer)

--- a/src/contracts/test/GPv2EncodingTestInterface.sol
+++ b/src/contracts/test/GPv2EncodingTestInterface.sol
@@ -17,52 +17,52 @@ contract GPv2EncodingTestInterface {
         return (GPv2Encoding.ORDER_TYPE_HASH);
     }
 
-    function decodeSignedOrdersTest(
+    function decodeTradesTest(
         IERC20[] calldata tokens,
-        uint256 orderCount,
-        bytes calldata encodedOrders
+        uint256 tradeCount,
+        bytes calldata encodedTrades
     )
         external
         view
         returns (
-            GPv2Encoding.Order[] memory orders,
+            GPv2Encoding.Trade[] memory trades,
             uint256 mem,
             uint256 gas_
         )
     {
         // solhint-disable no-inline-assembly
 
-        uint256 stride = GPv2Encoding.ORDER_STRIDE;
+        uint256 stride = GPv2Encoding.TRADE_STRIDE;
         bytes32 domainSeparator = DOMAIN_SEPARATOR;
 
-        orders = new GPv2Encoding.Order[](orderCount);
+        trades = new GPv2Encoding.Trade[](tradeCount);
 
         // NOTE: Solidity keeps a total memory count at address 0x40. Check
-        // before and after decoding an order to compute memory usage growth per
-        // call to `decodeSignedOrder`.
+        // before and after decoding a trade to compute memory usage growth per
+        // call to `decodeTrade`.
         assembly {
             mem := mload(0x40)
         }
         gas_ = gasleft();
 
         uint256 start;
-        bytes calldata encodedOrder;
-        for (uint256 i = 0; i < orderCount; i++) {
+        bytes calldata encodedTrade;
+        for (uint256 i = 0; i < tradeCount; i++) {
             start = i * stride;
-            if (i == orderCount - 1) {
-                // NOTE: Last order uses all remaining bytes. This allows the
-                // `decodeSignedOrder` method to be tested with short and long
-                // order bytes as well.
-                encodedOrder = encodedOrders[start:];
+            if (i == tradeCount - 1) {
+                // NOTE: Last trade uses all remaining bytes. This allows the
+                // `decodeTrade` method to be tested with short and long trade
+                // bytes as well.
+                encodedTrade = encodedTrades[start:];
             } else {
-                encodedOrder = encodedOrders[start:][:stride];
+                encodedTrade = encodedTrades[start:][:stride];
             }
 
-            GPv2Encoding.decodeSignedOrder(
+            GPv2Encoding.decodeTrade(
                 domainSeparator,
                 tokens,
-                encodedOrder,
-                orders[i]
+                encodedTrade,
+                trades[i]
             );
         }
 

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -19,16 +19,16 @@ function fillUint(bits: number, byte: number): BigNumber {
   return BigNumber.from(fillBytes(bits / 8, byte));
 }
 
-function parseTrade(
-  trade: unknown[],
-): {
+interface Trade {
   order: Order;
   sellTokenIndex: number;
   buyTokenIndex: number;
   executedAmount: BigNumber;
   digest: string;
   owner: string;
-} {
+}
+
+function parseTrade(trade: unknown[]): Trade {
   const order = trade[0] as unknown[];
   return {
     order: {

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -4,8 +4,9 @@ import { ethers, waffle } from "hardhat";
 
 import {
   ORDER_TYPE_HASH,
-  OrderEncoder,
+  Order,
   OrderKind,
+  SettlementEncoder,
   SigningScheme,
   hashOrder,
 } from "../src/ts";
@@ -16,6 +17,37 @@ function fillBytes(count: number, byte: number): string {
 
 function fillUint(bits: number, byte: number): BigNumber {
   return BigNumber.from(fillBytes(bits / 8, byte));
+}
+
+function parseTrade(
+  trade: unknown[],
+): {
+  order: Order;
+  sellTokenIndex: number;
+  buyTokenIndex: number;
+  executedAmount: BigNumber;
+  digest: string;
+  owner: string;
+} {
+  const order = trade[0] as unknown[];
+  return {
+    order: {
+      sellToken: order[1] as string,
+      buyToken: order[2] as string,
+      sellAmount: order[3] as BigNumber,
+      buyAmount: order[4] as BigNumber,
+      validTo: order[5] as number,
+      nonce: order[6] as number,
+      tip: order[7] as BigNumber,
+      kind: order[8] as OrderKind,
+      partiallyFillable: order[9] as boolean,
+    },
+    sellTokenIndex: trade[1] as number,
+    buyTokenIndex: trade[2] as number,
+    executedAmount: trade[3] as BigNumber,
+    digest: trade[4] as string,
+    owner: trade[5] as string,
+  };
 }
 
 describe("GPv2Encoding", () => {
@@ -58,8 +90,8 @@ describe("GPv2Encoding", () => {
     });
   });
 
-  describe("decodeSignedOrder", () => {
-    it("should round-trip encode executed order data", async () => {
+  describe("decodeTrade", () => {
+    it("should round-trip encode order data", async () => {
       // NOTE: Pay extra attention to use all bytes for each field, and that
       // they all have different values to make sure the are correctly
       // round-tripped.
@@ -76,93 +108,126 @@ describe("GPv2Encoding", () => {
       };
       const executedAmount = fillUint(256, 0x08);
 
-      const encoder = new OrderEncoder(testDomain);
-      await encoder.signEncodeOrder(
-        SigningScheme.TYPED_DATA,
-        traders[0],
+      const encoder = new SettlementEncoder(testDomain);
+      await encoder.signEncodeTrade(
         order,
         executedAmount,
+        traders[0],
+        SigningScheme.TYPED_DATA,
       );
 
-      const [decodedOrders] = await encoding.decodeSignedOrdersTest(
+      const [decodedTrades] = await encoding.decodeTradesTest(
         encoder.tokens,
-        encoder.orderCount,
-        encoder.encodedOrders,
+        encoder.tradeCount,
+        encoder.encodedTrades,
       );
 
       // NOTE: Ethers.js returns a tuple and not a struct with named fields for
       // `ABIEncoderV2` structs.
-      expect(decodedOrders.length).to.equal(1);
-      expect(decodedOrders[0]).to.deep.equal([
-        await traders[0].getAddress(),
-        order.sellToken,
-        order.buyToken,
-        order.sellAmount,
-        order.buyAmount,
-        order.validTo,
-        order.nonce,
-        order.tip,
-        order.kind,
-        order.partiallyFillable,
-        encoder.tokens.indexOf(order.sellToken),
-        encoder.tokens.indexOf(order.buyToken),
-        executedAmount,
-        hashOrder(order),
-      ]);
+      expect(decodedTrades.length).to.equal(1);
+
+      const {
+        order: decodedOrder,
+        executedAmount: decodedExecutedAmount,
+      } = parseTrade(decodedTrades[0]);
+      expect(decodedOrder).to.deep.equal(order);
+      expect(decodedExecutedAmount).to.deep.equal(executedAmount);
+    });
+
+    it("should return order token indices", async () => {
+      const encoder = new SettlementEncoder(testDomain);
+      await encoder.signEncodeTrade(
+        sampleOrder,
+        0,
+        traders[0],
+        SigningScheme.TYPED_DATA,
+      );
+
+      const [decodedTrades] = await encoding.decodeTradesTest(
+        encoder.tokens,
+        encoder.tradeCount,
+        encoder.encodedTrades,
+      );
+      const { sellTokenIndex, buyTokenIndex } = parseTrade(decodedTrades[0]);
+      expect(sellTokenIndex).to.equal(
+        encoder.tokens.indexOf(sampleOrder.sellToken),
+      );
+      expect(buyTokenIndex).to.equal(
+        encoder.tokens.indexOf(sampleOrder.buyToken),
+      );
+    });
+
+    it("should compute EIP-712 order struct hash", async () => {
+      const encoder = new SettlementEncoder(testDomain);
+      await encoder.signEncodeTrade(
+        sampleOrder,
+        0,
+        traders[0],
+        SigningScheme.TYPED_DATA,
+      );
+
+      const [decodedTrades] = await encoding.decodeTradesTest(
+        encoder.tokens,
+        encoder.tradeCount,
+        encoder.encodedTrades,
+      );
+      const { digest } = parseTrade(decodedTrades[0]);
+      expect(digest).to.equal(hashOrder(sampleOrder));
     });
 
     it("should recover signing address for all supported schemes", async () => {
-      const encoder = new OrderEncoder(testDomain);
+      const encoder = new SettlementEncoder(testDomain);
       for (const scheme of [SigningScheme.TYPED_DATA, SigningScheme.MESSAGE]) {
-        await encoder.signEncodeOrder(scheme, traders[0], sampleOrder, 0);
+        await encoder.signEncodeTrade(sampleOrder, 0, traders[0], scheme);
       }
 
-      const [decodedOrders] = await encoding.decodeSignedOrdersTest(
+      const [decodedTrades] = await encoding.decodeTradesTest(
         encoder.tokens,
-        encoder.orderCount,
-        encoder.encodedOrders,
+        encoder.tradeCount,
+        encoder.encodedTrades,
       );
 
       const traderAddress = await traders[0].getAddress();
-      for (const [owner] of decodedOrders) {
+      for (const decodedTrade of decodedTrades) {
+        const { owner } = parseTrade(decodedTrade);
         expect(owner).to.equal(traderAddress);
       }
     });
 
-    it("should revert if order bytes are too short.", async () => {
+    it("should revert if trade bytes are too short.", async () => {
       await expect(
-        encoding.decodeSignedOrdersTest([], 1, "0x1337"),
-      ).to.be.revertedWith("malformed order data");
+        encoding.decodeTradesTest([], 1, "0x1337"),
+      ).to.be.revertedWith("malformed trade data");
     });
 
-    it("should revert if order bytes are too long.", async () => {
+    it("should revert if trade bytes are too long.", async () => {
       await expect(
-        encoding.decodeSignedOrdersTest(
+        encoding.decodeTradesTest(
           [],
           1,
           ethers.utils.hexlify([...Array(205)].map(() => 42)),
         ),
-      ).to.be.revertedWith("malformed order data");
+      ).to.be.revertedWith("malformed trade data");
     });
 
     it("should revert for invalid order signatures", async () => {
-      const encoder = new OrderEncoder(testDomain);
-      await encoder.signEncodeOrder(
-        SigningScheme.TYPED_DATA,
-        traders[0],
+      const encoder = new SettlementEncoder(testDomain);
+      await encoder.signEncodeTrade(
         sampleOrder,
         sampleOrder.sellAmount,
+        traders[0],
+        SigningScheme.TYPED_DATA,
       );
 
       // NOTE: `v` must be either `27` or `28`, so just set it to something else
       // to generate an invalid signature.
-      const encodedOrderBytes = ethers.utils.arrayify(encoder.encodedOrders);
+      const encodedOrderBytes = ethers.utils.arrayify(encoder.encodedTrades);
       encodedOrderBytes[139] = 42;
 
       await expect(
-        encoding.decodeSignedOrdersTest(
+        encoding.decodeTradesTest(
           encoder.tokens,
-          encoder.orderCount,
+          encoder.tradeCount,
           encodedOrderBytes,
         ),
       ).to.be.revertedWith("invalid signature");
@@ -171,31 +236,31 @@ describe("GPv2Encoding", () => {
     it("should revert for invalid sell token indices", async () => {
       const lastToken = fillBytes(20, 0x03);
 
-      const encoder = new OrderEncoder(testDomain);
-      await encoder.signEncodeOrder(
-        SigningScheme.TYPED_DATA,
-        traders[0],
+      const encoder = new SettlementEncoder(testDomain);
+      await encoder.signEncodeTrade(
         sampleOrder,
         sampleOrder.sellAmount,
-      );
-      await encoder.signEncodeOrder(
+        traders[0],
         SigningScheme.TYPED_DATA,
-        traders[1],
+      );
+      await encoder.signEncodeTrade(
         {
           ...sampleOrder,
           sellToken: lastToken,
         },
         sampleOrder.sellAmount,
+        traders[1],
+        SigningScheme.TYPED_DATA,
       );
 
       // NOTE: Remove the last sell token (0x0303...0303).
       const tokens = encoder.tokens;
       expect(tokens.pop()).to.equal(lastToken);
       await expect(
-        encoding.decodeSignedOrdersTest(
+        encoding.decodeTradesTest(
           tokens,
-          encoder.orderCount,
-          encoder.encodedOrders,
+          encoder.tradeCount,
+          encoder.encodedTrades,
         ),
       ).to.be.reverted;
     });
@@ -203,31 +268,31 @@ describe("GPv2Encoding", () => {
     it("should revert for invalid sell token indices", async () => {
       const lastToken = fillBytes(20, 0x03);
 
-      const encoder = new OrderEncoder(testDomain);
-      await encoder.signEncodeOrder(
-        SigningScheme.TYPED_DATA,
-        traders[0],
+      const encoder = new SettlementEncoder(testDomain);
+      await encoder.signEncodeTrade(
         sampleOrder,
         sampleOrder.sellAmount,
-      );
-      await encoder.signEncodeOrder(
+        traders[0],
         SigningScheme.TYPED_DATA,
-        traders[1],
+      );
+      await encoder.signEncodeTrade(
         {
           ...sampleOrder,
           buyToken: lastToken,
         },
         sampleOrder.sellAmount,
+        traders[1],
+        SigningScheme.TYPED_DATA,
       );
 
       // NOTE: Remove the last buy token (0x0303...0303).
       const tokens = encoder.tokens;
       expect(tokens.pop()).to.equal(lastToken);
       await expect(
-        encoding.decodeSignedOrdersTest(
+        encoding.decodeTradesTest(
           tokens,
-          encoder.orderCount,
-          encoder.encodedOrders,
+          encoder.tradeCount,
+          encoder.encodedTrades,
         ),
       ).to.be.reverted;
     });
@@ -235,24 +300,24 @@ describe("GPv2Encoding", () => {
     it("should not allocate additional memory", async () => {
       // NOTE: We want to make sure that calls to `decodeOrder` does not require
       // additional memory allocations to save on memory per orders.
-      const encoder = new OrderEncoder(testDomain);
-      await encoder.signEncodeOrder(
-        SigningScheme.TYPED_DATA,
+      const encoder = new SettlementEncoder(testDomain);
+      await encoder.signEncodeTrade(
+        sampleOrder,
+        0,
         traders[0],
-        sampleOrder,
-        0,
+        SigningScheme.TYPED_DATA,
       );
-      await encoder.signEncodeOrder(
-        SigningScheme.MESSAGE,
-        traders[1],
+      await encoder.signEncodeTrade(
         sampleOrder,
         0,
+        traders[1],
+        SigningScheme.MESSAGE,
       );
 
-      const [, mem] = await encoding.decodeSignedOrdersTest(
+      const [, mem] = await encoding.decodeTradesTest(
         encoder.tokens,
-        encoder.orderCount,
-        encoder.encodedOrders,
+        encoder.tradeCount,
+        encoder.encodedTrades,
       );
       expect(mem.toNumber()).to.equal(0);
     });


### PR DESCRIPTION
This PR is my attempt at implementing @fleupold 's suggestion of splitting the current `Order` struct into two different structs, one for the actual order (the signed parameters that are submitted to GP) and the `Trade` which is a trade to be included in the settlement (so includes things like the executed amount, which is **not** part of the order).

All in all, I'm fairly happy with this implementation, but I am a bit disappointed that Solidity seems to allocate memories when doing `Order memory order = trade.order`. In fact, this does roughly (translated to C pseudo-code):
```
Order *order;
order = malloc(sizeof(Order)); // unneeded memory allocation.
order = &trade.order;
```

### Test Plan

New unit tests.
