### PR TITLE
Add function to compute allowance manager address off-chain

### DIFF
--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -26,6 +26,24 @@ export function domain(
 }
 
 /**
+ * Computes the address of the allowance manager contract for the specified
+ * settlement contract address.
+ * @param settlementAddress The address of the settlement contract.
+ * @return The address of the allowance manager contract.
+ */
+export function allowanceManagerAddress(settlementAddress: string): string {
+  // NOTE: `CREATE` opcode deploys a contract to a deterministic address based
+  // on the calling contract address and the nonce, which for the settlement
+  // contract is always 1 (as per EIP-161).
+  const ADDRESS_STRING_OFFSET = 2 /* 0x */ + 2 * (32 - 20);
+  return ethers.utils.getAddress(
+    `0x${ethers.utils
+      .keccak256(ethers.utils.RLP.encode([settlementAddress, "0x01"]))
+      .substr(ADDRESS_STRING_OFFSET)}`,
+  );
+}
+
+/**
  * Gnosis Protocol v2 order data.
  */
 export interface Order {

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { Contract } from "ethers";
 import { artifacts, ethers, waffle } from "hardhat";
 
-import { domain } from "../src/ts";
+import { allowanceManagerAddress, domain } from "../src/ts";
 
 describe("GPv2Settlement", () => {
   const [deployer, owner, solver] = waffle.provider.getWallets();
@@ -68,6 +68,12 @@ describe("GPv2Settlement", () => {
 
       expect(metadata(code)).to.equal(
         metadata(GPv2AllowanceManager.deployedBytecode),
+      );
+    });
+
+    it("should result in a deterministic address", async () => {
+      expect(await settlement.allowanceManagerTest()).to.equal(
+        allowanceManagerAddress(settlement.address),
       );
     });
 


### PR DESCRIPTION
This PR adds a new function to deterministically compute the address of the allowance manager contract of a deployed settlement contract. This allows us to compute the address off-chain and not require adding a public accessor to the settlement contract which has minor deploy time and runtime costs.

### Test Plan

Add new unit test.
