### PR TITLE
Add allowance manager implementation

### DIFF
--- a/src/contracts/GPv2AllowanceManager.sol
+++ b/src/contracts/GPv2AllowanceManager.sol
@@ -18,27 +18,27 @@ contract GPv2AllowanceManager {
         uint256 amount;
     }
 
-    /// @dev The owner contract of the allowance manager. The owner is set at
-    /// creation time and cannot change.
-    address private immutable owner;
+    /// @dev The recipient of all transfers made by the allowance manager. The
+    /// recipient is set at creation time and cannot change.
+    address private immutable recipient;
 
     constructor() {
-        owner = msg.sender;
+        recipient = msg.sender;
     }
 
     /// @dev Modifier that ensures that a function can only be called by the
-    /// owner of this contract.
-    modifier onlyOwner {
-        require(msg.sender == owner, "GPv2: not allowance owner");
+    /// recipient of this contract.
+    modifier onlyRecipient {
+        require(msg.sender == recipient, "GPv2: not allowance recipient");
         _;
     }
 
     /// @dev Executes all transfers from the specified accounts into the caller.
     ///
     /// This function reverts if:
-    /// - The caller is not the owner of the allowance manager
+    /// - The caller is not the recipient of the allowance manager
     /// - Any ERC20 tranfer fails
-    function transferIn(Transfer[] calldata transfers) external onlyOwner {
+    function transferIn(Transfer[] calldata transfers) external onlyRecipient {
         for (uint256 i = 0; i < transfers.length; i++) {
             transfers[i].token.safeTransferFrom(
                 transfers[i].owner,

--- a/src/contracts/GPv2AllowanceManager.sol
+++ b/src/contracts/GPv2AllowanceManager.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: LGPL-3.0-or-newer
+pragma solidity ^0.7.5;
+pragma abicoder v2;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+
+/// @title Gnosis Protocol v2 Allowance Manager Contract
+/// @author Gnosis Developers
+contract GPv2AllowanceManager {
+    using SafeERC20 for IERC20;
+
+    /// @dev A struct representing transfers to be executed as part of a batch
+    /// settlement.
+    struct Transfer {
+        address owner;
+        IERC20 token;
+        uint256 amount;
+    }
+
+    /// @dev The owner contract of the allowance manager. The owner is set at
+    /// creation time and cannot change.
+    address private immutable owner;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    /// @dev Modifier that ensures that a function can only be called by the
+    /// owner of this contract.
+    modifier onlyOwner {
+        require(msg.sender == owner, "GPv2: not allowance owner");
+        _;
+    }
+
+    /// @dev Executes all transfers from the specified accounts into the caller.
+    ///
+    /// This function reverts if:
+    /// - The caller is not the owner of the allowance manager
+    /// - Any ERC20 tranfer fails
+    function transferIn(Transfer[] calldata transfers) external onlyOwner {
+        for (uint256 i = 0; i < transfers.length; i++) {
+            transfers[i].token.safeTransferFrom(
+                transfers[i].owner,
+                msg.sender,
+                transfers[i].amount
+            );
+        }
+    }
+}

--- a/src/contracts/test/NonStandardERC20.sol
+++ b/src/contracts/test/NonStandardERC20.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: LGPL-3.0-or-newer
+pragma solidity ^0.7.5;
+
+interface NonStandardERC20 {
+    /// @dev Non-standard ERC20 `transferFrom` that does not return a bool
+    /// indicating success.
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) external;
+}

--- a/test/GPv2AllowanceManager.test.ts
+++ b/test/GPv2AllowanceManager.test.ts
@@ -16,13 +16,19 @@ function composeTransfers(
 }
 
 describe("GPv2AllowanceManager", () => {
-  const [deployer, nonOwner, ...traders] = waffle.provider.getWallets();
+  const [
+    deployer,
+    recipient,
+    nonRecipient,
+    ...traders
+  ] = waffle.provider.getWallets();
 
   let allowanceManager: Contract;
 
   beforeEach(async () => {
     const GPv2AllowanceManager = await ethers.getContractFactory(
       "GPv2AllowanceManager",
+      recipient,
     );
 
     allowanceManager = await GPv2AllowanceManager.deploy();
@@ -31,8 +37,8 @@ describe("GPv2AllowanceManager", () => {
   describe("transferIn", () => {
     it("should revert if not called by the owner", async () => {
       await expect(
-        allowanceManager.connect(nonOwner).transferIn([]),
-      ).to.be.revertedWith("not allowance owner");
+        allowanceManager.connect(nonRecipient).transferIn([]),
+      ).to.be.revertedWith("not allowance recipient");
     });
 
     it("should execute ERC20 transfers", async () => {
@@ -44,10 +50,10 @@ describe("GPv2AllowanceManager", () => {
 
       const amount = ethers.utils.parseEther("13.37");
       await tokens[0].mock.transferFrom
-        .withArgs(traders[0].address, deployer.address, amount)
+        .withArgs(traders[0].address, recipient.address, amount)
         .returns(true);
       await tokens[1].mock.transferFrom
-        .withArgs(traders[1].address, deployer.address, amount)
+        .withArgs(traders[1].address, recipient.address, amount)
         .returns();
 
       await expect(
@@ -73,7 +79,7 @@ describe("GPv2AllowanceManager", () => {
 
       const amount = ethers.utils.parseEther("4.2");
       await token.mock.transferFrom
-        .withArgs(traders[0].address, deployer.address, amount)
+        .withArgs(traders[0].address, recipient.address, amount)
         .revertsWithReason("test error");
 
       await expect(
@@ -94,7 +100,7 @@ describe("GPv2AllowanceManager", () => {
 
       const amount = ethers.utils.parseEther("4.2");
       await token.mock.transferFrom
-        .withArgs(traders[0].address, deployer.address, amount)
+        .withArgs(traders[0].address, recipient.address, amount)
         .returns(false);
 
       await expect(

--- a/test/GPv2AllowanceManager.test.ts
+++ b/test/GPv2AllowanceManager.test.ts
@@ -1,0 +1,127 @@
+import IERC20 from "@openzeppelin/contracts/build/contracts/IERC20.json";
+import { expect } from "chai";
+import { Contract, BigNumberish } from "ethers";
+import { artifacts, ethers, waffle } from "hardhat";
+
+interface Transfer {
+  owner: string;
+  token: string;
+  amount: BigNumberish;
+}
+
+function composeTransfers(
+  transfers: Transfer[],
+): [string, string, BigNumberish][] {
+  return transfers.map(({ owner, token, amount }) => [owner, token, amount]);
+}
+
+describe("GPv2AllowanceManager", () => {
+  const [deployer, nonOwner, ...traders] = waffle.provider.getWallets();
+
+  let allowanceManager: Contract;
+
+  beforeEach(async () => {
+    const GPv2AllowanceManager = await ethers.getContractFactory(
+      "GPv2AllowanceManager",
+    );
+
+    allowanceManager = await GPv2AllowanceManager.deploy();
+  });
+
+  describe("transferIn", () => {
+    it("should revert if not called by the owner", async () => {
+      await expect(
+        allowanceManager.connect(nonOwner).transferIn([]),
+      ).to.be.revertedWith("not allowance owner");
+    });
+
+    it("should execute ERC20 transfers", async () => {
+      const NonStandardERC20 = await artifacts.readArtifact("NonStandardERC20");
+      const tokens = [
+        await waffle.deployMockContract(deployer, IERC20.abi),
+        await waffle.deployMockContract(deployer, NonStandardERC20.abi),
+      ];
+
+      const amount = ethers.utils.parseEther("13.37");
+      await tokens[0].mock.transferFrom
+        .withArgs(traders[0].address, deployer.address, amount)
+        .returns(true);
+      await tokens[1].mock.transferFrom
+        .withArgs(traders[1].address, deployer.address, amount)
+        .returns();
+
+      await expect(
+        allowanceManager.transferIn(
+          composeTransfers([
+            {
+              owner: traders[0].address,
+              token: tokens[0].address,
+              amount,
+            },
+            {
+              owner: traders[1].address,
+              token: tokens[1].address,
+              amount,
+            },
+          ]),
+        ),
+      ).to.not.be.reverted;
+    });
+
+    it("should revert on failed ERC20 transfers", async () => {
+      const token = await waffle.deployMockContract(deployer, IERC20.abi);
+
+      const amount = ethers.utils.parseEther("4.2");
+      await token.mock.transferFrom
+        .withArgs(traders[0].address, deployer.address, amount)
+        .revertsWithReason("test error");
+
+      await expect(
+        allowanceManager.transferIn(
+          composeTransfers([
+            {
+              owner: traders[0].address,
+              token: token.address,
+              amount,
+            },
+          ]),
+        ),
+      ).to.be.revertedWith("test error");
+    });
+
+    it("should revert on failed non-standard ERC20 transfers", async () => {
+      const token = await waffle.deployMockContract(deployer, IERC20.abi);
+
+      const amount = ethers.utils.parseEther("4.2");
+      await token.mock.transferFrom
+        .withArgs(traders[0].address, deployer.address, amount)
+        .returns(false);
+
+      await expect(
+        allowanceManager.transferIn(
+          composeTransfers([
+            {
+              owner: traders[0].address,
+              token: token.address,
+              amount,
+            },
+          ]),
+        ),
+      ).to.be.revertedWith("ERC20 operation did not succeed");
+    });
+
+    it("should revert when transfering from an address without code", async () => {
+      await expect(
+        allowanceManager.transferIn(
+          composeTransfers([
+            {
+              owner: traders[0].address,
+              token: traders[1].address,
+              amount: ethers.constants.WeiPerEther,
+            },
+          ]),
+        ),
+      ).to.be.revertedWith("call to non-contract");
+    });
+  });
+});


### PR DESCRIPTION
Closes #121 

This PR introduces the allowance manager contract that is responsible for withdrawing funds for EOA orders.

Note that for now, this uses the OpenZeppelin `SafeERC20` implementation. We can, however, swap it out depending on the decision in #31 

### Test Plan

Added new unit tests.
