### PR TITLE
Implement method to transfer out executed buy amounts to EOA orders

### DIFF
--- a/src/contracts/GPv2AllowanceManager.sol
+++ b/src/contracts/GPv2AllowanceManager.sol
@@ -24,12 +24,15 @@ contract GPv2AllowanceManager {
         _;
     }
 
-    /// @dev Transfer's all sell amounts for the executed trades from their
+    /// @dev Transfers all sell amounts for the executed trades from their
     /// owners to the caller.
     ///
     /// This function reverts if:
     /// - The caller is not the recipient of the allowance manager
     /// - Any ERC20 transfer fails
+    ///
+    /// @param trades The executed trades whose sell amounts need to be
+    /// transferred in.
     function transferIn(GPv2TradeExecution.Data[] calldata trades)
         external
         onlyRecipient

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -13,6 +13,7 @@ import "./libraries/GPv2TradeExecution.sol";
 /// @author Gnosis Developers
 contract GPv2Settlement {
     using GPv2Encoding for bytes;
+    using GPv2TradeExecution for GPv2TradeExecution.Data;
     using SafeMath for uint256;
 
     /// @dev The EIP-712 domain type hash used for computing the domain
@@ -326,6 +327,18 @@ contract GPv2Settlement {
             orderDigest := calldataload(orderUid.offset)
             owner := shr(96, calldataload(add(orderUid.offset, 32)))
             validTo := shr(224, calldataload(add(orderUid.offset, 52)))
+        }
+    }
+
+    /// @dev Transfers all buy amounts for the executed trades from the
+    /// settlement contract to the order owners. This function reverst if any of
+    /// the ERC20 operations fail.
+    ///
+    /// @param trades The executed trades whose buy amounts need to be
+    /// transferred out.
+    function transferOut(GPv2TradeExecution.Data[] memory trades) internal {
+        for (uint256 i = 0; i < trades.length; i++) {
+            trades[i].transferBuyAmountToOwner();
         }
     }
 

--- a/src/contracts/libraries/GPv2TradeExecution.sol
+++ b/src/contracts/libraries/GPv2TradeExecution.sol
@@ -30,4 +30,10 @@ library GPv2TradeExecution {
             trade.sellAmount
         );
     }
+
+    /// @dev Executes the trade's buy amount, transferring it to the trade's
+    /// owner from the caller's address.
+    function transferBuyAmountToOwner(Data memory trade) internal {
+        trade.buyToken.safeTransfer(trade.owner, trade.buyAmount);
+    }
 }

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.7.5;
 pragma abicoder v2;
 
 import "../GPv2Settlement.sol";
+import "../libraries/GPv2Encoding.sol";
 import "../libraries/GPv2TradeExecution.sol";
 
 contract GPv2SettlementTestInterface is GPv2Settlement {
@@ -56,7 +57,7 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
     }
 
     function extractOrderUidParamsTest(bytes calldata orderUid)
-        public
+        external
         pure
         returns (
             bytes32 orderDigest,
@@ -65,5 +66,9 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
         )
     {
         return extractOrderUidParams(orderUid);
+    }
+
+    function transferOutTest(GPv2TradeExecution.Data[] memory trades) external {
+        transferOut(trades);
     }
 }

--- a/src/contracts/test/GPv2TradeExecutionTestInterface.sol
+++ b/src/contracts/test/GPv2TradeExecutionTestInterface.sol
@@ -13,4 +13,10 @@ contract GPv2TradeExecutionTestInterface {
     ) external {
         GPv2TradeExecution.transferSellAmountToRecipient(trade, recipient);
     }
+
+    function transferBuyAmountToOwnerTest(
+        GPv2TradeExecution.Data calldata trade
+    ) external {
+        trade.transferBuyAmountToOwner();
+    }
 }


### PR DESCRIPTION
This PR implements the required code to transfer out executed buy amounts for EOA orders.

### Test Plan

Added new unit tests that verify it works with non-standard ERC20 implementations.