### PR TITLE
rename processTrade to computeTradeExecution

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -137,7 +137,7 @@ contract GPv2Settlement {
     /// @param encodedTrades Encoded trades for signed EOA orders.
     /// @return inTransfers Array of transfers into the settlement contract.
     /// @return outTransfers Array of transfers to pay out to EOAs.
-    function processTrades(
+    function computeTradeExecutions(
         IERC20[] calldata tokens,
         uint256[] calldata clearingPrices,
         bytes calldata encodedTrades
@@ -160,7 +160,7 @@ contract GPv2Settlement {
                 tokens,
                 trade
             );
-            processTrade(
+            computeTradeExecution(
                 trade,
                 clearingPrices[trade.sellTokenIndex],
                 clearingPrices[trade.buyTokenIndex],
@@ -178,7 +178,7 @@ contract GPv2Settlement {
     /// settlement contract to execute trade.
     /// @param outTransfer Memory location to set computed transfer out to order
     /// owner to execute trade.
-    function processTrade(
+    function computeTradeExecution(
         GPv2Encoding.Trade memory trade,
         uint256 sellPrice,
         uint256 buyPrice,

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -21,7 +21,7 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
         return address(allowanceManager);
     }
 
-    function processTradesTest(
+    function computeTradeExecutionsTest(
         IERC20[] calldata tokens,
         uint256[] calldata clearingPrices,
         bytes calldata encodedTrades
@@ -33,14 +33,18 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
             GPv2AllowanceManager.Transfer[] memory outTransfers
         )
     {
-        (inTransfers, outTransfers) = processTrades(
+        (inTransfers, outTransfers) = computeTradeExecutions(
             tokens,
             clearingPrices,
             encodedTrades
         );
     }
 
-    function processTradeMemoryTest() external pure returns (uint256 mem) {
+    function computeTradeExecutionMemoryTest()
+        external
+        pure
+        returns (uint256 mem)
+    {
         GPv2Encoding.Trade memory trade;
         GPv2AllowanceManager.Transfer memory inTransfer;
         GPv2AllowanceManager.Transfer memory outTransfer;
@@ -53,7 +57,7 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
             mem := mload(0x40)
         }
 
-        processTrade(trade, 1, 1, inTransfer, outTransfer);
+        computeTradeExecution(trade, 1, 1, inTransfer, outTransfer);
 
         // solhint-disable-next-line no-inline-assembly
         assembly {

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -142,7 +142,7 @@ describe("GPv2Settlement", () => {
     });
   });
 
-  describe("processTrades", () => {
+  describe("computeTradeExecutions", () => {
     const tokens = [`0x${"11".repeat(20)}`, `0x${"22".repeat(20)}`];
     const prices = {
       [tokens[0]]: 1,
@@ -175,7 +175,7 @@ describe("GPv2Settlement", () => {
       }
 
       const [inTransfers, outTransfers] = parseTransfers(
-        await settlement.processTradesTest(
+        await settlement.computeTradeExecutionsTest(
           encoder.tokens,
           encoder.clearingPrices(prices),
           encoder.encodedTrades,
@@ -189,7 +189,7 @@ describe("GPv2Settlement", () => {
     describe("Order Variations", async () => {
       const { sellAmount, buyAmount } = partialOrder;
       const executedAmount = ethers.utils.parseEther("10.0");
-      const processTradeVariant = async (
+      const computeTradeExecutionVariant = async (
         kind: OrderKind,
         partiallyFillable: boolean,
       ) => {
@@ -209,7 +209,7 @@ describe("GPv2Settlement", () => {
           [{ amount: executedSellAmount }],
           [{ amount: executedBuyAmount }],
         ] = parseTransfers(
-          await settlement.processTradesTest(
+          await settlement.computeTradeExecutionsTest(
             encoder.tokens,
             encoder.clearingPrices(prices),
             encoder.encodedTrades,
@@ -230,7 +230,7 @@ describe("GPv2Settlement", () => {
           sellPrice,
           executedBuyAmount,
           buyPrice,
-        } = await processTradeVariant(OrderKind.SELL, false);
+        } = await computeTradeExecutionVariant(OrderKind.SELL, false);
 
         expect(executedSellAmount).to.deep.equal(sellAmount);
         expect(executedBuyAmount).to.deep.equal(
@@ -244,7 +244,7 @@ describe("GPv2Settlement", () => {
           sellPrice,
           executedBuyAmount,
           buyPrice,
-        } = await processTradeVariant(OrderKind.BUY, false);
+        } = await computeTradeExecutionVariant(OrderKind.BUY, false);
 
         expect(executedSellAmount).to.deep.equal(
           buyAmount.mul(sellPrice).div(buyPrice),
@@ -258,7 +258,7 @@ describe("GPv2Settlement", () => {
           sellPrice,
           executedBuyAmount,
           buyPrice,
-        } = await processTradeVariant(OrderKind.SELL, true);
+        } = await computeTradeExecutionVariant(OrderKind.SELL, true);
 
         expect(executedSellAmount).to.deep.equal(executedAmount);
         expect(executedBuyAmount).to.deep.equal(
@@ -272,7 +272,7 @@ describe("GPv2Settlement", () => {
           sellPrice,
           executedBuyAmount,
           buyPrice,
-        } = await processTradeVariant(OrderKind.BUY, true);
+        } = await computeTradeExecutionVariant(OrderKind.BUY, true);
 
         expect(executedSellAmount).to.deep.equal(
           executedAmount.mul(sellPrice).div(buyPrice),
@@ -303,7 +303,7 @@ describe("GPv2Settlement", () => {
       );
 
       const [inTransfers, outTransfers] = parseTransfers(
-        await settlement.processTradesTest(
+        await settlement.computeTradeExecutionsTest(
           encoder.tokens,
           encoder.clearingPrices(prices),
           encoder.encodedTrades,
@@ -332,7 +332,7 @@ describe("GPv2Settlement", () => {
       );
 
       const [[inTransfer]] = parseTransfers(
-        await settlement.processTradesTest(
+        await settlement.computeTradeExecutionsTest(
           encoder.tokens,
           encoder.clearingPrices(prices),
           encoder.encodedTrades,
@@ -343,9 +343,9 @@ describe("GPv2Settlement", () => {
     });
   });
 
-  describe("processTrade", () => {
+  describe("computeTradeExecution", () => {
     it("should not allocate additional memory", async () => {
-      expect(await settlement.processTradeMemoryTest()).to.deep.equal(
+      expect(await settlement.computeTradeExecutionMemoryTest()).to.deep.equal(
         ethers.constants.Zero,
       );
     });


### PR DESCRIPTION
This PR renames `processTrade` to `computeTradeExecution` as discussed here: https://github.com/gnosis/oba-contracts/pull/184#discussion_r530807417. The PR was accidentally merged without that modification.

### Test Plan

CI still passes.
