### PR TITLE
Bump up deployment gas limit

### DIFF
--- a/src/deploy/002_settlement.ts
+++ b/src/deploy/002_settlement.ts
@@ -15,7 +15,7 @@ const deploySettlement: DeployFunction = async function ({
 
   await deploy(settlement, {
     from: deployer,
-    gasLimit: 2000000,
+    gasLimit: 3000000,
     args: [authenticatorAddress],
     deterministicDeployment: SALT,
     log: true,


### PR DESCRIPTION
The settlement contract is getting larger, and soon it won't fit into the transaction gas limit we specified in the deployment. This PR increases the limit.

The settlement contract currently costs >1.9M gas to deploy ([tx](https://rinkeby.etherscan.io/tx/0x32c0067339e3f42c7643f5b861a7f6478ac96530af8c08aa62ad2feab86e156d)).
The solver management contract is still ok at <1M gas ([tx](https://rinkeby.etherscan.io/tx/0x3f9e7c51b8c7595fdfc4ed7bc4b767c419c97d2b8c364921752d2ad8ca3651b3)).