### PR TITLE
[Easy] Two Forgotten suggestions from #224

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -320,11 +320,10 @@ contract GPv2Settlement {
         // This is the topic of https://github.com/gnosis/gp-v2-contracts/issues/240
         if (!success) {
             // Assembly used to revert with correctly encoded error message.
-            // solhint-disable no-inline-assembly
+            // solhint-disable-next-line no-inline-assembly
             assembly {
                 revert(add(response, 0x20), mload(response))
             }
-            // solhint-enable no-inline-assembly
         }
     }
 

--- a/test/encoding.ts
+++ b/test/encoding.ts
@@ -1,4 +1,4 @@
-import { BigNumber, Bytes } from "ethers";
+import { BigNumber, BytesLike } from "ethers";
 import { ethers } from "hardhat";
 
 import { Order } from "../src/ts";
@@ -28,7 +28,7 @@ export interface Trade {
 
 export interface Interaction {
   target: string;
-  callData: string | Bytes;
+  callData: BytesLike;
 }
 
 export function decodeTrade(trade: AbiTrade): Trade {


### PR DESCRIPTION
Using `BytesLike` instead of `Bytes | string` and change `solhint-disable` to include `-next-line`.


