### PR TITLE
Remove syntactic sugar for decode call

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -159,7 +159,8 @@ contract GPv2Settlement {
 
         GPv2Encoding.Trade memory trade;
         for (uint256 i = 0; i < tradeCount; i++) {
-            encodedTrades.tradeAtIndex(i).decodeTrade(
+            GPv2Encoding.decodeTrade(
+                encodedTrades.tradeAtIndex(i),
                 domainSeparator,
                 tokens,
                 trade

--- a/src/contracts/test/GPv2EncodingTestInterface.sol
+++ b/src/contracts/test/GPv2EncodingTestInterface.sol
@@ -56,7 +56,8 @@ contract GPv2EncodingTestInterface {
         gas_ = gasleft();
 
         for (uint256 i = 0; i < tradeCount; i++) {
-            encodedTrades.tradeAtIndex(i).decodeTrade(
+            GPv2Encoding.decodeTrade(
+                encodedTrades.tradeAtIndex(i),
                 domainSeparator,
                 tokens,
                 trades[i]


### PR DESCRIPTION
Remove syntactic sugar for `decodeTrade` call as it seems to increase the gas cost by 48 per order. This is rather unexpected, and surprisingly it does not increase gas costs for other similar calls (such as `encodedTrades.tradeAtIndex(i)` has identical gas costs to `GPv2Encoding.tradeAtIndex(encodedTrades, i)`.

I am opening this as a draft PR for now as I want to take a look at the disassembly first to understand better what is going on and maybe get in touch with the Solidity team to see if this is expected.

### Test Plan

Enable optimizations for a fair comparison:

<details><summary><code>git diff</code></summary>

```diff
diff --git a/hardhat.config.ts b/hardhat.config.ts
index c03ceb9..2c997df 100644
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -42,6 +42,12 @@ export default {
   },
   solidity: {
     version: "0.7.5",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 1000000,
+      },
+    },
   },
   networks: {
     mainnet: {
```

</details>

Here is the gas benchmark before:
```
$ yarn run -s bench:decodeTrade
5400 gas used for decoding 1 orders
26678 gas used for decoding 5 orders
53276 gas used for decoding 10 orders
133068 gas used for decoding 25 orders
266055 gas used for decoding 50 orders
532030 gas used for decoding 100 orders
```

and after the change:
```
$ yarn run -s bench:decodeTrade
5358 gas used for decoding 1 orders
26468 gas used for decoding 5 orders
52856 gas used for decoding 10 orders
132018 gas used for decoding 25 orders
263955 gas used for decoding 50 orders
527830 gas used for decoding 100 orders
```