### PR TITLE
Run TypeSCript compiler on CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,7 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-yarn-
       - run: yarn --frozen-lockfile
+      - run: yarn tsc
       - run: yarn build
       - run: yarn lint
       - run: yarn test

--- a/bench/decodeTrade.ts
+++ b/bench/decodeTrade.ts
@@ -25,7 +25,7 @@ async function main() {
           buyAmount: ethers.utils.parseEther("13.37"),
           validTo: 0xffffffff,
           appData: i,
-          tip: ethers.constants.WeiPerEther,
+          feeAmount: ethers.constants.WeiPerEther,
           kind: OrderKind.SELL,
           partiallyFillable: false,
         },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "license": "LGPL-3.0-or-later",
   "scripts": {
+    "tsc": "tsc",
     "build": "hardhat compile",
     "deploy": "hardhat deploy",
     "test": "hardhat test",


### PR DESCRIPTION
This PR adds runs `tsc` on CI to catch any compiler errors on unused code (such as the benchmarking). This fixes a type-checking issue that came up.
 
### Test Plan

CI, check that invalid code actually breaks the build:
```
$ echo 'invalid code' > src/ts/invalid.ts
$ yarn run -s tsc
src/ts/invalid.ts:1:9 - error TS1005: ';' expected.

1 invalid code
          ~~~~


Found 1 error.
```
