### PR TITLE
Adding etherscan contract verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,16 @@ After replacing these values, run:
 ```sh
 NETWORK='rinkeby'
 GAS_PRICE_WEI='1000000000'
+INFURA_KEY="Your infura key"
 yarn deploy --network $NETWORK --gasprice $GAS_PRICE_WEI
 ```
 
 New files containing details of this deployment will be created in the `deployment` folder.
 These files should be committed to this repository.
+
+In order to verify the contract in Etherscan, run:
+
+```
+MY_ETHERSCAN_API_KEY="your key"
+npx hardhat verify --network $NETWORK DEPLOYED_CONTRACT_ADDRESS "Constructor argument 1"
+```

--- a/README.md
+++ b/README.md
@@ -37,6 +37,6 @@ These files should be committed to this repository.
 In order to verify the contract in Etherscan, run:
 
 ```
-MY_ETHERSCAN_API_KEY="your key"
+ETHERSCAN_API_KEY="your key"
 npx hardhat verify --network $NETWORK DEPLOYED_CONTRACT_ADDRESS "Constructor argument 1"
 ```

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -16,7 +16,7 @@ const argv = yargs
 
 // Load environment variables.
 dotenv.config();
-const { INFURA_KEY, MNEMONIC, PK, MY_ETHERSCAN_API_KEY } = process.env;
+const { INFURA_KEY, MNEMONIC, PK, ETHERSCAN_API_KEY } = process.env;
 
 const DEFAULT_MNEMONIC =
   "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat";
@@ -78,6 +78,6 @@ export default {
     },
   },
   etherscan: {
-    apiKey: MY_ETHERSCAN_API_KEY,
+    apiKey: ETHERSCAN_API_KEY,
   },
 };

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,4 +1,5 @@
 import "@nomiclabs/hardhat-waffle";
+import "@nomiclabs/hardhat-etherscan";
 import "hardhat-deploy";
 
 import dotenv from "dotenv";
@@ -15,7 +16,7 @@ const argv = yargs
 
 // Load environment variables.
 dotenv.config();
-const { INFURA_KEY, MNEMONIC, PK } = process.env;
+const { INFURA_KEY, MNEMONIC, PK, MY_ETHERSCAN_API_KEY } = process.env;
 
 const DEFAULT_MNEMONIC =
   "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat";
@@ -75,5 +76,8 @@ export default {
       default: "0x" + "1".padStart(40, "0"),
       hardhat: 1,
     },
+  },
+  etherscan: {
+    apiKey: MY_ETHERSCAN_API_KEY,
   },
 };

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@gnosis.pm/util-contracts": "3.0.1-solc-7",
     "@nomiclabs/hardhat-ethers": "^2.0.1",
+    "@nomiclabs/hardhat-etherscan": "^2.1.0",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "^3.3.0",
     "@types/chai": "^4.2.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -548,6 +548,18 @@
   resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.0.1.tgz#f86a6fa210dbe6270adffccc75e93ed60a856904"
   integrity sha512-uTFHDhhvJ+UjfvvMeQxD3ZALuzuI3FXzTYT1Z5N3ebyZL5z4Ogwt55GB0R9tdKY0p5HhDhBjU/gsCjUEwIVoaw==
 
+"@nomiclabs/hardhat-etherscan@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-2.1.0.tgz#08512c3e602155dc0d2becb193cd2e0155867839"
+  integrity sha512-YK9/UZI1Ct9TYfqZJnjIERlFC7bFrG0eUS2O0kFrH8RjLdcQXBI0GNpxXGAuDbotBg0t8wRKHibbK50TQu0ybA==
+  dependencies:
+    "@ethersproject/abi" "^5.0.2"
+    "@ethersproject/address" "^5.0.2"
+    cbor "^5.0.2"
+    fs-extra "^7.0.1"
+    node-fetch "^2.6.0"
+    semver "^6.3.0"
+
 "@nomiclabs/hardhat-waffle@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-waffle/-/hardhat-waffle-2.0.1.tgz#5d43654fba780720c5033dea240fe14f70ef4bd2"
@@ -2241,6 +2253,14 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+cbor@^5.0.2:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-5.1.0.tgz#c3be220dcbbd96a338d279a664237aed3f596904"
+  integrity sha512-qzEc7kUShdMbWTaUH7X+aHW8owvBU3FS0dfYR1lGYpoZr0mGJhhojLlZJH653x/DfeMZ56h315FRNBUIG1R7qg==
+  dependencies:
+    bignumber.js "^9.0.0"
+    nofilter "^1.0.4"
 
 chai@^4.2.0:
   version "4.2.0"
@@ -6118,6 +6138,11 @@ node-gyp-build@^4.2.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
   integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
+
+nofilter@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-1.0.4.tgz#78d6f4b6a613e7ced8b015cec534625f7667006e"
+  integrity sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==
 
 normalize-package-data@^2.3.2:
   version "2.5.0"


### PR DESCRIPTION
Using a cool hardhat plugin to verify the deployed contract on etherscan. This will be very hand to debug issues with e2e testing via tenderly


### Test Plan
Run readme and check result on rinkeby - if you really wanna do it, you have to do it with another salt.

 It worked for me: https://rinkeby.etherscan.io/address/0x91D6387ffbB74621625F39200d91a50386C9Ab15#code