### PR TITLE
New uid format

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -305,6 +305,7 @@ contract GPv2Settlement {
         )
     {
         require(orderUid.length == 32 + 4 + 20, "GPv2: invalid uid");
+        // Use assembly to efficiently decode packed calldata.
         // solhint-disable-next-line no-inline-assembly
         assembly {
             orderDigest := calldataload(orderUid.offset)

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -304,7 +304,7 @@ contract GPv2Settlement {
             uint32 validTo
         )
     {
-        require(orderUid.length == 32 + 4 + 20, "GPv2: invalid uid");
+        require(orderUid.length == 32 + 20 + 4, "GPv2: invalid uid");
         // Use assembly to efficiently decode packed calldata.
         // solhint-disable-next-line no-inline-assembly
         assembly {

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -64,4 +64,16 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
             mem := sub(mload(0x40), mem)
         }
     }
+
+    function extractOrderUidParamsTest(bytes calldata orderUid)
+        public
+        pure
+        returns (
+            bytes32 orderDigest,
+            uint32 validTo,
+            address owner
+        )
+    {
+        return extractOrderUidParams(orderUid);
+    }
 }

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -70,8 +70,8 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
         pure
         returns (
             bytes32 orderDigest,
-            uint32 validTo,
-            address owner
+            address owner,
+            uint32 validTo
         )
     {
         return extractOrderUidParams(orderUid);

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -395,15 +395,18 @@ export function signOrder(
  * contract.
  *
  * @param orderDigest The digest representing the parameters of the user order.
+ * @param validTo Time until which the order is valid.
  * @param userAddress The address of the user who owns the order.
  * @returns A string that unequivocally identifies the order of the user.
  */
 export function computeOrderUid(
   orderDigest: string,
+  validTo: number | Date,
   userAddress: string,
 ): string {
-  return ethers.utils.solidityKeccak256(
-    ["bytes32", "address"],
-    [orderDigest, userAddress],
-  );
+  return (
+    orderDigest +
+    timestamp(validTo).toString(16).padStart(4, "0") +
+    userAddress.slice(2)
+  ).toLowerCase();
 }

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -404,9 +404,8 @@ export function computeOrderUid(
   userAddress: string,
   validTo: number | Date,
 ): string {
-  return (
-    orderDigest +
-    userAddress.slice(2) +
-    timestamp(validTo).toString(16).padStart(4, "0")
-  ).toLowerCase();
+  return ethers.utils.solidityPack(
+    ["bytes32", "address", "uint32"],
+    [orderDigest, userAddress, timestamp(validTo)],
+  );
 }

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -395,18 +395,18 @@ export function signOrder(
  * contract.
  *
  * @param orderDigest The digest representing the parameters of the user order.
- * @param validTo Time until which the order is valid.
  * @param userAddress The address of the user who owns the order.
+ * @param validTo Time until which the order is valid.
  * @returns A string that unequivocally identifies the order of the user.
  */
 export function computeOrderUid(
   orderDigest: string,
-  validTo: number | Date,
   userAddress: string,
+  validTo: number | Date,
 ): string {
   return (
     orderDigest +
-    timestamp(validTo).toString(16).padStart(4, "0") +
-    userAddress.slice(2)
+    userAddress.slice(2) +
+    timestamp(validTo).toString(16).padStart(4, "0")
   ).toLowerCase();
 }

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -692,9 +692,7 @@ describe("GPv2Settlement", () => {
   });
 
   describe("computeTradeExecution", () => {
-    // Skipped. This test fails because the implementation of `orderUidKey`
-    // allocates memory. This test should be reenabled when it is updated.
-    it.skip("should not allocate additional memory", async () => {
+    it("should not allocate additional memory", async () => {
       expect(
         await settlement.callStatic.computeTradeExecutionMemoryTest(),
       ).to.deep.equal(ethers.constants.Zero);

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -135,7 +135,7 @@ describe("GPv2Settlement", () => {
 
   describe("filledAmount", () => {
     it("is zero for an uninitialized order", async () => {
-      const zeroBytes = "0x".padEnd(66, "0");
+      const zeroBytes = ethers.constants.HashZero;
       expect(await settlement.filledAmount(zeroBytes)).to.equal(
         ethers.constants.Zero,
       );
@@ -144,8 +144,8 @@ describe("GPv2Settlement", () => {
 
   describe("getFilledAmount", () => {
     it("is zero for an untouched order", async () => {
-      const orderUid = "0x".padEnd(66, "0");
-      const owner = "0x".padEnd(42, "0");
+      const orderUid = ethers.constants.HashZero;
+      const owner = ethers.constants.AddressZero;
       const validTo = 2 ** 32 - 1;
 
       expect(

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -145,12 +145,12 @@ describe("GPv2Settlement", () => {
   describe("getFilledAmount", () => {
     it("is zero for an untouched order", async () => {
       const orderUid = "0x".padEnd(66, "0");
-      const validTo = 2 ** 32 - 1;
       const owner = "0x".padEnd(42, "0");
+      const validTo = 2 ** 32 - 1;
 
       expect(
         await settlement.getFilledAmount(
-          computeOrderUid(orderUid, validTo, owner),
+          computeOrderUid(orderUid, owner, validTo),
         ),
       ).to.equal(ethers.constants.Zero);
     });
@@ -179,8 +179,8 @@ describe("GPv2Settlement", () => {
       const validTo = 2 ** 32 - 1;
       const orderUid = computeOrderUid(
         orderDigest,
-        validTo,
         traders[0].address,
+        validTo,
       );
 
       await settlement.connect(traders[0]).invalidateOrder(orderUid);
@@ -193,8 +193,8 @@ describe("GPv2Settlement", () => {
       const validTo = 2 ** 32 - 1;
       const orderUid = computeOrderUid(
         orderDigest,
-        validTo,
         traders[0].address,
+        validTo,
       );
 
       await expect(settlement.invalidateOrder(orderUid)).to.be.revertedWith(
@@ -532,17 +532,17 @@ describe("GPv2Settlement", () => {
     it("round trip encode/decode", async () => {
       // Start from 17 (0x11) so that the first byte has no zeroes.
       const orderDigest = "0x" + fillDistinctBytes(32, 17);
-      const validTo = parseInt(fillDistinctBytes(4, 17 + 32), 16);
       const address = ethers.utils.getAddress(
-        "0x" + fillDistinctBytes(20, 17 + 32 + 4),
+        "0x" + fillDistinctBytes(20, 17 + 32),
       );
-      const orderUid = computeOrderUid(orderDigest, validTo, address);
-      expect(orderUid).to.equal("0x" + fillDistinctBytes(32 + 4 + 20, 17));
+      const validTo = parseInt(fillDistinctBytes(4, 17 + 32 + 20), 16);
+      const orderUid = computeOrderUid(orderDigest, address, validTo);
+      expect(orderUid).to.equal("0x" + fillDistinctBytes(32 + 20 + 4, 17));
 
       const {
         orderDigest: extractedOrderDigest,
-        validTo: extractedValidTo,
         owner: extractedAddress,
+        validTo: extractedValidTo,
       } = await settlement.extractOrderUidParamsTest(orderUid);
       expect(extractedOrderDigest).to.equal(orderDigest);
       expect(extractedValidTo).to.equal(validTo);


### PR DESCRIPTION
Implements the uid format discussed in #195 with Felix and Nick.

The uid is now a concatenation of `orderDigest`, `validTo`, and `ownerAddress`.

### Test Plan

New unit tests.