### PR TITLE
refactor deterministic address computation

### DIFF
--- a/src/deploy/001_authenticator.ts
+++ b/src/deploy/001_authenticator.ts
@@ -1,7 +1,7 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-import { SALT, contractNames } from "../ts/deploy";
+import { CONTRACT_NAMES, SALT } from "../ts/deploy";
 
 const deployAuthenticator: DeployFunction = async function ({
   deployments,
@@ -10,7 +10,7 @@ const deployAuthenticator: DeployFunction = async function ({
   const { deployer, owner } = await getNamedAccounts();
   const { deploy } = deployments;
 
-  const { authenticator } = contractNames;
+  const { authenticator } = CONTRACT_NAMES;
 
   await deploy(authenticator, {
     from: deployer,

--- a/src/deploy/002_settlement.ts
+++ b/src/deploy/002_settlement.ts
@@ -1,7 +1,7 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-import { SALT, contractNames } from "../ts/deploy";
+import { CONTRACT_NAMES, SALT } from "../ts/deploy";
 
 const deploySettlement: DeployFunction = async function ({
   deployments,
@@ -10,9 +10,8 @@ const deploySettlement: DeployFunction = async function ({
   const { deployer } = await getNamedAccounts();
   const { deploy, get } = deployments;
 
-  const { settlement, authenticator } = contractNames;
-
-  const authenticatorAddress = (await get(authenticator)).address;
+  const { authenticator, settlement } = CONTRACT_NAMES;
+  const { address: authenticatorAddress } = await get(authenticator);
 
   await deploy(settlement, {
     from: deployer,

--- a/src/ts/deploy.ts
+++ b/src/ts/deploy.ts
@@ -50,11 +50,10 @@ export async function deterministicDeploymentAddress<C extends ContractName>(
   contractName: C,
   ...deploymentArguments: DeploymentArguments<C>
 ): Promise<string> {
-  // NOTE: Use `require` to load the contract artifact instead of `getContract`
-  // so that we don't need to depend on `hardhat` when using this project as
-  // a dependency.
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { abi, bytecode } = require(getArtifactPath(contractName));
+  // NOTE: Use dynamic import to load the contract artifact instead of
+  // `getContract` so that we don't need to depend on `hardhat` when using this
+  // project as a dependency.
+  const { abi, bytecode } = await import(getArtifactPath(contractName));
 
   const contractInterface = new utils.Interface(abi);
   const deployData = utils.hexConcat([

--- a/src/ts/deploy.ts
+++ b/src/ts/deploy.ts
@@ -1,13 +1,4 @@
 import { utils } from "ethers";
-import { ethers } from "hardhat";
-
-/**
- * Dictionary containing deployed contract names.
- */
-export const contractNames = {
-  authenticator: "GPv2AllowListAuthentication",
-  settlement: "GPv2Settlement",
-};
 
 /**
  * The salt used when deterministically deploying smart contracts.
@@ -24,6 +15,35 @@ export const SALT = utils.formatBytes32String("dev");
 const DEPLOYER_CONTRACT = "0x4e59b44847b379578588920ca78fbf26c0b4956c";
 
 /**
+ * The name of a deployed contract.
+ */
+export type ContractName = "GPv2AllowListAuthentication" | "GPv2Settlement";
+
+/**
+ * Dictionary containing all deployed contract names.
+ */
+export const CONTRACT_NAMES = {
+  authenticator: "GPv2AllowListAuthentication",
+  settlement: "GPv2Settlement",
+} as const;
+
+// NOTE: Use the compiler to assert that the contract names in the above
+// dictionary are correct.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const _assertValidContractNames: Record<string, ContractName> = CONTRACT_NAMES;
+
+/**
+ * The deployment args for a contract.
+ */
+export type DeploymentArguments<
+  T extends ContractName
+> = T extends "GPv2AllowListAuthentication"
+  ? [string]
+  : T extends "GPv2Settlement"
+  ? [string]
+  : never;
+
+/**
  * Computes the deterministic address at which the contract will be deployed.
  * This address does not depend on which network the contract is deployed to.
  *
@@ -31,18 +51,30 @@ const DEPLOYER_CONTRACT = "0x4e59b44847b379578588920ca78fbf26c0b4956c";
  * @param deploymentArguments Extra arguments that are necessary to deploy.
  * @returns The address that is expected to store the deployed code.
  */
-export async function deterministicDeploymentAddress(
-  contractName: string,
-  ...deploymentArguments: unknown[]
+export async function deterministicDeploymentAddress<C extends ContractName>(
+  contractName: C,
+  ...deploymentArguments: DeploymentArguments<C>
 ): Promise<string> {
-  const factory = await ethers.getContractFactory(contractName);
-  const deployTransaction = factory.getDeployTransaction(
-    ...deploymentArguments,
-  );
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { abi, bytecode } = require(getArtifactPath(contractName));
+  const contractInterface = new utils.Interface(abi);
+
+  const deployData = utils.hexConcat([
+    bytecode,
+    contractInterface.encodeDeploy(deploymentArguments),
+  ]);
 
   return utils.getCreate2Address(
     DEPLOYER_CONTRACT,
     SALT,
-    utils.keccak256(deployTransaction.data || "0x"),
+    utils.keccak256(deployData),
   );
+}
+
+function getArtifactPath(contractName: ContractName): string {
+  // NOTE: Use `require` to load the contract artifact instead of `getContract`
+  // so that we don't need to depend on `hardhat` when using this project as
+  // a dependency.
+  const artifactsRoot = "../../build/artifacts/";
+  return `${artifactsRoot}/src/contracts/${contractName}.sol/${contractName}.json`;
 }


### PR DESCRIPTION
This PR refactors the `deterministicDeploymentAddress` function so that it is type-safe on the contract name and that it works without requiring `hardhat` and `hardhat-ethers` plugin (which is useful for consumers of the TS library).

### Test Plan

Unit tests still pass without modification! Additionally, make sure that `yarn compile` is **NOT** required for the tests to run successfully (i.e. it works on a fresh `git clone`):
```
$ trash build/ && yarn test && echo OK
...
OK
```
