### PR TITLE
Check filled amounts

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -301,10 +301,10 @@ contract GPv2Settlement {
         pure
         returns (bytes32 uid)
     {
-        // NOTE: Use the 64 bytes of scratch space for computing this hash
-        // instead of allocating. We hash a total of 52 bytes and write to
-        // memory in **reverse order** as memory operations write 32-bytes at a
-        // time but we want to use a packed encoding:
+        // NOTE: Use the 64 bytes of scratch space starting at memory address 0
+        // for computing this hash instead of allocating. We hash a total of 52
+        // bytes and write to memory in **reverse order** as memory operations
+        // write 32-bytes at a time and we want to use a packed encoding:
         //
         //       |           111111111122222222223333333333444444444455
         // byte  | 0123456789012345678901234567890123456789012345678901

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -148,7 +148,6 @@ contract GPv2Settlement {
         bytes calldata encodedTrades
     )
         internal
-        view
         returns (
             GPv2AllowanceManager.Transfer[] memory inTransfers,
             GPv2AllowanceManager.Transfer[] memory outTransfers
@@ -193,7 +192,7 @@ contract GPv2Settlement {
         uint256 buyPrice,
         GPv2AllowanceManager.Transfer memory inTransfer,
         GPv2AllowanceManager.Transfer memory outTransfer
-    ) internal view {
+    ) internal {
         GPv2Encoding.Order memory order = trade.order;
         // NOTE: Currently, the above instanciation allocates an unitialized
         // `Order` that gets never used. Adjust the free memory pointer to free
@@ -240,6 +239,9 @@ contract GPv2Settlement {
         uint256 executedBuyAmount;
         uint256 executedFeeAmount;
 
+        bytes32 uid = orderUid(trade.digest, trade.owner);
+        uint256 currentFilledAmount = filledAmount[uid];
+
         // NOTE: Don't use `SafeMath.div` anywhere here as it allocates a string
         // even if it does not revert. The method only checks that the divisor
         // is non-zero and `revert`s in that case instead of consuming all of
@@ -256,6 +258,12 @@ contract GPv2Settlement {
             }
 
             executedBuyAmount = executedSellAmount.mul(sellPrice) / buyPrice;
+
+            currentFilledAmount = currentFilledAmount.add(executedSellAmount);
+            require(
+                currentFilledAmount <= order.sellAmount,
+                "GPv2: order filled"
+            );
         } else {
             if (order.partiallyFillable) {
                 executedBuyAmount = trade.executedAmount;
@@ -268,10 +276,18 @@ contract GPv2Settlement {
             }
 
             executedSellAmount = executedBuyAmount.mul(buyPrice) / sellPrice;
+
+            currentFilledAmount = currentFilledAmount.add(executedBuyAmount);
+            require(
+                currentFilledAmount <= order.buyAmount,
+                "GPv2: order filled"
+            );
         }
 
         inTransfer.amount = executedSellAmount.add(executedFeeAmount);
         outTransfer.amount = executedBuyAmount;
+
+        filledAmount[uid] = currentFilledAmount;
     }
 
     /// @dev Compute a unique identifier that represents a user order.
@@ -283,8 +299,27 @@ contract GPv2Settlement {
     function orderUid(bytes32 orderDigest, address owner)
         private
         pure
-        returns (bytes32)
+        returns (bytes32 uid)
     {
-        return keccak256(abi.encodePacked(orderDigest, owner));
+        // NOTE: Use the 64 bytes of scratch space for computing this hash
+        // instead of allocating. We hash a total of 52 bytes and write to
+        // memory in **reverse order** as memory operations write 32-bytes at a
+        // time but we want to use a packed encoding:
+        //
+        //       |           111111111122222222223333333333444444444455
+        // byte  | 0123456789012345678901234567890123456789012345678901
+        // ------+-----------------------------------------------------
+        // field | [..........orderDigest.........][.......owner......]
+        // ------+-----------------------------------------------------
+        // write |                     [.............owner............]
+        //       | [..........orderDigest.........]
+        //
+        // <https://docs.soliditylang.org/en/v0.7.5/internals/layout_in_memory.html>
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            mstore(20, owner)
+            mstore(0, orderDigest)
+            uid := keccak256(0, 52)
+        }
     }
 }

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -304,15 +304,19 @@ contract GPv2Settlement {
         // NOTE: Use the 64 bytes of scratch space starting at memory address 0
         // for computing this hash instead of allocating. We hash a total of 52
         // bytes and write to memory in **reverse order** as memory operations
-        // write 32-bytes at a time and we want to use a packed encoding:
+        // write 32-bytes at a time and we want to use a packed encoding. This
+        // means, for example, that after writing the value of `owner` to bytes
+        // `20:52`, writing the `orderDigest` to bytes `0:32` will **overwrite**
+        // bytes `20:32`. This is desireable as addresses are only 20 bytes and
+        // `20:32` should be `0`s:
         //
-        //       |           111111111122222222223333333333444444444455
-        // byte  | 0123456789012345678901234567890123456789012345678901
-        // ------+-----------------------------------------------------
-        // field | [..........orderDigest.........][.......owner......]
-        // ------+-----------------------------------------------------
-        // write |                     [.............owner............]
-        //       | [..........orderDigest.........]
+        //        |           111111111122222222223333333333444444444455
+        //   byte | 0123456789012345678901234567890123456789012345678901
+        // -------+-----------------------------------------------------
+        //  field | [.........orderDigest..........][......owner.......]
+        // -------+-----------------------------------------------------
+        // mstore |                     [00000000000.......owner.......]
+        //        | [.........orderDigest..........]
         //
         // <https://docs.soliditylang.org/en/v0.7.5/internals/layout_in_memory.html>
         // solhint-disable-next-line no-inline-assembly

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -27,7 +27,6 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
         bytes calldata encodedTrades
     )
         external
-        view
         returns (
             GPv2AllowanceManager.Transfer[] memory inTransfers,
             GPv2AllowanceManager.Transfer[] memory outTransfers
@@ -40,11 +39,7 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
         );
     }
 
-    function computeTradeExecutionMemoryTest()
-        external
-        view
-        returns (uint256 mem)
-    {
+    function computeTradeExecutionMemoryTest() external returns (uint256 mem) {
         GPv2Encoding.Trade memory trade;
         GPv2AllowanceManager.Transfer memory inTransfer;
         GPv2AllowanceManager.Transfer memory outTransfer;

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -206,7 +206,7 @@ describe("GPv2Settlement", () => {
       }
 
       const [inTransfers, outTransfers] = parseTransfers(
-        await settlement.computeTradeExecutionsTest(
+        await settlement.callStatic.computeTradeExecutionsTest(
           encoder.tokens,
           encoder.clearingPrices(prices),
           encoder.encodedTrades,
@@ -265,7 +265,7 @@ describe("GPv2Settlement", () => {
         toNumberLossy(buyAmount.mul(buyPrice)),
       );
       await expect(
-        settlement.computeTradeExecutionsTest(
+        settlement.callStatic.computeTradeExecutionsTest(
           encoder.tokens,
           encoder.clearingPrices({
             [sellToken]: sellPrice,
@@ -290,7 +290,7 @@ describe("GPv2Settlement", () => {
       );
 
       const { sellAmount, buyAmount } = partialOrder;
-      const executions = settlement.computeTradeExecutionsTest(
+      const executions = settlement.callStatic.computeTradeExecutionsTest(
         encoder.tokens,
         encoder.clearingPrices({
           [sellToken]: buyAmount,
@@ -329,7 +329,7 @@ describe("GPv2Settlement", () => {
           [{ amount: executedSellAmount }],
           [{ amount: executedBuyAmount }],
         ] = parseTransfers(
-          await settlement.computeTradeExecutionsTest(
+          await settlement.callStatic.computeTradeExecutionsTest(
             encoder.tokens,
             encoder.clearingPrices(prices),
             encoder.encodedTrades,
@@ -489,7 +489,7 @@ describe("GPv2Settlement", () => {
         );
 
         const [[inTransfer]] = parseTransfers(
-          await settlement.computeTradeExecutionsTest(
+          await settlement.callStatic.computeTradeExecutionsTest(
             encoder.tokens,
             encoder.clearingPrices(prices),
             encoder.encodedTrades,
@@ -559,20 +559,20 @@ describe("GPv2Settlement", () => {
 
       const encoder = new SettlementEncoder(testDomain);
       await encoder.signEncodeTrade(
-        order,
+        { ...order, appData: 0 },
         0,
         traders[0],
         SigningScheme.TYPED_DATA,
       );
       await encoder.signEncodeTrade(
-        order,
+        { ...order, appData: 1 },
         ethers.utils.parseEther("1.0"),
         traders[0],
         SigningScheme.TYPED_DATA,
       );
 
       const [inTransfers, outTransfers] = parseTransfers(
-        await settlement.computeTradeExecutionsTest(
+        await settlement.callStatic.computeTradeExecutionsTest(
           encoder.tokens,
           encoder.clearingPrices(prices),
           encoder.encodedTrades,
@@ -586,9 +586,9 @@ describe("GPv2Settlement", () => {
 
   describe("computeTradeExecution", () => {
     it("should not allocate additional memory", async () => {
-      expect(await settlement.computeTradeExecutionMemoryTest()).to.deep.equal(
-        ethers.constants.Zero,
-      );
+      expect(
+        await settlement.callStatic.computeTradeExecutionMemoryTest(),
+      ).to.deep.equal(ethers.constants.Zero);
     });
   });
 });

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -10,6 +10,7 @@ import {
   allowanceManagerAddress,
   domain,
   computeOrderUid,
+  hashOrder,
 } from "../src/ts";
 
 import { builtAndDeployedMetadataCoincide } from "./bytecode";
@@ -547,6 +548,76 @@ describe("GPv2Settlement", () => {
         expect(transferAmount).to.deep.equal(
           executedSellAmount.add(executedFee),
         );
+      });
+    });
+
+    describe("Order Filled Amounts", () => {
+      const { sellAmount, buyAmount } = partialOrder;
+      const readOrderFilledAmountAfterProcessing = async (
+        { kind, partiallyFillable }: Pick<Order, "kind" | "partiallyFillable">,
+        executedAmount?: BigNumber,
+      ) => {
+        const order = {
+          ...partialOrder,
+          kind,
+          partiallyFillable,
+        };
+        const encoder = new SettlementEncoder(testDomain);
+        await encoder.signEncodeTrade(
+          order,
+          executedAmount || 0,
+          traders[0],
+          SigningScheme.TYPED_DATA,
+        );
+
+        await settlement.computeTradeExecutionsTest(
+          encoder.tokens,
+          encoder.clearingPrices(prices),
+          encoder.encodedTrades,
+        );
+
+        const orderUid = computeOrderUid(hashOrder(order), traders[0].address);
+        const filledAmount = await settlement.filledAmount(orderUid);
+
+        return filledAmount;
+      };
+
+      it("should fill the full sell amount for fill-or-kill sell orders", async () => {
+        const filledAmount = await readOrderFilledAmountAfterProcessing({
+          kind: OrderKind.SELL,
+          partiallyFillable: false,
+        });
+
+        expect(filledAmount).to.deep.equal(sellAmount);
+      });
+
+      it("should fill the full buy amount for fill-or-kill buy orders", async () => {
+        const filledAmount = await readOrderFilledAmountAfterProcessing({
+          kind: OrderKind.BUY,
+          partiallyFillable: false,
+        });
+
+        expect(filledAmount).to.deep.equal(buyAmount);
+      });
+
+      it("should fill the executed amount for partially filled sell orders", async () => {
+        const executedSellAmount = sellAmount.div(3);
+        const filledAmount = await readOrderFilledAmountAfterProcessing(
+          { kind: OrderKind.SELL, partiallyFillable: true },
+          executedSellAmount,
+        );
+
+        expect(filledAmount).to.deep.equal(executedSellAmount);
+      });
+
+      it("should fill the executed amount for partially filled buy orders", async () => {
+        const executedBuyAmount = buyAmount.div(4);
+        const filledAmount = await readOrderFilledAmountAfterProcessing(
+          { kind: OrderKind.BUY, partiallyFillable: true },
+          executedBuyAmount,
+        );
+
+        expect(filledAmount).to.deep.equal(executedBuyAmount);
       });
     });
 


### PR DESCRIPTION
Closes #68 and #14

This PR checks the order's `filledAmount` to make sure that it isn't being reused and, for partially fillable orders, there is enough of the order remaining.

The unit tests file is getting quite large and I think there is value in splitting it into smaller files (for example, one file for the EOA orders, one file for future SC interactions, etc.) WDYT?

### Test Plan

New unit tests added.
