### PR TITLE
Enable Solidity optimizer

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -42,6 +42,12 @@ export default {
   },
   solidity: {
     version: "0.7.5",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 1000000,
+      },
+    },
   },
   networks: {
     mainnet: {


### PR DESCRIPTION
Closes #174 

This PR enables the optimizer with default settings. I tried enabling additional settings as described here <https://docs.soliditylang.org/en/v0.7.5/using-the-compiler.html#input-description> but none of them seemed to have any impact.

We can mess around with the optimizer settings more once we can generate end-to-end settlements and benchmark them.

### Test Plan

CI still passes.
