### PR TITLE
Implement free order storage for gas refunds

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -371,4 +371,17 @@ contract GPv2Settlement {
             trades[i].transferBuyAmountToOwner();
         }
     }
+
+    /// @dev Frees the storage for an order that is no longer valid granting a
+    /// gas refund.
+    ///
+    /// This method reverts if the order is still valid.
+    ///
+    /// @param orderUid The unique identifier of the order to free.
+    function freeOrderStorage(bytes calldata orderUid) internal {
+        (, , uint32 validTo) = orderUid.extractOrderUidParams();
+        // solhint-disable-next-line not-rely-on-time
+        require(validTo < block.timestamp, "GPv2: order still valid");
+        filledAmount[orderUid] = 0;
+    }
 }

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -63,4 +63,8 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
     {
         executeInteraction(interaction);
     }
+
+    function freeOrderStorageTest(bytes calldata orderUid) external {
+        freeOrderStorage(orderUid);
+    }
 }


### PR DESCRIPTION
This PR implements a method to free the order storage for an expired order in order to claim gas refunds during settlement. It is currently not called as part of the settlement, that will come later.

### Test Plan

Added unit tests.
