### PR TITLE
Check order has not expired

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -190,6 +190,7 @@ contract GPv2Settlement {
             mstore(0x40, sub(mload(0x40), 288))
         }
 
+        // solhint-disable-next-line not-rely-on-time
         require(order.validTo >= block.timestamp, "GPv2: order expired");
 
         inTransfer.owner = trade.owner;

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -161,6 +161,7 @@ contract GPv2Settlement {
 
     /// @dev Compute the in and out transfer amounts for a single EOA order
     /// trade. This function reverts if:
+    /// - The order has expired
     /// - The order's limit price is not respected.
     ///
     /// @param trade The trade to process.
@@ -176,7 +177,7 @@ contract GPv2Settlement {
         uint256 buyPrice,
         GPv2AllowanceManager.Transfer memory inTransfer,
         GPv2AllowanceManager.Transfer memory outTransfer
-    ) internal pure {
+    ) internal view {
         GPv2Encoding.Order memory order = trade.order;
         // NOTE: Currently, the above instanciation allocates an unitialized
         // `Order` that gets never used. Adjust the free memory pointer to free
@@ -188,6 +189,8 @@ contract GPv2Settlement {
         assembly {
             mstore(0x40, sub(mload(0x40), 288))
         }
+
+        require(order.validTo >= block.timestamp, "GPv2: order expired");
 
         inTransfer.owner = trade.owner;
         inTransfer.token = order.sellToken;

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -57,6 +57,7 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
             mem := mload(0x40)
         }
 
+        // solhint-disable-next-line not-rely-on-time
         trade.order.validTo = uint32(block.timestamp);
         computeTradeExecution(trade, 1, 1, inTransfer, outTransfer);
 

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -42,7 +42,7 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
 
     function computeTradeExecutionMemoryTest()
         external
-        pure
+        view
         returns (uint256 mem)
     {
         GPv2Encoding.Trade memory trade;
@@ -57,6 +57,7 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
             mem := mload(0x40)
         }
 
+        trade.order.validTo = uint32(block.timestamp);
         computeTradeExecution(trade, 1, 1, inTransfer, outTransfer);
 
         // solhint-disable-next-line no-inline-assembly

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -194,6 +194,30 @@ describe("GPv2Settlement", () => {
       expect(outTransfers.length).to.equal(tradeCount);
     });
 
+    it("should revert if the order expired", async () => {
+      const { timestamp } = await ethers.provider.getBlock("latest");
+      const encoder = new SettlementEncoder(testDomain);
+      await encoder.signEncodeTrade(
+        {
+          ...partialOrder,
+          validTo: timestamp - 1,
+          kind: OrderKind.SELL,
+          partiallyFillable: false,
+        },
+        0,
+        traders[0],
+        SigningScheme.TYPED_DATA,
+      );
+
+      await expect(
+        settlement.computeTradeExecutionsTest(
+          encoder.tokens,
+          encoder.clearingPrices(prices),
+          encoder.encodedTrades,
+        ),
+      ).to.be.revertedWith("order expired");
+    });
+
     it("should revert if the limit price is not respected", async () => {
       const sellAmount = ethers.utils.parseEther("100.0");
       const sellPrice = 1;


### PR DESCRIPTION
Closes #6 

This PR add order expiry check in the settlement contract (it existed in the old PreAMMBatcher implementation but had not been 
ported yet).

### Test Plan

Unit test.
