### PR TITLE
[Trivial] Making the domainSeperator public

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -35,7 +35,7 @@ contract GPv2Settlement {
     /// separator is computed following the EIP-712 standard and has replay
     /// protection mixed in so that signed orders are only valid for specific
     /// GPv2 contracts.
-    bytes32 internal immutable domainSeparator;
+    bytes32 public immutable domainSeparator;
 
     /// @dev The authenticator is used to determine who can call the settle function.
     /// That is, only authorised solvers have the ability to invoke settlements.

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -14,10 +14,6 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
 
     }
 
-    function domainSeparatorTest() external view returns (bytes32) {
-        return domainSeparator;
-    }
-
     function computeTradeExecutionsTest(
         IERC20[] calldata tokens,
         uint256[] calldata clearingPrices,

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -53,7 +53,7 @@ describe("GPv2Settlement", () => {
 
   describe("domainSeparator", () => {
     it("should have an EIP-712 domain separator", async () => {
-      expect(await settlement.domainSeparatorTest()).to.equal(
+      expect(await settlement.domainSeparator()).to.equal(
         ethers.utils._TypedDataEncoder.hashDomain(testDomain),
       );
     });
@@ -65,8 +65,8 @@ describe("GPv2Settlement", () => {
       );
       const settlement2 = await GPv2Settlement.deploy(authenticator.address);
 
-      expect(await settlement.domainSeparatorTest()).to.not.equal(
-        await settlement2.domainSeparatorTest(),
+      expect(await settlement.domainSeparator()).to.not.equal(
+        await settlement2.domainSeparator(),
       );
     });
   });


### PR DESCRIPTION
It seems like the majority is in favor of making this change, see here: https://github.com/gnosis/gp-v2-services/pull/110
