### PR TITLE
Refactor order UID

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -46,14 +46,13 @@ contract GPv2Settlement {
     /// contract is created during deployment
     GPv2AllowanceManager public immutable allowanceManager;
 
-    /// @dev Map each user order to the amount that has been filled so far. If
-    /// this amount is larger than or equal to the amount traded in the order
-    /// (amount sold for sell orders, amount bought for buy orders) then the
-    /// order cannot be traded anymore. If the order is fill or kill, then this
-    /// value is only used to determine whether the order has already been
+    /// @dev Map each user order by UID to the amount that has been filled so
+    /// far. If this amount is larger than or equal to the amount traded in the
+    /// order (amount sold for sell orders, amount bought for buy orders) then
+    /// the order cannot be traded anymore. If the order is fill or kill, then
+    /// this value is only used to determine whether the order has already been
     /// executed.
-    /// See [`orderUidKey`] for how an order key is defined.
-    mapping(bytes32 => uint256) public filledAmount;
+    mapping(bytes => uint256) public filledAmount;
 
     constructor(GPv2Authentication authenticator_) {
         authenticator = authenticator_;
@@ -133,27 +132,9 @@ contract GPv2Settlement {
     /// must be the the sender of this message. See [`extractOrderUidParams`]
     /// for details on orderUid.
     function invalidateOrder(bytes calldata orderUid) external {
-        (bytes32 orderDigest, address owner, uint32 validTo) =
-            extractOrderUidParams(orderUid);
+        (, address owner, ) = orderUid.extractOrderUidParams();
         require(owner == msg.sender, "GPv2: caller does not own order");
-        filledAmount[orderUidKey(orderDigest, msg.sender, validTo)] = uint256(
-            -1
-        );
-    }
-
-    /// @dev Return how much of the input order has been filled so far. See
-    /// [`filledAmount`] to know how this value depends on the order type.
-    /// @param orderUid The unique identifier associated to the order for which
-    /// to recover the filled amount. See [`extractOrderUidParams`] for details.
-    /// @return amount How much the order has been filled in absolute amount.
-    function getFilledAmount(bytes calldata orderUid)
-        external
-        view
-        returns (uint256 amount)
-    {
-        (bytes32 orderDigest, address owner, uint32 validTo) =
-            extractOrderUidParams(orderUid);
-        amount = filledAmount[orderUidKey(orderDigest, owner, validTo)];
+        filledAmount[orderUid] = uint256(-1);
     }
 
     /// @dev Process all trades for EOA orders one at a time returning the
@@ -248,9 +229,7 @@ contract GPv2Settlement {
         uint256 executedSellAmount;
         uint256 executedBuyAmount;
         uint256 executedFeeAmount;
-
-        bytes32 uidKey = orderUidKey(trade.digest, trade.owner, order.validTo);
-        uint256 currentFilledAmount = filledAmount[uidKey];
+        uint256 currentFilledAmount = filledAmount[trade.orderUid];
 
         // NOTE: Don't use `SafeMath.div` anywhere here as it allocates a string
         // even if it does not revert. The method only checks that the divisor
@@ -297,7 +276,7 @@ contract GPv2Settlement {
         executedTrade.sellAmount = executedSellAmount.add(executedFeeAmount);
         executedTrade.buyAmount = executedBuyAmount;
 
-        filledAmount[uidKey] = currentFilledAmount;
+        filledAmount[trade.orderUid] = currentFilledAmount;
     }
 
     /// @dev Allows settlment function to make arbitrary contract executions.
@@ -327,36 +306,6 @@ contract GPv2Settlement {
         }
     }
 
-    /// @dev Extracts specific order information from the standardized unique
-    /// order id of the protocol.
-    /// @param orderUid The unique identifier used to represent an order in
-    /// the protocol. This uid is the packed concatenation of the order digest,
-    /// the validTo order parameter and the address of the user who created the
-    /// order. It is used by the user to interface with the contract directly,
-    /// and not by calls that are triggered by the solvers.
-    /// @return orderDigest The unique digest associated to the parameters of an
-    /// order. See [`orderUidKey`] for details.
-    /// @return owner The address of the user who owns this order.
-    /// @return validTo The epoch time at which the order will stop being valid.
-    function extractOrderUidParams(bytes calldata orderUid)
-        internal
-        pure
-        returns (
-            bytes32 orderDigest,
-            address owner,
-            uint32 validTo
-        )
-    {
-        require(orderUid.length == 32 + 20 + 4, "GPv2: invalid uid");
-        // Use assembly to efficiently decode packed calldata.
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            orderDigest := calldataload(orderUid.offset)
-            owner := shr(96, calldataload(add(orderUid.offset, 32)))
-            validTo := shr(224, calldataload(add(orderUid.offset, 52)))
-        }
-    }
-
     /// @dev Transfers all buy amounts for the executed trades from the
     /// settlement contract to the order owners. This function reverts if any of
     /// the ERC20 operations fail.
@@ -366,48 +315,6 @@ contract GPv2Settlement {
     function transferOut(GPv2TradeExecution.Data[] memory trades) internal {
         for (uint256 i = 0; i < trades.length; i++) {
             trades[i].transferBuyAmountToOwner();
-        }
-    }
-
-    /// @dev Compute the key used to access, in the mapping of filled amounts,
-    /// the user order described by the input parameters.
-    /// @param orderDigest The unique digest associated to the parameters of an
-    /// order (an instance of the Order struct in the [`GPv2Encoding`] library).
-    /// The order digest is the (unpacked) hash of all entries in the order in
-    /// which they appear.
-    /// @param owner The address of the user that is assigned to the order.
-    /// @param validTo The epoch time at which the order will stop being valid.
-    /// @return uid Key of the given order in the [`filledAmount`] mapping.
-    function orderUidKey(
-        bytes32 orderDigest,
-        address owner,
-        uint32 validTo
-    ) internal pure returns (bytes32 uid) {
-        // NOTE: Use the 64 bytes of scratch space starting at memory address 0
-        // for computing this hash instead of allocating. We hash a total of 56
-        // bytes and write to memory in **reverse order** as memory operations
-        // write 32-bytes at a time and we want to use a packed encoding. This
-        // means, for example, that after writing the value of `owner` to bytes
-        // `20:52`, writing the `orderDigest` to bytes `0:32` will **overwrite**
-        // bytes `20:32`. This is desirable as addresses are only 20 bytes and
-        // `20:32` should be `0`s:
-        //
-        //        |           1111111111222222222233333333334444444444555555
-        //   byte | 01234567890123456789012345678901234567890123456789012345
-        // -------+---------------------------------------------------------
-        //  field | [.........orderDigest..........][......owner.......][vT]
-        // -------+---------------------------------------------------------
-        // mstore |                         [000000000000000000000000000.vT]
-        //        |                     [00000000000.......owner.......]
-        //        | [.........orderDigest..........]
-        //
-        // <https://docs.soliditylang.org/en/v0.7.5/internals/layout_in_memory.html>
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            mstore(24, validTo)
-            mstore(20, owner)
-            mstore(0, orderDigest)
-            uid := keccak256(0, 56)
         }
     }
 }

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -229,7 +229,7 @@ contract GPv2Settlement {
         uint256 executedSellAmount;
         uint256 executedBuyAmount;
         uint256 executedFeeAmount;
-        uint256 currentFilledAmount = filledAmount[trade.orderUid];
+        uint256 currentFilledAmount;
 
         // NOTE: Don't use `SafeMath.div` anywhere here as it allocates a string
         // even if it does not revert. The method only checks that the divisor
@@ -248,7 +248,9 @@ contract GPv2Settlement {
 
             executedBuyAmount = executedSellAmount.mul(sellPrice) / buyPrice;
 
-            currentFilledAmount = currentFilledAmount.add(executedSellAmount);
+            currentFilledAmount = filledAmount[trade.orderUid].add(
+                executedSellAmount
+            );
             require(
                 currentFilledAmount <= order.sellAmount,
                 "GPv2: order filled"
@@ -266,7 +268,9 @@ contract GPv2Settlement {
 
             executedSellAmount = executedBuyAmount.mul(buyPrice) / sellPrice;
 
-            currentFilledAmount = currentFilledAmount.add(executedBuyAmount);
+            currentFilledAmount = filledAmount[trade.orderUid].add(
+                executedBuyAmount
+            );
             require(
                 currentFilledAmount <= order.buyAmount,
                 "GPv2: order filled"

--- a/src/contracts/test/GPv2EncodingTestInterface.sol
+++ b/src/contracts/test/GPv2EncodingTestInterface.sol
@@ -43,6 +43,9 @@ contract GPv2EncodingTestInterface {
 
         uint256 tradeCount = encodedTrades.tradeCount();
         trades = new GPv2Encoding.Trade[](tradeCount);
+        for (uint256 i = 0; i < tradeCount; i++) {
+            trades[i].orderUid = new bytes(56);
+        }
 
         // NOTE: Solidity keeps a total memory count at address 0x40. Check
         // before and after decoding a trade to compute memory usage growth per
@@ -68,5 +71,17 @@ contract GPv2EncodingTestInterface {
             mem := sub(mload(0x40), mem)
         }
         gas_ = gas_ - gasleft();
+    }
+
+    function extractOrderUidParamsTest(bytes calldata orderUid)
+        external
+        pure
+        returns (
+            bytes32 orderDigest,
+            address owner,
+            uint32 validTo
+        )
+    {
+        return orderUid.extractOrderUidParams();
     }
 }

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -52,18 +52,6 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
         }
     }
 
-    function extractOrderUidParamsTest(bytes calldata orderUid)
-        external
-        pure
-        returns (
-            bytes32 orderDigest,
-            address owner,
-            uint32 validTo
-        )
-    {
-        return extractOrderUidParams(orderUid);
-    }
-
     function transferOutTest(GPv2TradeExecution.Data[] memory trades) external {
         transferOut(trades);
     }

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -413,7 +413,7 @@ export function computeOrderUid({
  * Extracts the order unique identifier parameters from the specified bytes.
  *
  * @param orderUid The order UID encoded as a hexadecimal string.
- * @returns The extracted order UID prameters.
+ * @returns The extracted order UID parameters.
  */
 export function extractOrderUidParams(orderUid: string): OrderUidParams {
   const bytes = ethers.utils.arrayify(orderUid);

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -412,7 +412,7 @@ export function computeOrderUid({
 /**
  * Extracts the order unique identifier parameters from the specified bytes.
  *
- * @param orderUid The order UID encoded as a hexideciaml string.
+ * @param orderUid The order UID encoded as a hexadecimal string.
  * @returns The extracted order UID prameters.
  */
 export function extractOrderUidParams(orderUid: string): OrderUidParams {

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -373,21 +373,60 @@ export function signOrder(
 }
 
 /**
+ * Order unique identifier parameters.
+ */
+export interface OrderUidParams {
+  /**
+   * The EIP-712 order struct hash.
+   */
+  orderDigest: string;
+  /**
+   * The owner of the order.
+   */
+  owner: string;
+  /**
+   * The timestamp this order is valid until.
+   */
+  validTo: number | Date;
+}
+
+/**
  * Compute the unique identifier describing a user order in the settlement
  * contract.
  *
- * @param orderDigest The digest representing the parameters of the user order.
- * @param userAddress The address of the user who owns the order.
- * @param validTo Time until which the order is valid.
+ * @param OrderUidParams The parameters used for computing the order's unique
+ * identifier.
  * @returns A string that unequivocally identifies the order of the user.
  */
-export function computeOrderUid(
-  orderDigest: string,
-  userAddress: string,
-  validTo: number | Date,
-): string {
+export function computeOrderUid({
+  orderDigest,
+  owner,
+  validTo,
+}: OrderUidParams): string {
   return ethers.utils.solidityPack(
     ["bytes32", "address", "uint32"],
-    [orderDigest, userAddress, timestamp(validTo)],
+    [orderDigest, owner, timestamp(validTo)],
   );
+}
+
+/**
+ * Extracts the order unique identifier parameters from the specified bytes.
+ *
+ * @param orderUid The order UID encoded as a hexideciaml string.
+ * @returns The extracted order UID prameters.
+ */
+export function extractOrderUidParams(orderUid: string): OrderUidParams {
+  const bytes = ethers.utils.arrayify(orderUid);
+  if (bytes.length != 56) {
+    throw new Error("invalid order UID length");
+  }
+
+  const view = new DataView(bytes.buffer);
+  return {
+    orderDigest: ethers.utils.hexlify(bytes.subarray(0, 32)),
+    owner: ethers.utils.getAddress(
+      ethers.utils.hexlify(bytes.subarray(32, 52)),
+    ),
+    validTo: view.getUint32(52),
+  };
 }

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -7,6 +7,8 @@ import {
   OrderKind,
   SettlementEncoder,
   SigningScheme,
+  computeOrderUid,
+  extractOrderUidParams,
   hashOrder,
 } from "../src/ts";
 
@@ -14,6 +16,12 @@ import { decodeTrade } from "./encoding";
 
 function fillBytes(count: number, byte: number): string {
   return ethers.utils.hexlify([...Array(count)].map(() => byte));
+}
+
+function fillDistinctBytes(count: number, start: number): string {
+  return ethers.utils.hexlify(
+    [...Array(count)].map((_, i) => (start + i) % 256),
+  );
 }
 
 function fillUint(bits: number, byte: number): BigNumber {
@@ -126,7 +134,7 @@ describe("GPv2Encoding", () => {
       );
 
       // NOTE: Ethers.js returns a tuple and not a struct with named fields for
-      // `ABIEncoderV2` structs.
+      // `abicoder v2` structs.
       expect(decodedTrades.length).to.equal(1);
 
       const {
@@ -172,8 +180,11 @@ describe("GPv2Encoding", () => {
         encoder.tokens,
         encoder.encodedTrades,
       );
-      const { digest } = decodeTrade(decodedTrades[0]);
-      expect(digest).to.equal(hashOrder(sampleOrder));
+
+      const { orderDigest } = extractOrderUidParams(
+        decodeTrade(decodedTrades[0]).orderUid,
+      );
+      expect(orderDigest).to.equal(hashOrder(sampleOrder));
     });
 
     it("should recover signing address for all supported schemes", async () => {
@@ -289,6 +300,51 @@ describe("GPv2Encoding", () => {
         encoder.encodedTrades,
       );
       expect(mem.toNumber()).to.equal(0);
+    });
+  });
+
+  describe("extractOrderUidParams", () => {
+    it("round trip encode/decode", async () => {
+      // Start from 17 (0x11) so that the first byte has no zeroes.
+      const orderDigest = fillDistinctBytes(32, 17);
+      const address = ethers.utils.getAddress(fillDistinctBytes(20, 17 + 32));
+      const validTo = BigNumber.from(fillDistinctBytes(4, 17 + 32 + 20));
+
+      const orderUid = computeOrderUid({
+        orderDigest,
+        owner: address,
+        validTo: validTo.toNumber(),
+      });
+      expect(orderUid).to.equal(fillDistinctBytes(32 + 20 + 4, 17));
+
+      const {
+        orderDigest: extractedOrderDigest,
+        owner: extractedAddress,
+        validTo: extractedValidTo,
+      } = await encoding.extractOrderUidParamsTest(orderUid);
+      expect(extractedOrderDigest).to.equal(orderDigest);
+      expect(extractedValidTo).to.equal(validTo);
+      expect(extractedAddress).to.equal(address);
+    });
+
+    describe("fails on uid", () => {
+      const uidStride = 32 + 20 + 4;
+
+      it("longer than expected", async () => {
+        const invalidUid = "0x" + "00".repeat(uidStride + 1);
+
+        await expect(
+          encoding.extractOrderUidParamsTest(invalidUid),
+        ).to.be.revertedWith("GPv2: invalid uid");
+      });
+
+      it("shorter than expected", async () => {
+        const invalidUid = "0x" + "00".repeat(uidStride - 1);
+
+        await expect(
+          encoding.extractOrderUidParamsTest(invalidUid),
+        ).to.be.revertedWith("GPv2: invalid uid");
+      });
     });
   });
 });

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -187,6 +187,30 @@ describe("GPv2Encoding", () => {
       expect(orderDigest).to.equal(hashOrder(sampleOrder));
     });
 
+    it("should compute order unique identifier", async () => {
+      const encoder = new SettlementEncoder(testDomain);
+      await encoder.signEncodeTrade(
+        sampleOrder,
+        0,
+        traders[0],
+        SigningScheme.TYPED_DATA,
+      );
+
+      const [decodedTrades] = await encoding.decodeTradesTest(
+        encoder.tokens,
+        encoder.encodedTrades,
+      );
+
+      const { orderUid } = decodeTrade(decodedTrades[0]);
+      expect(orderUid).to.equal(
+        computeOrderUid({
+          orderDigest: hashOrder(sampleOrder),
+          owner: traders[0].address,
+          validTo: sampleOrder.validTo,
+        }),
+      );
+    });
+
     it("should recover signing address for all supported schemes", async () => {
       const encoder = new SettlementEncoder(testDomain);
       for (const scheme of [SigningScheme.TYPED_DATA, SigningScheme.MESSAGE]) {

--- a/test/encoding.ts
+++ b/test/encoding.ts
@@ -22,13 +22,8 @@ export interface Trade {
   sellTokenIndex: number;
   buyTokenIndex: number;
   executedAmount: BigNumber;
-  digest: string;
   owner: string;
-}
-
-export interface Interaction {
-  target: string;
-  callData: BytesLike;
+  orderUid: string;
 }
 
 export function decodeTrade(trade: AbiTrade): Trade {
@@ -47,9 +42,14 @@ export function decodeTrade(trade: AbiTrade): Trade {
     sellTokenIndex: trade[1],
     buyTokenIndex: trade[2],
     executedAmount: trade[3],
-    digest: trade[4],
-    owner: trade[5],
+    owner: trade[4],
+    orderUid: trade[5],
   };
+}
+
+export interface Interaction {
+  target: string;
+  callData: BytesLike;
 }
 
 export type AbiExecutedTrade = [string, string, string, BigNumber, BigNumber];


### PR DESCRIPTION
This PR refactors how the order UID is computed and used. Specifically, the order UID is now computed during trade decoding. This has the benefit of:
- Being able to reuse the order UID bytes buffer
- Moving all related assembly out of `GPv2Settlement.sol` and into `GPv2Encoding.sol` (into the already assembly-loaded code).
- No special considerations if the order UID would become bigger than 64 bytes for whatever reason (was the case before as we were using the "scratch" memory location).
- The `filledAmount` storage no longer requires a custom accessor
- `orderKey` is completely abstracted away - only `orderUid` remains
- Sets up the code for being able to emit trade events without having to allocate memory

### Test Plan

Adjusted unit tests still pass :tada: 
