### PR TITLE
Memory-efficient orderUidKey

### DIFF
--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -694,7 +694,7 @@ describe("GPv2Settlement", () => {
   describe("computeTradeExecution", () => {
     // Skipped. This test fails because the implementation of `orderUidKey`
     // allocates memory. This test should be reenabled when it is updated.
-    it.skip("should not allocate additional memory", async () => {
+    it("should not allocate additional memory", async () => {
       expect(
         await settlement.callStatic.computeTradeExecutionMemoryTest(),
       ).to.deep.equal(ethers.constants.Zero);

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -692,8 +692,6 @@ describe("GPv2Settlement", () => {
   });
 
   describe("computeTradeExecution", () => {
-    // Skipped. This test fails because the implementation of `orderUidKey`
-    // allocates memory. This test should be reenabled when it is updated.
     it("should not allocate additional memory", async () => {
       expect(
         await settlement.callStatic.computeTradeExecutionMemoryTest(),


### PR DESCRIPTION
A memory efficient version of the implementation of `orderUidKey` from #214.
Logic is copied from #213, which was removed when merging master into #214.

### Test Plan

Existing unit tests.
