### PR TITLE
Implement decoding packed order UIDs

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -374,14 +374,9 @@ contract GPv2Settlement {
     /// @param encodedOrderRefunds Packed encoded order unique identifiers for
     /// which to claim gas refunds.
     function claimOrderRefunds(bytes calldata encodedOrderRefunds) internal {
-        for (
-            uint256 i = 0;
-            i < encodedOrderRefunds.length;
-            i += GPv2Encoding.ORDER_UID_LENGTH
-        ) {
-            freeOrderStorage(
-                encodedOrderRefunds[i:i + GPv2Encoding.ORDER_UID_LENGTH]
-            );
+        uint256 refundCount = encodedOrderRefunds.orderUidCount();
+        for (uint256 i = 0; i < refundCount; i++) {
+            freeOrderStorage(encodedOrderRefunds.orderUidAtIndex(i));
         }
     }
 

--- a/src/contracts/test/GPv2EncodingTestInterface.sol
+++ b/src/contracts/test/GPv2EncodingTestInterface.sol
@@ -109,4 +109,15 @@ contract GPv2EncodingTestInterface {
     {
         return orderUid.extractOrderUidParams();
     }
+
+    function decodeOrderUidsTest(bytes calldata encodedOrderUids)
+        external
+        pure
+        returns (bytes[] memory orderUids)
+    {
+        orderUids = new bytes[](encodedOrderUids.orderUidCount());
+        for (uint256 i = 0; i < orderUids.length; i++) {
+            orderUids[i] = encodedOrderUids.orderUidAtIndex(i);
+        }
+    }
 }

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -533,4 +533,34 @@ describe("GPv2Encoding", () => {
       });
     });
   });
+
+  describe("decodeOrderUidsTest", () => {
+    it("should round trip encode/decode", async () => {
+      // Start from 17 (0x11) so that the first byte has no zeroes.
+      const orderUids = [
+        fillDistinctBytes(56, 17),
+        fillDistinctBytes(56, 17 + 56),
+        fillDistinctBytes(56, 17 + 56 * 2),
+      ];
+
+      const decodedOrderUids = await encoding.decodeOrderUidsTest(
+        ethers.utils.solidityPack(
+          orderUids.map(() => "bytes"),
+          orderUids,
+        ),
+      );
+      expect(decodedOrderUids).to.deep.equal(orderUids);
+    });
+
+    it("should accept empty order UIDs", async () => {
+      expect(await encoding.decodeOrderUidsTest("0x")).to.deep.equal([]);
+    });
+
+    it("should revert on malformed order UIDs", async () => {
+      const invalidUids = "0x00";
+      await expect(
+        encoding.decodeOrderUidsTest(invalidUids),
+      ).to.be.revertedWith("malformed order UIDs");
+    });
+  });
 });


### PR DESCRIPTION
This PR implements code in the encoding library for decoding packed order UIDs for processing order gas refunds.

### Test Plan

Added unit tests for new encoding methods. Using this slicing method we claim a bit more gas, also the settlement contract loop is nicer to read IMO, and all order UID decoding is completely encapsulated in the `GPv2Encoding` library.

Before:
```
$ DEBUG=e2e:orderRefunds yarn test
...
  E2E: Expired Order Gas Refunds
  e2e:orderRefunds Gas savings per order: 8521 +0ms
...
```

After:
```
$ DEBUG=e2e:orderRefunds yarn test
...
  E2E: Expired Order Gas Refunds
  e2e:orderRefunds Gas savings per order: 8584 +0ms
...
```

So the gas savings are extremely marginal.
