### PR TITLE
Initial order processing implementation.

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -2,12 +2,18 @@
 pragma solidity ^0.7.5;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
 import "./GPv2AllowanceManager.sol";
 import "./interfaces/GPv2Authentication.sol";
+import "./libraries/GPv2Encoding.sol";
 
 /// @title Gnosis Protocol v2 Settlement Contract
 /// @author Gnosis Developers
 contract GPv2Settlement {
+    using GPv2Encoding for bytes;
+    using SafeMath for uint256;
+
     /// @dev The EIP-712 domain type hash used for computing the domain
     /// separator.
     bytes32 private constant DOMAIN_TYPE_HASH =
@@ -100,7 +106,7 @@ contract GPv2Settlement {
     /// @param clearingPrices An array of clearing prices where the `i`-th price
     /// is for the `i`-th token in the [`tokens`] array.
     /// @param feeFactor The fee factor to use for the trade.
-    /// @param encodedOrders Encoded signed EOA orders.
+    /// @param encodedTrades Encoded trades for signed EOA orders.
     /// @param encodedInteractions Encoded smart contract interactions.
     /// @param encodedOrderRefunds Encoded order refunds for clearing storage
     /// related to invalid orders.
@@ -108,16 +114,117 @@ contract GPv2Settlement {
         IERC20[] calldata tokens,
         uint256[] calldata clearingPrices,
         uint256 feeFactor,
-        bytes calldata encodedOrders,
+        bytes calldata encodedTrades,
         bytes calldata encodedInteractions,
         bytes calldata encodedOrderRefunds
-    ) external view onlySolver {
+    ) external onlySolver {
         require(tokens.length == 0, "not yet implemented");
         require(clearingPrices.length == 0, "not yet implemented");
         require(feeFactor == 0, "not yet implemented");
-        require(encodedOrders.length == 0, "not yet implemented");
+        require(encodedTrades.length == 0, "not yet implemented");
         require(encodedInteractions.length == 0, "not yet implemented");
         require(encodedOrderRefunds.length == 0, "not yet implemented");
+
         revert("Final: not yet implemented");
+    }
+
+    /// @dev Process all trades for EOA orders one at a time returning the
+    /// computed net in and out transfers for the trades.
+    ///
+    /// This method reverts if processing of any single trade fails. See
+    /// [`processOrder`] for more details.
+    /// @param tokens An array of ERC20 tokens to be traded in the settlement.
+    /// @param clearingPrices An array of token clearing prices.
+    /// @param encodedTrades Encoded trades for signed EOA orders.
+    /// @return inTransfers Array of transfers into the settlement contract.
+    /// @return outTransfers Array of transfers to pay out to EOAs.
+    function processTrades(
+        IERC20[] calldata tokens,
+        uint256[] calldata clearingPrices,
+        bytes calldata encodedTrades
+    )
+        internal
+        returns (
+            GPv2AllowanceManager.Transfer[] memory inTransfers,
+            GPv2AllowanceManager.Transfer[] memory outTransfers
+        )
+    {
+        uint256 tradeCount = encodedTrades.tradeCount();
+        inTransfers = new GPv2AllowanceManager.Transfer[](tradeCount);
+        outTransfers = new GPv2AllowanceManager.Transfer[](tradeCount);
+
+        GPv2Encoding.Trade memory trade;
+        for (uint256 i = 0; i < tradeCount; i++) {
+            encodedTrades.tradeAtIndex(i).decodeTrade(
+                domainSeparator,
+                tokens,
+                trade
+            );
+            processTrade(
+                trade,
+                clearingPrices[trade.sellTokenIndex],
+                clearingPrices[trade.buyTokenIndex],
+                inTransfers[i],
+                outTransfers[i]
+            );
+        }
+    }
+
+    /// @dev Process trades for a single EOA order.
+    /// @param trade The trade to process.
+    /// @param sellPrice The price of the order's sell token.
+    /// @param buyPrice The price of the order's buy token.
+    /// @param inTransfer Memory location to set computed tranfer into the
+    /// settlement contract to execute trade.
+    /// @param outTransfer Memory location to set computed transfer out to order
+    /// owner to execute trade.
+    function processTrade(
+        GPv2Encoding.Trade memory trade,
+        uint256 sellPrice,
+        uint256 buyPrice,
+        GPv2AllowanceManager.Transfer memory inTransfer,
+        GPv2AllowanceManager.Transfer memory outTransfer
+    ) private {
+        GPv2Encoding.Order memory order = trade.order;
+
+        // NOTE: Currently, the above instanciation allocates an unitialized
+        // `Order` that gets never used. Adjust the free memory pointer to free
+        // the unused memory by subtracting `sizeof(Order) == 288` bytes.
+        // <https://solidity.readthedocs.io/en/v0.7.5/internals/layout_in_memory.html>
+        // TODO: Remove this once the following fix is merged and released:
+        // <https://github.com/ethereum/solidity/pull/10341>
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            mstore(0x40, sub(mload(0x40), 288))
+        }
+
+        inTransfer.owner = trade.owner;
+        inTransfer.token = order.sellToken;
+        outTransfer.owner = trade.owner;
+        outTransfer.token = order.buyToken;
+
+        if (order.kind == GPv2Encoding.OrderKind.Sell) {
+            uint256 executedSellAmount;
+            if (order.partiallyFillable) {
+                executedSellAmount = trade.executedAmount;
+            } else {
+                executedSellAmount = order.sellAmount;
+            }
+
+            inTransfer.amount = executedSellAmount;
+            outTransfer.amount = executedSellAmount.mul(buyPrice).div(
+                sellPrice
+            );
+        } else {
+            uint256 executedBuyAmount;
+            if (order.partiallyFillable) {
+                executedBuyAmount = trade.executedAmount;
+            } else {
+                executedBuyAmount = order.buyAmount;
+            }
+
+            inTransfer.amount = executedBuyAmount.mul(sellPrice).div(buyPrice);
+            outTransfer.amount = executedBuyAmount;
+        }
     }
 }

--- a/src/contracts/test/GPv2EncodingTestInterface.sol
+++ b/src/contracts/test/GPv2EncodingTestInterface.sol
@@ -39,8 +39,6 @@ contract GPv2EncodingTestInterface {
             uint256 gas_
         )
     {
-        // solhint-disable no-inline-assembly
-
         bytes32 domainSeparator = DOMAIN_SEPARATOR;
 
         uint256 tradeCount = encodedTrades.tradeCount();
@@ -50,6 +48,7 @@ contract GPv2EncodingTestInterface {
         // before and after decoding a trade to compute memory usage growth per
         // call to `decodeTrade`. Additionally, write 0 past the free memory
         // pointer so the size of `trades` does not affect the gas measurement.
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             mem := mload(0x40)
             mstore(mem, 0)
@@ -64,11 +63,10 @@ contract GPv2EncodingTestInterface {
             );
         }
 
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             mem := sub(mload(0x40), mem)
         }
         gas_ = gas_ - gasleft();
-
-        // solhint-enable
     }
 }

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 pragma solidity ^0.7.5;
+pragma abicoder v2;
 
+import "../GPv2AllowanceManager.sol";
 import "../GPv2Settlement.sol";
 
 contract GPv2SettlementTestInterface is GPv2Settlement {
@@ -17,5 +19,45 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
 
     function allowanceManagerTest() external view returns (address) {
         return address(allowanceManager);
+    }
+
+    function processTradesTest(
+        IERC20[] calldata tokens,
+        uint256[] calldata clearingPrices,
+        bytes calldata encodedTrades
+    )
+        external
+        view
+        returns (
+            GPv2AllowanceManager.Transfer[] memory inTransfers,
+            GPv2AllowanceManager.Transfer[] memory outTransfers
+        )
+    {
+        (inTransfers, outTransfers) = processTrades(
+            tokens,
+            clearingPrices,
+            encodedTrades
+        );
+    }
+
+    function processTradeMemoryTest() external pure returns (uint256 mem) {
+        GPv2Encoding.Trade memory trade;
+        GPv2AllowanceManager.Transfer memory inTransfer;
+        GPv2AllowanceManager.Transfer memory outTransfer;
+
+        // NOTE: Solidity stores the free memory pointer at address 0x40. Read
+        // it before and after calling `processOrder` to ensure that there are
+        // no memory allocations.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            mem := mload(0x40)
+        }
+
+        processTrade(trade, 1, 1, inTransfer, outTransfer);
+
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            mem := sub(mload(0x40), mem)
+        }
     }
 }

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -218,6 +218,24 @@ export class SettlementEncoder {
   }
 
   /**
+   * Returns a clearing price vector for the current settlement tokens from the
+   * provided price map.
+   * @param prices The price map from token address to price.
+   * @return The price vector.
+   */
+  public clearingPrices(
+    prices: Record<string, BigNumberish | undefined>,
+  ): BigNumberish[] {
+    return this.tokens.map((token) => {
+      const price = prices[token];
+      if (price === undefined) {
+        throw new Error(`"missing price for token ${token}`);
+      }
+      return price;
+    });
+  }
+
+  /**
    * Encodes a trade from a signed order and executed amount, appending it to
    * the `calldata` bytes that are being built.
    *

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -229,7 +229,7 @@ export class SettlementEncoder {
     return this.tokens.map((token) => {
       const price = prices[token];
       if (price === undefined) {
-        throw new Error(`"missing price for token ${token}`);
+        throw new Error(`missing price for token ${token}`);
       }
       return price;
     });

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -93,22 +93,10 @@ describe("GPv2Encoding", () => {
   describe("tradeCount", () => {
     it("should compute the number of encoded trades", async () => {
       const tradeCount = 10;
-      const order = {
-        sellToken: ethers.constants.AddressZero,
-        buyToken: ethers.constants.AddressZero,
-        sellAmount: 0,
-        buyAmount: 0,
-        validTo: 0,
-        appData: 0,
-        tip: 0,
-        kind: OrderKind.SELL,
-        partiallyFillable: false,
-      };
-
       const encoder = new SettlementEncoder(testDomain);
       for (let i = 0; i < tradeCount; i++) {
         await encoder.signEncodeTrade(
-          order,
+          { ...sampleOrder, appData: i },
           0,
           traders[0],
           SigningScheme.TYPED_DATA,

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -1,13 +1,37 @@
 import { expect } from "chai";
-import { Contract } from "ethers";
+import { BigNumber, Contract, TypedDataDomain } from "ethers";
 import { artifacts, ethers, waffle } from "hardhat";
 
-import { allowanceManagerAddress, domain } from "../src/ts";
+import {
+  OrderKind,
+  SettlementEncoder,
+  SigningScheme,
+  allowanceManagerAddress,
+  domain,
+} from "../src/ts";
+
+interface Transfer {
+  owner: string;
+  token: string;
+  amount: BigNumber;
+}
+
+function parseTransfers(transfers: unknown[][][]): [Transfer[], Transfer[]] {
+  const parseTransfer = (transfer: unknown[]) => ({
+    owner: transfer[0] as string,
+    token: transfer[1] as string,
+    amount: transfer[2] as BigNumber,
+  });
+
+  return [transfers[0].map(parseTransfer), transfers[1].map(parseTransfer)];
+}
 
 describe("GPv2Settlement", () => {
-  const [deployer, owner, solver] = waffle.provider.getWallets();
-  let settlement: Contract;
+  const [deployer, owner, solver, ...traders] = waffle.provider.getWallets();
+
   let authenticator: Contract;
+  let settlement: Contract;
+  let testDomain: TypedDataDomain;
 
   beforeEach(async () => {
     const GPv2AllowListAuthentication = await ethers.getContractFactory(
@@ -21,17 +45,15 @@ describe("GPv2Settlement", () => {
       deployer,
     );
     settlement = await GPv2Settlement.deploy(authenticator.address);
+
+    const { chainId } = await ethers.provider.getNetwork();
+    testDomain = domain(chainId, settlement.address);
   });
 
   describe("domainSeparator", () => {
     it("should have an EIP-712 domain separator", async () => {
-      const { chainId } = await ethers.provider.getNetwork();
-
-      expect(chainId).to.not.equal(ethers.constants.Zero);
       expect(await settlement.domainSeparatorTest()).to.equal(
-        ethers.utils._TypedDataEncoder.hashDomain(
-          domain(chainId, settlement.address),
-        ),
+        ethers.utils._TypedDataEncoder.hashDomain(testDomain),
       );
     });
 
@@ -127,6 +149,215 @@ describe("GPv2Settlement", () => {
       await expect(
         settlement.connect(solver).settle([], [], 0, [], [], []),
       ).revertedWith("Final: not yet implemented");
+    });
+  });
+
+  describe("processTrades", () => {
+    const tokens = [`0x${"11".repeat(20)}`, `0x${"22".repeat(20)}`];
+    const prices = {
+      [tokens[0]]: 1,
+      [tokens[1]]: 2,
+    };
+    const partialOrder = {
+      sellToken: tokens[0],
+      buyToken: tokens[1],
+      sellAmount: ethers.utils.parseEther("42"),
+      buyAmount: ethers.utils.parseEther("13.37"),
+      validTo: 0xffffffff,
+      appData: 0,
+      tip: ethers.constants.Zero,
+    };
+
+    it("should compute in/out transfers for multiple trades", async () => {
+      const tradeCount = 10;
+      const encoder = new SettlementEncoder(testDomain);
+      for (let i = 0; i < tradeCount; i++) {
+        await encoder.signEncodeTrade(
+          {
+            ...partialOrder,
+            kind: OrderKind.BUY,
+            partiallyFillable: true,
+          },
+          ethers.utils.parseEther("0.7734"),
+          traders[0],
+          SigningScheme.TYPED_DATA,
+        );
+      }
+
+      const [inTransfers, outTransfers] = parseTransfers(
+        await settlement.processTradesTest(
+          encoder.tokens,
+          encoder.clearingPrices(prices),
+          encoder.encodedTrades,
+        ),
+      );
+
+      expect(inTransfers.length).to.equal(tradeCount);
+      expect(outTransfers.length).to.equal(tradeCount);
+    });
+
+    describe("Order Variations", async () => {
+      const { sellAmount, buyAmount } = partialOrder;
+      const executedAmount = ethers.utils.parseEther("10.0");
+      const processTradeVariant = async (
+        kind: OrderKind,
+        partiallyFillable: boolean,
+      ) => {
+        const encoder = new SettlementEncoder(testDomain);
+        await encoder.signEncodeTrade(
+          {
+            ...partialOrder,
+            kind,
+            partiallyFillable,
+          },
+          executedAmount,
+          traders[0],
+          SigningScheme.TYPED_DATA,
+        );
+
+        const [
+          [{ amount: executedSellAmount }],
+          [{ amount: executedBuyAmount }],
+        ] = parseTransfers(
+          await settlement.processTradesTest(
+            encoder.tokens,
+            encoder.clearingPrices(prices),
+            encoder.encodedTrades,
+          ),
+        );
+
+        const [sellPrice, buyPrice] = [
+          prices[partialOrder.sellToken],
+          prices[partialOrder.buyToken],
+        ];
+
+        return { executedSellAmount, sellPrice, executedBuyAmount, buyPrice };
+      };
+
+      it("should compute amounts for fill-or-kill sell orders", async () => {
+        const {
+          executedSellAmount,
+          sellPrice,
+          executedBuyAmount,
+          buyPrice,
+        } = await processTradeVariant(OrderKind.SELL, false);
+
+        expect(executedSellAmount).to.deep.equal(sellAmount);
+        expect(executedBuyAmount).to.deep.equal(
+          sellAmount.mul(buyPrice).div(sellPrice),
+        );
+      });
+
+      it("should compute amounts for fill-or-kill buy orders", async () => {
+        const {
+          executedSellAmount,
+          sellPrice,
+          executedBuyAmount,
+          buyPrice,
+        } = await processTradeVariant(OrderKind.BUY, false);
+
+        expect(executedSellAmount).to.deep.equal(
+          buyAmount.mul(sellPrice).div(buyPrice),
+        );
+        expect(executedBuyAmount).to.deep.equal(buyAmount);
+      });
+
+      it("should compute amounts for partially fillable sell orders", async () => {
+        const {
+          executedSellAmount,
+          sellPrice,
+          executedBuyAmount,
+          buyPrice,
+        } = await processTradeVariant(OrderKind.SELL, true);
+
+        expect(executedSellAmount).to.deep.equal(executedAmount);
+        expect(executedBuyAmount).to.deep.equal(
+          executedAmount.mul(buyPrice).div(sellPrice),
+        );
+      });
+
+      it("should compute amounts for partially fillable buy orders", async () => {
+        const {
+          executedSellAmount,
+          sellPrice,
+          executedBuyAmount,
+          buyPrice,
+        } = await processTradeVariant(OrderKind.BUY, true);
+
+        expect(executedSellAmount).to.deep.equal(
+          executedAmount.mul(sellPrice).div(buyPrice),
+        );
+        expect(executedBuyAmount).to.deep.equal(executedAmount);
+      });
+    });
+
+    it("should ignore the executed trade amount for fill-or-kill orders", async () => {
+      const order = {
+        ...partialOrder,
+        kind: OrderKind.BUY,
+        partiallyFillable: false,
+      };
+
+      const encoder = new SettlementEncoder(testDomain);
+      await encoder.signEncodeTrade(
+        order,
+        0,
+        traders[0],
+        SigningScheme.TYPED_DATA,
+      );
+      await encoder.signEncodeTrade(
+        order,
+        ethers.utils.parseEther("1.0"),
+        traders[0],
+        SigningScheme.TYPED_DATA,
+      );
+
+      const [inTransfers, outTransfers] = parseTransfers(
+        await settlement.processTradesTest(
+          encoder.tokens,
+          encoder.clearingPrices(prices),
+          encoder.encodedTrades,
+        ),
+      );
+
+      expect(inTransfers[0]).to.deep.equal(inTransfers[1]);
+      expect(outTransfers[0]).to.deep.equal(outTransfers[1]);
+    });
+
+    it("should add the tip to the in transfer", async () => {
+      const tip = ethers.utils.parseEther("10");
+      const order = {
+        ...partialOrder,
+        tip,
+        kind: OrderKind.SELL,
+        partiallyFillable: false,
+      };
+
+      const encoder = new SettlementEncoder(testDomain);
+      await encoder.signEncodeTrade(
+        order,
+        0,
+        traders[0],
+        SigningScheme.TYPED_DATA,
+      );
+
+      const [[inTransfer]] = parseTransfers(
+        await settlement.processTradesTest(
+          encoder.tokens,
+          encoder.clearingPrices(prices),
+          encoder.encodedTrades,
+        ),
+      );
+
+      expect(inTransfer.amount).to.deep.equal(order.sellAmount.add(tip));
+    });
+  });
+
+  describe("processTrade", () => {
+    it("should not allocate additional memory", async () => {
+      expect(await settlement.processTradeMemoryTest()).to.deep.equal(
+        ethers.constants.Zero,
+      );
     });
   });
 });

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -125,7 +125,7 @@ describe("GPv2Settlement", () => {
       // TODO - this will have to be changed when other constraints become active
       // and when settle function no longer reverts.
       await expect(
-        settlement.connect(solver.address).settle([], [], 0, [], [], []),
+        settlement.connect(solver).settle([], [], 0, [], [], []),
       ).revertedWith("Final: not yet implemented");
     });
   });


### PR DESCRIPTION
This PR adds an initial implementation of the order processing, computing the input and output transfer amounts required to execute the decoded trades.

Currently, this implementation **DOES NOT**:
- verify limit price is respected
- add fees
- verify order is not being replayed
- etc.

### Test Plan

Added unit tests covering all the order variants which change the computation for input and output amounts as well as some other test.
