### PR TITLE
Only use fixed fees

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -89,14 +89,6 @@ contract GPv2Settlement {
     ///     settlement
     ///   - Critically, user orders are entirely protected
     ///
-    /// Note that settlements can specify fees encoded as a fee factor.  The fee
-    /// factor to use for the trade. The actual fee is computed as
-    /// `1 / feeFactor`. This means that the received amount is expected to be
-    /// `executedBuyAmount * (feeFactor - 1) / feeFactor`. Note that a value of
-    /// `0` is reserved to mean no fees. This is useful for example when
-    /// settling directly with Uniswap where we don't want users to incur
-    /// additional fees.
-    ///
     /// Note that some parameters are encoded as packed bytes in order to save
     /// calldata gas. For more information on encoding format consult the
     /// [`GPv2Encoding`] library.
@@ -105,7 +97,6 @@ contract GPv2Settlement {
     /// Orders and interactions encode tokens as indices into this array.
     /// @param clearingPrices An array of clearing prices where the `i`-th price
     /// is for the `i`-th token in the [`tokens`] array.
-    /// @param feeFactor The fee factor to use for the trade.
     /// @param encodedTrades Encoded trades for signed EOA orders.
     /// @param encodedInteractions Encoded smart contract interactions.
     /// @param encodedOrderRefunds Encoded order refunds for clearing storage
@@ -113,14 +104,12 @@ contract GPv2Settlement {
     function settle(
         IERC20[] calldata tokens,
         uint256[] calldata clearingPrices,
-        uint256 feeFactor,
         bytes calldata encodedTrades,
         bytes calldata encodedInteractions,
         bytes calldata encodedOrderRefunds
     ) external view onlySolver {
         require(tokens.length == 0, "not yet implemented");
         require(clearingPrices.length == 0, "not yet implemented");
-        require(feeFactor == 0, "not yet implemented");
         require(encodedTrades.length == 0, "not yet implemented");
         require(encodedInteractions.length == 0, "not yet implemented");
         require(encodedOrderRefunds.length == 0, "not yet implemented");
@@ -240,6 +229,6 @@ contract GPv2Settlement {
             outTransfer.amount = executedBuyAmount;
         }
 
-        inTransfer.amount = inTransfer.amount.add(order.tip);
+        inTransfer.amount = inTransfer.amount.add(order.feeAmount);
     }
 }

--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -15,7 +15,7 @@ library GPv2Encoding {
         uint256 buyAmount;
         uint32 validTo;
         uint32 appData;
-        uint256 tip;
+        uint256 feeAmount;
         OrderKind kind;
         bool partiallyFillable;
     }
@@ -35,14 +35,14 @@ library GPv2Encoding {
     ///         "uint256 buyAmount," +
     ///         "uint32 validTo," +
     ///         "uint32 appData," +
-    ///         "uint256 tip," +
+    ///         "uint256 feeAmount," +
     ///         "uint8 kind," +
     ///         "bool partiallyFillable" +
     ///     ")"
     /// );
     /// ```
     bytes32 internal constant ORDER_TYPE_HASH =
-        hex"23428e7b8eed4e2df6f66591da9a09de9a88ce5b69f7ae818818afffb53da045";
+        hex"b71968fcf5e55b9c3370f2809d4078a4695be79dfa43e5aa1f2baa0a9b84f186";
 
     /// @dev A struct representing a trade to be executed as part a batch
     /// settlement.
@@ -115,7 +115,7 @@ library GPv2Encoding {
     ///     uint256 buyAmount;
     ///     uint32 validTo;
     ///     uint32 appData;
-    ///     uint256 tip;
+    ///     uint256 feeAmount;
     ///     uint8 flags;
     ///     uint256 executedAmount;
     ///     Signature {
@@ -196,7 +196,7 @@ library GPv2Encoding {
                 add(order, 160),
                 shr(224, calldataload(add(encodedTrade.offset, 70)))
             )
-            // order.tip = uint256(encodedTrade[74:106])
+            // order.feeAmount = uint256(encodedTrade[74:106])
             mstore(add(order, 192), calldataload(add(encodedTrade.offset, 74)))
             // flags = uint8(encodedTrade[106])
             flags := shr(248, calldataload(add(encodedTrade.offset, 106)))

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -84,13 +84,9 @@ export interface Order {
    */
   appData: number;
   /**
-   * Additional fee to give to the protocol.
-   *
-   * This tip is used to offset solution submission gas costs so orders that
-   * aren't economically viable (i.e. small orders that do not generate enough
-   * fees) still get executed.
+   * Fee to give to the protocol.
    */
-  tip: BigNumberish;
+  feeAmount: BigNumberish;
   /**
    * The order kind.
    */
@@ -130,7 +126,7 @@ export const ORDER_TYPE_FIELDS = [
   { name: "buyAmount", type: "uint256" },
   { name: "validTo", type: "uint32" },
   { name: "appData", type: "uint32" },
-  { name: "tip", type: "uint256" },
+  { name: "feeAmount", type: "uint256" },
   { name: "kind", type: "uint8" },
   { name: "partiallyFillable", type: "bool" },
 ];
@@ -276,7 +272,7 @@ export class SettlementEncoder {
         order.buyAmount,
         timestamp(order.validTo),
         order.appData,
-        order.tip,
+        order.feeAmount,
         encodeOrderFlags(order),
         executedAmount,
         encodeSigningScheme(sig.v, scheme),

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -38,7 +38,7 @@ function parseTrade(trade: unknown[]): Trade {
       buyAmount: order[3] as BigNumber,
       validTo: order[4] as number,
       appData: order[5] as number,
-      tip: order[6] as BigNumber,
+      feeAmount: order[6] as BigNumber,
       kind: order[7] as OrderKind,
       partiallyFillable: order[8] as boolean,
     },
@@ -61,7 +61,7 @@ describe("GPv2Encoding", () => {
     buyAmount: ethers.utils.parseEther("13.37"),
     validTo: 0xffffffff,
     appData: 0,
-    tip: ethers.constants.WeiPerEther,
+    feeAmount: ethers.utils.parseEther("1.0"),
     kind: OrderKind.SELL,
     partiallyFillable: false,
   };
@@ -136,7 +136,7 @@ describe("GPv2Encoding", () => {
         buyAmount: fillUint(256, 0x04),
         validTo: fillUint(32, 0x05).toNumber(),
         appData: fillUint(32, 0x06).toNumber(),
-        tip: fillUint(256, 0x07),
+        feeAmount: fillUint(256, 0x07),
         kind: OrderKind.BUY,
         partiallyFillable: true,
       };

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -127,7 +127,7 @@ describe("GPv2Settlement", () => {
 
   describe("settle", () => {
     it("rejects transactions from non-solvers", async () => {
-      await expect(settlement.settle([], [], 0, [], [], [])).to.be.revertedWith(
+      await expect(settlement.settle([], [], [], [], [])).to.be.revertedWith(
         "GPv2: not a solver",
       );
     });
@@ -137,7 +137,7 @@ describe("GPv2Settlement", () => {
       // TODO - this will have to be changed when other constraints become active
       // and when settle function no longer reverts.
       await expect(
-        settlement.connect(solver).settle([], [], 0, [], [], []),
+        settlement.connect(solver).settle([], [], [], [], []),
       ).revertedWith("Final: not yet implemented");
     });
   });
@@ -155,7 +155,7 @@ describe("GPv2Settlement", () => {
       buyAmount: ethers.utils.parseEther("13.37"),
       validTo: 0xffffffff,
       appData: 0,
-      tip: ethers.constants.Zero,
+      feeAmount: ethers.constants.Zero,
     };
 
     it("should compute in/out transfers for multiple trades", async () => {
@@ -358,11 +358,11 @@ describe("GPv2Settlement", () => {
       expect(outTransfers[0]).to.deep.equal(outTransfers[1]);
     });
 
-    it("should add the tip to the in transfer", async () => {
-      const tip = ethers.utils.parseEther("10");
+    it("should add the fee to the in transfer", async () => {
+      const feeAmount = ethers.utils.parseEther("10");
       const order = {
         ...partialOrder,
-        tip,
+        feeAmount,
         kind: OrderKind.SELL,
         partiallyFillable: false,
       };
@@ -383,7 +383,7 @@ describe("GPv2Settlement", () => {
         ),
       );
 
-      expect(inTransfer.amount).to.deep.equal(order.sellAmount.add(tip));
+      expect(inTransfer.amount).to.deep.equal(order.sellAmount.add(feeAmount));
     });
   });
 


### PR DESCRIPTION
With @e00E proposal for modifying the fee model, we now only have fixed fees per order (formally the tip) and no longer use fees computed on the volume which can be removed from the `settle` function signature and documentation.

### Test Plan

Unit tests still pass.
