### PR TITLE
Upgrade to Solidity v0.7.5

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -2,7 +2,8 @@
   "extends": "solhint:recommended",
   "plugins": ["prettier"],
   "rules": {
-    "compiler-version": ["error", "^0.6.12"],
+    "compiler-version": ["error", "^0.7.0"],
+    "func-visibility": ["warn", { "ignoreConstructors": true }],
     "prettier/prettier": "error"
   }
 }

--- a/.solhint.json
+++ b/.solhint.json
@@ -2,7 +2,7 @@
   "extends": "solhint:recommended",
   "plugins": ["prettier"],
   "rules": {
-    "compiler-version": ["error", "^0.7.0"],
+    "compiler-version": "off",
     "func-visibility": ["warn", { "ignoreConstructors": true }],
     "prettier/prettier": "error"
   }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -7,6 +7,6 @@ export default {
     sources: "src/contracts",
   },
   solidity: {
-    version: "0.6.12",
+    version: "0.7.5",
   },
 };

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.0",
     "@nomiclabs/hardhat-waffle": "^2.0.0",
-    "@openzeppelin/contracts": "^3.2.0",
+    "@openzeppelin/contracts": "^3.2.2-solc-0.7",
     "@types/chai": "^4.2.14",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^8.0.4",

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-newer
-pragma solidity ^0.6.12;
+pragma solidity ^0.7.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
@@ -13,7 +13,7 @@ contract GPv2Settlement {
     /// GPv2 contracts.
     bytes32 internal immutable domainSeparator;
 
-    constructor() public {
+    constructor() {
         uint256 chainId;
 
         // NOTE: Currently, the only way to get the chain ID in solidity is

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-newer
-pragma solidity ^0.7.0;
+pragma solidity ^0.7.5;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-newer
-pragma solidity ^0.6.12;
+pragma solidity ^0.7.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-newer
-pragma solidity ^0.7.0;
+pragma solidity ^0.7.5;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/src/contracts/test/GPv2EncodingTestInterface.sol
+++ b/src/contracts/test/GPv2EncodingTestInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-newer
-pragma solidity ^0.6.12;
+pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "../libraries/GPv2Encoding.sol";

--- a/src/contracts/test/GPv2EncodingTestInterface.sol
+++ b/src/contracts/test/GPv2EncodingTestInterface.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-newer
-pragma solidity ^0.7.0;
-pragma experimental ABIEncoderV2;
+pragma solidity ^0.7.5;
+pragma abicoder v2;
 
 import "../libraries/GPv2Encoding.sol";
 

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.7.0;
-pragma experimental ABIEncoderV2;
+pragma solidity ^0.7.5;
 
 import "../GPv2Settlement.sol";
 

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
-pragma solidity ^0.6.12;
+pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
 import "../GPv2Settlement.sol";

--- a/yarn.lock
+++ b/yarn.lock
@@ -511,10 +511,10 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.2.0.tgz#3e6b3a7662d8ed64271ade96ef42655db983fd9d"
-  integrity sha512-bUOmkSoPkjnUyMiKo6RYnb0VHBk5D9KKDAgNLzF41aqAM3TeE0yGdFF5dVRcV60pZdJLlyFT/jjXIZCWyyEzAQ==
+"@openzeppelin/contracts@^3.2.2-solc-0.7":
+  version "3.2.2-solc-0.7"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.2.2-solc-0.7.tgz#8ab169da64438d59f47ca285f1a10efe2f9ba19e"
+  integrity sha512-vFV53E4pvfsAEjzL9Um2VX9MEuXyq7Hyd9JjnP77AGsrEPxkJaYS06zZIVyhAt3rXTM6QGdW0C282Zv7fM93AA==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"


### PR DESCRIPTION
This PR upgrades the contracts to use the latest Solidity compiler. This will allow us to use features such as:
- `calldata` support in `assembly` blocks (see #159)

This also paves the way for using v0.7.6 which might add:
- Memory assignment optimizations (for nested struct support, see https://github.com/gnosis/oba-contracts/pull/156#discussion_r526670732)

### Test Plan

CI still passes, only minor breaking change in code where constructors no longer accept modifiers.
