### PR TITLE
Encode signature as r||s||v

### DIFF
--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -149,9 +149,9 @@ library GPv2Encoding {
     ///     uint256 executedAmount;
     ///     uint16 feeDiscount;
     ///     Signature {
-    ///         uint8 v;
     ///         bytes32 r;
     ///         bytes32 s;
+    ///         uint8 v;
     ///     } signature;
     /// }
     /// ```
@@ -236,12 +236,12 @@ library GPv2Encoding {
                 add(trade, 128),
                 shr(240, calldataload(add(encodedTrade.offset, 139)))
             )
-            // v = uint8(encodedTrade[141])
-            v := shr(248, calldataload(add(encodedTrade.offset, 141)))
-            // r = uint256(encodedTrade[142:174])
-            r := calldataload(add(encodedTrade.offset, 142))
-            // s = uint256(encodedTrade[174:206])
-            s := calldataload(add(encodedTrade.offset, 174))
+            // r = uint256(encodedTrade[141:173])
+            r := calldataload(add(encodedTrade.offset, 141))
+            // s = uint256(encodedTrade[173:205])
+            s := calldataload(add(encodedTrade.offset, 173))
+            // v = uint8(encodedTrade[205])
+            v := shr(248, calldataload(add(encodedTrade.offset, 205)))
         }
 
         trade.order.sellToken = tokens[sellTokenIndex];

--- a/src/ts/order.ts
+++ b/src/ts/order.ts
@@ -209,11 +209,11 @@ export async function signOrder(
   );
 
   return ethers.utils.solidityPack(
-    ["uint8", "bytes32", "bytes32"],
+    ["bytes32", "bytes32", "uint8"],
     [
-      encodeSigningScheme(ecdsaSignature.v, scheme),
       ecdsaSignature.r,
       ecdsaSignature.s,
+      encodeSigningScheme(ecdsaSignature.v, scheme),
     ],
   );
 }

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -238,7 +238,7 @@ describe("GPv2Encoding", () => {
       // NOTE: `v` must be either `27` or `28`, so just set it to something else
       // to generate an invalid signature.
       const encodedTradeBytes = ethers.utils.arrayify(encoder.encodedTrades);
-      encodedTradeBytes[141] = 42;
+      encodedTradeBytes[205] = 42;
 
       await expect(
         encoding.decodeTradesTest(encoder.tokens, encodedTradeBytes),


### PR DESCRIPTION
Closes #281

This PR encodes the signature as r||s||v instead of v||r||s as the former is more standard and widely used.

### Test Plan

Adjusted tests still pass.
