### PR TITLE
Add utility methods for slicing encoded trades

### DIFF
--- a/bench/decodeTrade.ts
+++ b/bench/decodeTrade.ts
@@ -39,7 +39,6 @@ async function main() {
 
     const [, , gas] = await encoding.decodeTradesTest(
       encoder.tokens,
-      encoder.tradeCount,
       encoder.encodedTrades,
     );
     console.log(`${gas} gas used for decoding ${orderCount} orders`);


### PR DESCRIPTION
This PR encapsulates all of the trade decoding logic within the `GPv2Encoding` library instead of leaking details like the `TRADE_STRIDE`. This allows us to more easily change the encoding without affecting the calling code.

### Test Plan

Added new unit tests for the `tradeCount` method and adjusted others to match new signature. We also are a little more gas efficient now (~200 gas per order) as we do not check bounds when slicing the trade byte calldata array, nor do we check the slice length for each trade.
