### PR TITLE
Package version bump to 0.0.1-alpha.4

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -7,14 +7,14 @@
   },
   "GPv2Settlement": {
     "4": {
-      "address": "0x91D6387ffbB74621625F39200d91a50386C9Ab15",
-      "transactionHash": "0xd39a37b72a0ba3f6e7d05575f98494d54b5b81700366b0cfdbb9215fc218c994"
+      "address": "0x58BC5137849d22cD586601adf1f3454FdF2fd0e2",
+      "transactionHash": "0xcf3e366336799ca5484bd285237704db42789bc9bd89d95ca1efeb930b4587a0"
     }
   },
   "GPv2AllowanceManager": {
     "4": {
-      "address": "0x90c25afb622BBf85a7b7d48820B554b4A13bc31F",
-      "transactionHash": "0xd39a37b72a0ba3f6e7d05575f98494d54b5b81700366b0cfdbb9215fc218c994"
+      "address": "0x31658E2405Ea55446Ec2271AAD661E706DEeFB33",
+      "transactionHash": "0xcf3e366336799ca5484bd285237704db42789bc9bd89d95ca1efeb930b4587a0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:sol": "solhint 'src/contracts/**/*.sol'",
     "lint:ts": "eslint --max-warnings 0 .",
     "fmt:sol": "prettier 'src/contracts/**/*.sol' -w",
-    "prepack": "yarn build && yarn deploy --network rinkeby"
+    "prepack": "yarn build"
   },
   "peerDependencies": {
     "ethers": "~5.0.18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v2-contracts",
-  "version": "0.0.1-alpha.3",
+  "version": "0.0.1-alpha.4",
   "license": "LGPL-3.0-or-later",
   "scripts": {
     "build": "tsc && hardhat compile",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:sol": "solhint 'src/contracts/**/*.sol'",
     "lint:ts": "eslint --max-warnings 0 .",
     "fmt:sol": "prettier 'src/contracts/**/*.sol' -w",
-    "prepack": "yarn build"
+    "prepack": "yarn build && yarn deploy --network rinkeby"
   },
   "peerDependencies": {
     "ethers": "~5.0.18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v2-contracts",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "license": "LGPL-3.0-or-later",
   "scripts": {
     "build": "tsc && hardhat compile",


### PR DESCRIPTION
This bumps the package version to include the fixes to issues seen when trying to consume this as a package for the swap interface.

I removed the `yarn deploy` from the prepublish step as this release was about the fixes to the TS library. We should probably eventually keep deployment separate from package releases anyway.

### Test Plan

<https://www.npmjs.com/package/@gnosis.pm/gp-v2-contracts/v/0.0.1-alpha.4>
