### PR TITLE
Add single trade matcher on Uniswap

### DIFF
--- a/test/e2e/uniswapMatch.test.ts
+++ b/test/e2e/uniswapMatch.test.ts
@@ -1,0 +1,112 @@
+import ERC20 from "@openzeppelin/contracts/build/contracts/ERC20PresetMinterPauser.json";
+import UniswapV2Factory from "@uniswap/v2-core/build/UniswapV2Factory.json";
+import UniswapV2Pair from "@uniswap/v2-core/build/UniswapV2Pair.json";
+import { expect } from "chai";
+import { Contract, Wallet } from "ethers";
+import { ethers, waffle } from "hardhat";
+
+import { SigningScheme, domain, signOrder } from "../../src/ts";
+
+import { deployTestContracts } from "./fixture";
+import { UniswapMatch } from "./uniswap_match";
+
+describe("E2E: single trade matched directly with Uniswap", () => {
+  let deployer: Wallet;
+  let solver: Wallet;
+  let pooler: Wallet;
+  let user: Wallet;
+
+  let settlement: Contract;
+  let allowanceManager: Contract;
+
+  let weth: Contract;
+  let usdc: Contract;
+  let uniswapFactory: Contract;
+
+  beforeEach(async () => {
+    const deployment = await deployTestContracts();
+
+    ({
+      deployer,
+      settlement,
+      allowanceManager,
+      wallets: [solver, pooler, user],
+    } = deployment);
+
+    const { authenticator, owner } = deployment;
+    await authenticator.connect(owner).addSolver(solver.address);
+
+    weth = await waffle.deployContract(deployer, ERC20, ["WETH", 18]);
+    usdc = await waffle.deployContract(deployer, ERC20, ["USDC", 6]);
+
+    uniswapFactory = await waffle.deployContract(deployer, UniswapV2Factory, [
+      deployer.address,
+    ]);
+    await uniswapFactory.createPair(weth.address, usdc.address);
+    const uniswapPair = new Contract(
+      await uniswapFactory.getPair(weth.address, usdc.address),
+      UniswapV2Pair.abi,
+      deployer,
+    );
+
+    const uniswapWethReserve = ethers.utils.parseEther("1000.0");
+    const uniswapUsdtReserve = ethers.utils.parseUnits("600000.0", 6);
+    await weth.mint(uniswapPair.address, uniswapWethReserve);
+    await usdc.mint(uniswapPair.address, uniswapUsdtReserve);
+    await uniswapPair.mint(pooler.address);
+
+    await usdc.mint(user.address, ethers.utils.parseUnits("1000000.0", 6));
+  });
+
+  it("sell USDC for WETH", async () => {
+    expect(await weth.balanceOf(user.address)).to.equal(ethers.constants.Zero);
+    const userUsdcStartingBalance = await usdc.balanceOf(user.address);
+
+    await usdc
+      .connect(user)
+      .approve(allowanceManager.address, ethers.constants.MaxUint256);
+
+    const uniswapMatch = new UniswapMatch({
+      uniswapFactoryAddress: uniswapFactory.address,
+      settlementAddress: settlement.address,
+      provider: ethers.provider,
+    });
+
+    const sellAmount = ethers.utils.parseUnits("600.0", 6);
+    const sellToken = usdc.address;
+    const buyToken = weth.address;
+
+    const order = await uniswapMatch.createSellOrder({
+      sellAmount,
+      sellToken,
+      buyToken,
+    });
+
+    const { chainId } = await ethers.provider.getNetwork();
+    const signedDataDomain = domain(chainId, settlement.address);
+    const signature = await signOrder(
+      signedDataDomain,
+      order,
+      user,
+      SigningScheme.TYPED_DATA,
+    );
+
+    await uniswapMatch.submitSolution(
+      signature,
+      SigningScheme.TYPED_DATA,
+      solver,
+    );
+
+    expect(order.buyAmount).not.to.equal(ethers.constants.Zero);
+    expect(await weth.balanceOf(user.address)).to.equal(order.buyAmount);
+    expect(
+      userUsdcStartingBalance.sub(await usdc.balanceOf(user.address)),
+    ).to.equal(order.sellAmount);
+    expect(await usdc.balanceOf(settlement.address)).to.equal(
+      ethers.constants.Zero,
+    );
+    expect(await weth.balanceOf(settlement.address)).to.equal(
+      ethers.constants.Zero,
+    );
+  });
+});

--- a/test/e2e/uniswap_match.ts
+++ b/test/e2e/uniswap_match.ts
@@ -1,0 +1,199 @@
+import ERC20 from "@openzeppelin/contracts/build/contracts/ERC20PresetMinterPauser.json";
+import UniswapV2Factory from "@uniswap/v2-core/build/UniswapV2Factory.json";
+import UniswapV2Pair from "@uniswap/v2-core/build/UniswapV2Pair.json";
+import { BigNumber, BigNumberish, Contract, providers, Signer } from "ethers";
+
+import GPv2Settlement from "../../build/artifacts/src/contracts/GPv2Settlement.sol/GPv2Settlement.json";
+import { domain } from "../../src/ts";
+import { Order, OrderKind, SigningScheme } from "../../src/ts/order";
+import { SettlementEncoder } from "../../src/ts/settlement";
+import type { SignatureLike, TypedDataDomain } from "../../src/ts/types/ethers";
+
+export interface UniswapTradeRequest {
+  sellToken: string;
+  buyToken: string;
+  sellAmount: BigNumberish;
+}
+
+export interface UniswapPairState {
+  uniswapPair: Contract;
+  sellToken: Contract;
+  reserveSellToken: BigNumber;
+  buyToken: Contract;
+  reserveBuyToken: BigNumber;
+  isSellTokenToken0: boolean;
+}
+
+async function getUniswapState(
+  uniswapFactory: Contract,
+  { sellToken, buyToken }: { sellToken: string; buyToken: string },
+  provider: providers.JsonRpcProvider,
+): Promise<UniswapPairState> {
+  const uniswapPair = new Contract(
+    await uniswapFactory.getPair(sellToken, buyToken),
+    UniswapV2Pair.abi,
+    provider,
+  );
+  const sellTokenContract = new Contract(sellToken, ERC20.abi, provider);
+  const buyTokenContract = new Contract(buyToken, ERC20.abi, provider);
+
+  const [reserveSellToken, reserveBuyToken, pairToken0] = await Promise.all([
+    sellTokenContract.balanceOf(uniswapPair.address),
+    buyTokenContract.balanceOf(uniswapPair.address),
+    uniswapPair.token0(),
+  ]);
+
+  const isSellTokenToken0 = sellToken === pairToken0;
+  console.log(isSellTokenToken0);
+  return {
+    uniswapPair,
+    reserveSellToken,
+    reserveBuyToken,
+    sellToken: sellTokenContract,
+    buyToken: buyTokenContract,
+    isSellTokenToken0,
+  };
+}
+
+/**
+ * A very basic solver that takes the amount a user wishes to trade on Uniswap
+ * and uses it to:
+ * 1. transform the swap into a GPv2 sell order to sign;
+ * 2. given the signed order, settle the trade onchain.
+ *
+ * This class is single use: each new Uniswap order requires a new instance of
+ * this class.
+ */
+export class UniswapMatch {
+  private readonly uniswapFactory: Contract;
+  private readonly settlement: Contract;
+  private readonly domainSeparator: Promise<TypedDataDomain>;
+  private readonly provider: providers.JsonRpcProvider;
+  order?: Order;
+  uniswapState?: UniswapPairState;
+
+  constructor({
+    uniswapFactoryAddress,
+    settlementAddress,
+    provider,
+  }: {
+    uniswapFactoryAddress: string;
+    settlementAddress: string;
+    provider: providers.JsonRpcProvider;
+  }) {
+    this.uniswapFactory = new Contract(
+      uniswapFactoryAddress,
+      UniswapV2Factory.abi,
+      provider,
+    );
+    this.settlement = new Contract(
+      settlementAddress,
+      GPv2Settlement.abi,
+      provider,
+    );
+    this.provider = provider;
+    this.domainSeparator = provider
+      .getNetwork()
+      .then(({ chainId }) => domain(chainId, this.settlement.address));
+  }
+
+  async createSellOrder({
+    sellToken,
+    buyToken,
+    sellAmount,
+  }: UniswapTradeRequest): Promise<Order> {
+    sellAmount = BigNumber.from(sellAmount);
+
+    const uniswapState = await getUniswapState(
+      this.uniswapFactory,
+      {
+        sellToken,
+        buyToken,
+      },
+      this.provider,
+    );
+
+    const buyAmount = uniswapState.reserveBuyToken
+      .mul(sellAmount)
+      .mul(997)
+      .div(uniswapState.reserveSellToken.mul(1000).add(sellAmount.mul(997)));
+
+    this.uniswapState = uniswapState;
+
+    this.order = {
+      kind: OrderKind.BUY,
+      partiallyFillable: false,
+      buyToken,
+      sellToken,
+      buyAmount,
+      sellAmount,
+      feeAmount: 0,
+      validTo: 0xffffffff,
+      appData: 0,
+    };
+
+    return this.order;
+  }
+
+  async submitSolution(
+    signature: SignatureLike,
+    scheme: SigningScheme,
+    solver: Signer,
+  ): Promise<void> {
+    const encoder = new SettlementEncoder(await this.domainSeparator);
+
+    if (this.order === undefined || this.uniswapState === undefined) {
+      throw new Error(
+        "Uniswap order must be created before submitting a solution.",
+      );
+    }
+    const {
+      uniswapPair,
+      isSellTokenToken0,
+      sellToken,
+      buyToken,
+    } = this.uniswapState;
+
+    encoder.encodeTrade(this.order, signature, scheme);
+
+    encoder.encodeInteraction({
+      target: sellToken.address,
+      callData: sellToken.interface.encodeFunctionData("transfer", [
+        uniswapPair.address,
+        this.order.sellAmount,
+      ]),
+    });
+
+    const [amount0Out, amount1Out] = isSellTokenToken0
+      ? [0, this.order.buyAmount]
+      : [this.order.buyAmount, 0];
+    encoder.encodeInteraction({
+      target: this.uniswapState.uniswapPair.address,
+      callData: uniswapPair.interface.encodeFunctionData("swap", [
+        amount0Out,
+        amount1Out,
+        this.settlement.address,
+        "0x",
+      ]),
+    });
+
+    await this.settlement.connect(solver).settle(
+      encoder.tokens,
+      encoder.clearingPrices({
+        // Sell and buy tokens are swapped. This is a consequence of how prices
+        // are defined on the settlement contract: for example, the sell token
+        // price means that you can get this.order.buyAmount units in exchange
+        // for a "theoretical" quote token. This means that in exchange for one
+        // sell token wei, the batch trades this.order.buyAmount /
+        // this.order.sellAmount buy token wei. That is, this.order.sellAmount
+        // wei of buy token are exchanged for this.order.sellAmount sell
+        // token wei.
+        [sellToken.address]: this.order.buyAmount,
+        [buyToken.address]: this.order.sellAmount,
+      }),
+      encoder.encodedTrades,
+      encoder.encodedInteractions,
+      "0x",
+    );
+  }
+}


### PR DESCRIPTION
This PR creates a `UniswapMatch` class that "transforms" a Uniswap trade into a GPv2 trade and, when requested, settles it onchain. Its main purpose is to serve as a reference implementation of a basic solver for the frontend tests.

The `beforeEach` part of the new test file is s setup phase that should be external to the frontend. The test "sell USDC for WETH" describes the steps that are expected to be executed by the web interface.

No fees are taken in the process.

### Test Plan

New unit test. Comments by @anxolin.