### PR TITLE
Add networks.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@ yarn deploy --network $NETWORK --gasprice $GAS_PRICE_WEI
 
 New files containing details of this deployment will be created in the `deployment` folder.
 These files should be committed to this repository.
+
+## Deployed Contract Addresses
+
+This package additonally contains a `networks.json` file at the root with the
+address of each deployed contract as well the hash of the Ethereum transaction
+used to create the contract.

--- a/networks.json
+++ b/networks.json
@@ -2,19 +2,13 @@
   "GPv2AllowListAuthentication": {
     "4": {
       "address": "0x8D8C520c2073f7F4684A6c0c36FE05821173b972",
-      "transactionHash": "0xc22b40872f4cc483aa61e830c30429b995712c0a11a6416773c17a4d78a8f73f",
-      "deploymentArguments": [
-        "0x0000000000000000000000000000000000000001"
-      ]
+      "transactionHash": "0xc22b40872f4cc483aa61e830c30429b995712c0a11a6416773c17a4d78a8f73f"
     }
   },
   "GPv2Settlement": {
     "4": {
       "address": "0x91D6387ffbB74621625F39200d91a50386C9Ab15",
-      "transactionHash": "0xd39a37b72a0ba3f6e7d05575f98494d54b5b81700366b0cfdbb9215fc218c994",
-      "deploymentArguments": [
-        "0x8D8C520c2073f7F4684A6c0c36FE05821173b972"
-      ]
+      "transactionHash": "0xd39a37b72a0ba3f6e7d05575f98494d54b5b81700366b0cfdbb9215fc218c994"
     }
   },
   "GPv2AllowanceManager": {

--- a/networks.json
+++ b/networks.json
@@ -1,0 +1,25 @@
+{
+  "GPv2AllowListAuthentication": {
+    "4": {
+      "address": "0x8D8C520c2073f7F4684A6c0c36FE05821173b972",
+      "transactionHash": "0xc22b40872f4cc483aa61e830c30429b995712c0a11a6416773c17a4d78a8f73f",
+      "deploymentArguments": [
+        "0x0000000000000000000000000000000000000001"
+      ]
+    }
+  },
+  "GPv2Settlement": {
+    "4": {
+      "address": "0x91D6387ffbB74621625F39200d91a50386C9Ab15",
+      "transactionHash": "0xd39a37b72a0ba3f6e7d05575f98494d54b5b81700366b0cfdbb9215fc218c994",
+      "deploymentArguments": [
+        "0x8D8C520c2073f7F4684A6c0c36FE05821173b972"
+      ]
+    }
+  },
+  "GPv2AllowanceManager": {
+    "4": {
+      "address": "0x90c25afb622BBf85a7b7d48820B554b4A13bc31F"
+    }
+  }
+}

--- a/networks.json
+++ b/networks.json
@@ -13,7 +13,8 @@
   },
   "GPv2AllowanceManager": {
     "4": {
-      "address": "0x90c25afb622BBf85a7b7d48820B554b4A13bc31F"
+      "address": "0x90c25afb622BBf85a7b7d48820B554b4A13bc31F",
+      "transactionHash": "0xd39a37b72a0ba3f6e7d05575f98494d54b5b81700366b0cfdbb9215fc218c994"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,12 +47,12 @@
     "yargs": "^16.2.0"
   },
   "main": "lib/ts/index.js",
+  "types": "lib/ts/index.d.ts",
   "files": [
-    "/bench",
     "/build",
     "/deployments",
-    "/lib",
+    "/lib/src",
+    "/network.json",
     "/src"
-  ],
-  "types": "lib/ts/index.d.ts"
+  ]
 }

--- a/src/deploy/999_networks.ts
+++ b/src/deploy/999_networks.ts
@@ -32,29 +32,34 @@ const updateNetworks: DeployFunction = async function ({
     await fs.readFile(NETWORKS_PATH, "utf-8"),
   );
 
-  const initializeRecord = (contractName: string, address: string) => {
+  const updateRecord = (
+    contractName: string,
+    { address, transactionHash }: DeploymentRecord,
+  ) => {
     networks[contractName] = networks[contractName] || {};
-    return (networks[contractName][chainId] = {
+    const record = (networks[contractName][chainId] = {
       ...networks[contractName][chainId],
       address,
     });
-  };
-
-  for (const [name, { address, transactionHash }] of Object.entries(
-    await deployments.all(),
-  )) {
-    const record = initializeRecord(name, address);
 
     // NOTE: Preserve transaction hash in case there is no new deployment
     // because the contract bytecode did not change.
     record.transactionHash = transactionHash || record.transactionHash;
+  };
+
+  for (const [name, deployment] of Object.entries(await deployments.all())) {
+    updateRecord(name, deployment);
   }
 
+  const settlementRecord = networks["GPv2Settlement"][chainId];
   const settlement = await ethers.getContractAt(
     "GPv2Settlement",
-    networks["GPv2Settlement"][chainId].address,
+    settlementRecord.address,
   );
-  initializeRecord("GPv2AllowanceManager", await settlement.allowanceManager());
+  updateRecord("GPv2AllowanceManager", {
+    address: await settlement.allowanceManager(),
+    transactionHash: settlementRecord.transactionHash,
+  });
 
   await fs.writeFile(NETWORKS_PATH, JSON.stringify(networks, null, INDENT));
 };

--- a/src/deploy/999_networks.ts
+++ b/src/deploy/999_networks.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "fs";
 import path from "path";
 
-import { Deployment, DeployFunction } from "hardhat-deploy/types";
+import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 const NETWORKS_PATH = path.join(__dirname, "../../networks.json");
@@ -13,7 +13,6 @@ type Network = Record<number, DeploymentRecord>;
 interface DeploymentRecord {
   address: string;
   transactionHash?: string;
-  deploymentArguments?: unknown[];
 }
 
 const updateNetworks: DeployFunction = async function ({
@@ -41,14 +40,14 @@ const updateNetworks: DeployFunction = async function ({
     });
   };
 
-  for (const [name, deployment] of Object.entries(await deployments.all())) {
-    const { address, transactionHash, args } = deployment;
+  for (const [name, { address, transactionHash }] of Object.entries(
+    await deployments.all(),
+  )) {
     const record = initializeRecord(name, address);
 
-    // NOTE: Preserve transaction hash and arguments in case there is no new
-    // deployment because the contract bytecode did not change.
+    // NOTE: Preserve transaction hash in case there is no new deployment
+    // because the contract bytecode did not change.
     record.transactionHash = transactionHash || record.transactionHash;
-    record.deploymentArguments = args || record.deploymentArguments;
   }
 
   const settlement = await ethers.getContractAt(

--- a/src/deploy/999_networks.ts
+++ b/src/deploy/999_networks.ts
@@ -1,0 +1,63 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+import { Deployment, DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+const NETWORKS_PATH = path.join(__dirname, "../../networks.json");
+const INDENT = "  ";
+
+type Networks = Record<string, Network>;
+type Network = Record<number, DeploymentRecord>;
+
+interface DeploymentRecord {
+  address: string;
+  transactionHash?: string;
+  deploymentArguments?: unknown[];
+}
+
+const updateNetworks: DeployFunction = async function ({
+  deployments,
+  getChainId,
+  ethers,
+  network,
+}: HardhatRuntimeEnvironment) {
+  if (network.name === "hardhat") {
+    return;
+  }
+
+  console.log("updating 'networks.json'...");
+
+  const chainId = parseInt(await getChainId());
+  const networks: Networks = JSON.parse(
+    await fs.readFile(NETWORKS_PATH, "utf-8"),
+  );
+
+  const initializeRecord = (contractName: string, address: string) => {
+    networks[contractName] = networks[contractName] || {};
+    return (networks[contractName][chainId] = {
+      ...networks[contractName][chainId],
+      address,
+    });
+  };
+
+  for (const [name, deployment] of Object.entries(await deployments.all())) {
+    const { address, transactionHash, args } = deployment;
+    const record = initializeRecord(name, address);
+
+    // NOTE: Preserve transaction hash and arguments in case there is no new
+    // deployment because the contract bytecode did not change.
+    record.transactionHash = transactionHash || record.transactionHash;
+    record.deploymentArguments = args || record.deploymentArguments;
+  }
+
+  const settlement = await ethers.getContractAt(
+    "GPv2Settlement",
+    networks["GPv2Settlement"][chainId].address,
+  );
+  initializeRecord("GPv2AllowanceManager", await settlement.allowanceManager());
+
+  await fs.writeFile(NETWORKS_PATH, JSON.stringify(networks, null, INDENT));
+};
+
+export default updateNetworks;


### PR DESCRIPTION
This PR adds a `network.json` file in the same format as in existing Gnosis projects for easy consumption of the package. Note that `hardhat-deploy` includes a `--export` flag that does something similar, but I decided to use a custom deployment script instead as it omits the transaction hash of the contract deployment which I think can be very useful (for knowing which block to start indexing events for example).

### Test Plan

Remove the addresses and run `yarn deploy --network rinkeby` and see them get added back!
