### PR TITLE
Check limit price when computing trade execution

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -159,7 +159,10 @@ contract GPv2Settlement {
         }
     }
 
-    /// @dev Process trades for a single EOA order.
+    /// @dev Compute the in and out transfer amounts for a single EOA order
+    /// trade. This function reverts if:
+    /// - The order's limit price is not respected.
+    ///
     /// @param trade The trade to process.
     /// @param sellPrice The price of the order's sell token.
     /// @param buyPrice The price of the order's buy token.
@@ -196,12 +199,23 @@ contract GPv2Settlement {
         // amount_x * price_x = amount_y * price_y
         // ```
         // Intuitively, if a chocolate bar is 0,50€ and a beer is 4€, 1 beer
-        // is roughly worth 8 chocolate bars (`1 * 4 = 8 * 0.5`). This means
-        // that for computing the amount of token `y` equivalent to some amount
-        // of token `x` given the clearing prices, the equation is:
+        // is roughly worth 8 chocolate bars (`1 * 4 = 8 * 0.5`). From this
+        // equation, we can derive:
+        // - The limit price for selling `x` and buying `y` is respected iff
+        // ```
+        // limit_x * price_x >= limit_y * price_y
+        // ```
+        // - The executed amount of token `y` given some amount of `x` and
+        //   clearing prices is:
         // ```
         // amount_y = amount_x * price_x / price_y
         // ```
+
+        require(
+            order.sellAmount * sellPrice >= order.buyAmount * buyPrice,
+            "GPv2: limit price not respected"
+        );
+
         if (order.kind == GPv2Encoding.OrderKind.Sell) {
             uint256 executedSellAmount;
             if (order.partiallyFillable) {

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -212,7 +212,7 @@ contract GPv2Settlement {
         // ```
 
         require(
-            order.sellAmount * sellPrice >= order.buyAmount * buyPrice,
+            order.sellAmount.mul(sellPrice) >= order.buyAmount.mul(buyPrice),
             "GPv2: limit price not respected"
         );
 

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -214,7 +214,7 @@ describe("GPv2Settlement", () => {
         SigningScheme.TYPED_DATA,
       );
 
-      expect(toNumberLossy(sellAmount.mul(sellPrice))).to.be.lessThan(
+      expect(toNumberLossy(sellAmount.mul(sellPrice))).not.to.be.gte(
         toNumberLossy(buyAmount.mul(buyPrice)),
       );
       await expect(

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -143,14 +143,15 @@ describe("GPv2Settlement", () => {
   });
 
   describe("computeTradeExecutions", () => {
-    const tokens = [`0x${"11".repeat(20)}`, `0x${"22".repeat(20)}`];
+    const sellToken = `0x${"11".repeat(20)}`;
+    const buyToken = `0x${"22".repeat(20)}`;
     const prices = {
-      [tokens[0]]: 1,
-      [tokens[1]]: 2,
+      [sellToken]: 1,
+      [buyToken]: 2,
     };
     const partialOrder = {
-      sellToken: tokens[0],
-      buyToken: tokens[1],
+      sellToken,
+      buyToken,
       sellAmount: ethers.utils.parseEther("42"),
       buyAmount: ethers.utils.parseEther("13.37"),
       validTo: 0xffffffff,
@@ -203,9 +204,9 @@ describe("GPv2Settlement", () => {
         settlement.computeTradeExecutionsTest(
           encoder.tokens,
           encoder.clearingPrices({
-            [tokens[0]]: 1,
-            // NOTE: The price of the buy token is too high!
-            [tokens[1]]: 1000,
+            [sellToken]: 1,
+            // NOTE: The price of the buy token is way too high!
+            [buyToken]: 1000,
           }),
           encoder.encodedTrades,
         ),
@@ -229,8 +230,8 @@ describe("GPv2Settlement", () => {
       const executions = settlement.computeTradeExecutionsTest(
         encoder.tokens,
         encoder.clearingPrices({
-          [tokens[0]]: buyAmount,
-          [tokens[1]]: sellAmount,
+          [sellToken]: buyAmount,
+          [buyToken]: sellAmount,
         }),
         encoder.encodedTrades,
       );


### PR DESCRIPTION
Closes #205

This PR adds a check to ensure that the order's limit price is respected by the settlement clearing price.

### Test Plan

Added new unit tests to make sure it works
