### PR TITLE
adjust main and types path in module

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "typescript": "^4.1.2",
     "yargs": "^16.2.0"
   },
-  "main": "lib/ts/index.js",
-  "types": "lib/ts/index.d.ts",
+  "main": "lib/src/ts/index.js",
+  "types": "lib/src/ts/index.d.ts",
   "files": [
     "/build",
     "/deployments",


### PR DESCRIPTION
This PR fixes the `"main"` and `"types"` paths in the `package.json`.

### Test Plan

```
$ yarn pack
$ tar -tvf gnosis.pm-gp-v2-contracts-v0.0.1-alpha.2.tgz | grep ts/index.js
-rw-r--r-- 0/0            1334 2020-12-11 17:54 package/lib/src/ts/index.js
```
