### PR TITLE
Buy ETH

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
     "@uniswap/v2-core": "^1.0.1",
+    "canonical-weth": "^1.4.0",
     "chai": "^4.2.0",
     "debug": "^4.3.1",
     "dotenv": "^8.2.0",

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -92,6 +92,12 @@ contract GPv2Settlement {
         allowanceManager = new GPv2AllowanceManager();
     }
 
+    // solhint-disable-next-line no-empty-blocks
+    receive() external payable {
+        // NOTE: Include an empty receive function so that the settlement
+        // contract can receive ETH from contract interactions.
+    }
+
     /// @dev This modifier is called by settle function to block any non-listed
     /// senders from settling batches.
     modifier onlySolver {

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -95,7 +95,7 @@ contract GPv2Settlement {
     // solhint-disable-next-line no-empty-blocks
     receive() external payable {
         // NOTE: Include an empty receive function so that the settlement
-        // contract can receive ETH from contract interactions.
+        // contract can receive Ether from contract interactions.
     }
 
     /// @dev This modifier is called by settle function to block any non-listed

--- a/src/contracts/libraries/GPv2TradeExecution.sol
+++ b/src/contracts/libraries/GPv2TradeExecution.sol
@@ -9,6 +9,10 @@ import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 library GPv2TradeExecution {
     using SafeERC20 for IERC20;
 
+    /// @dev Ether marker address used to indicate an order is buying Ether.
+    address internal constant BUY_ETH_ADDRESS =
+        0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
     /// @dev Executed trade data.
     struct Data {
         address owner;
@@ -34,6 +38,10 @@ library GPv2TradeExecution {
     /// @dev Executes the trade's buy amount, transferring it to the trade's
     /// owner from the caller's address.
     function transferBuyAmountToOwner(Data memory trade) internal {
-        trade.buyToken.safeTransfer(trade.owner, trade.buyAmount);
+        if (address(trade.buyToken) == BUY_ETH_ADDRESS) {
+            payable(trade.owner).transfer(trade.buyAmount);
+        } else {
+            trade.buyToken.safeTransfer(trade.owner, trade.buyAmount);
+        }
     }
 }

--- a/src/contracts/test/GPv2TradeExecutionTestInterface.sol
+++ b/src/contracts/test/GPv2TradeExecutionTestInterface.sol
@@ -19,4 +19,7 @@ contract GPv2TradeExecutionTestInterface {
     ) external {
         trade.transferBuyAmountToOwner();
     }
+
+    // solhint-disable-next-line no-empty-blocks
+    receive() external payable {}
 }

--- a/src/ts/order.ts
+++ b/src/ts/order.ts
@@ -57,7 +57,7 @@ export interface Order {
 }
 
 /**
- * Marker address to indicate that an order is buying ETH.
+ * Marker address to indicate that an order is buying Ether.
  *
  * Note that this address is only has special meaning in the `buyToken` and will
  * be treated as a ERC20 token address in the `sellToken` position, causing the

--- a/src/ts/order.ts
+++ b/src/ts/order.ts
@@ -57,6 +57,15 @@ export interface Order {
 }
 
 /**
+ * Marker address to indicate that an order is buying ETH.
+ *
+ * Note that this address is only has special meaning in the `buyToken` and will
+ * be treated as a ERC20 token address in the `sellToken` position, causing the
+ * settlement to revert.
+ */
+export const BUY_ETH_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+
+/**
  * Gnosis Protocol v2 order flags.
  */
 export type OrderFlags = Pick<Order, "kind" | "partiallyFillable">;

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -131,6 +131,17 @@ describe("GPv2Settlement", () => {
     });
   });
 
+  describe("receive", () => {
+    it("allows receiving Ether directly in the settlement contract", async () => {
+      await expect(
+        traders[0].sendTransaction({
+          to: settlement.address,
+          value: ethers.utils.parseEther("1.0"),
+        }),
+      ).to.not.be.reverted;
+    });
+  });
+
   describe("settle", () => {
     it("rejects transactions from non-solvers", async () => {
       await expect(settlement.settle([], [], [], [], [])).to.be.revertedWith(

--- a/test/GPv2TradeExecution.test.ts
+++ b/test/GPv2TradeExecution.test.ts
@@ -209,7 +209,7 @@ describe("GPv2TradeExecution", () => {
       ).to.be.revertedWith("call to non-contract");
     });
 
-    it("should transfer Eth if the marker address is used", async () => {
+    it("should transfer Ether if the marker address is used", async () => {
       const amount = ethers.utils.parseEther("1.0");
       const initialBalance = await traders[0].getBalance();
 

--- a/test/GPv2TradeExecution.test.ts
+++ b/test/GPv2TradeExecution.test.ts
@@ -213,7 +213,7 @@ describe("GPv2TradeExecution", () => {
       const amount = ethers.utils.parseEther("1.0");
       const initialBalance = await traders[0].getBalance();
 
-      deployer.sendTransaction({
+      await deployer.sendTransaction({
         to: tradeExecution.address,
         value: amount,
       });

--- a/test/GPv2TradeExecution.test.ts
+++ b/test/GPv2TradeExecution.test.ts
@@ -3,6 +3,8 @@ import { expect } from "chai";
 import { Contract } from "ethers";
 import { ethers, waffle } from "hardhat";
 
+import { BUY_ETH_ADDRESS } from "../src/ts";
+
 import { encodeExecutedTrade } from "./encoding";
 
 const NON_STANDARD_ERC20 = [
@@ -84,6 +86,20 @@ describe("GPv2TradeExecution", () => {
           recipient.address,
         ),
       ).to.be.revertedWith("call to non-contract");
+    });
+
+    it("should revert when using marker buy Ether address", async () => {
+      await expect(
+        tradeExecution.transferSellAmountToRecipientTest(
+          encodeExecutedTrade({
+            owner: traders[0].address,
+            sellToken: BUY_ETH_ADDRESS,
+            sellAmount: ethers.utils.parseEther("1.0"),
+            ...withoutBuy,
+          }),
+          recipient.address,
+        ),
+      ).to.be.reverted;
     });
 
     describe("Non-Standard ERC20 Tokens", () => {
@@ -191,6 +207,29 @@ describe("GPv2TradeExecution", () => {
           }),
         ),
       ).to.be.revertedWith("call to non-contract");
+    });
+
+    it("should transfer Eth if the marker address is used", async () => {
+      const amount = ethers.utils.parseEther("1.0");
+      const initialBalance = await traders[0].getBalance();
+
+      deployer.sendTransaction({
+        to: tradeExecution.address,
+        value: amount,
+      });
+
+      await tradeExecution.transferBuyAmountToOwnerTest(
+        encodeExecutedTrade({
+          owner: traders[0].address,
+          buyToken: BUY_ETH_ADDRESS,
+          buyAmount: amount,
+          ...withoutSell,
+        }),
+      );
+
+      expect(await traders[0].getBalance()).to.deep.equal(
+        initialBalance.add(amount),
+      );
     });
 
     describe("Non-Standard ERC20 Tokens", () => {

--- a/test/GPv2TradeExecution.test.ts
+++ b/test/GPv2TradeExecution.test.ts
@@ -88,7 +88,7 @@ describe("GPv2TradeExecution", () => {
       ).to.be.revertedWith("call to non-contract");
     });
 
-    it("should revert when using marker buy Ether address", async () => {
+    it("should revert when mistakenly trying to sell ETH using the marker buy Ether address", async () => {
       await expect(
         tradeExecution.transferSellAmountToRecipientTest(
           encodeExecutedTrade({

--- a/test/e2e/buyEth.test.ts
+++ b/test/e2e/buyEth.test.ts
@@ -47,14 +47,14 @@ describe("E2E: Buy Ether", () => {
     usdt = await waffle.deployContract(deployer, ERC20, ["USDT", 6]);
   });
 
-  it("should unwrap WETH for orders buying ETH", async () => {
+  it("should unwrap WETH for orders buying Ether", async () => {
     // Settle a trivial batch between two overlapping trades:
     //
     //   /----(1. SELL 1 WETH for USDT if p(WETH) >= 1100)----\
     //   |                                                    v
-    // [USDT]                                              [WETH]
+    // [USDT]                                              [(W)ETH]
     //   ^                                                    |
-    //   \----(2. BUY 1 WETH for USDT if p(WETH) <= 1200)-----/
+    //   \-----(2. BUY 1 ETH for USDT if p(WETH) <= 1200)-----/
 
     const encoder = new SettlementEncoder(domainSeparator);
 

--- a/test/e2e/buyEth.test.ts
+++ b/test/e2e/buyEth.test.ts
@@ -1,0 +1,133 @@
+import ERC20 from "@openzeppelin/contracts/build/contracts/ERC20PresetMinterPauser.json";
+import WETH from "canonical-weth/build/contracts/WETH9.json";
+import { expect } from "chai";
+import { Contract, Wallet } from "ethers";
+import { ethers, waffle } from "hardhat";
+
+import {
+  BUY_ETH_ADDRESS,
+  OrderKind,
+  SettlementEncoder,
+  SigningScheme,
+  TypedDataDomain,
+  domain,
+} from "../../src/ts";
+
+import { deployTestContracts } from "./fixture";
+
+describe("E2E: Buy Ether", () => {
+  let deployer: Wallet;
+  let solver: Wallet;
+  let traders: Wallet[];
+
+  let settlement: Contract;
+  let allowanceManager: Contract;
+  let domainSeparator: TypedDataDomain;
+
+  let weth: Contract;
+  let usdt: Contract;
+
+  beforeEach(async () => {
+    const deployment = await deployTestContracts();
+
+    ({
+      deployer,
+      settlement,
+      allowanceManager,
+      wallets: [solver, ...traders],
+    } = deployment);
+
+    const { authenticator, owner } = deployment;
+    await authenticator.connect(owner).addSolver(solver.address);
+
+    const { chainId } = await ethers.provider.getNetwork();
+    domainSeparator = domain(chainId, settlement.address);
+
+    weth = await waffle.deployContract(deployer, WETH);
+    usdt = await waffle.deployContract(deployer, ERC20, ["USDT", 6]);
+  });
+
+  it("should unwrap WETH for orders buying ETH", async () => {
+    // Settle a trivial batch between two overlapping trades:
+    //
+    //   /----(1. SELL 1 WETH for USDT if p(WETH) >= 1100)----\
+    //   |                                                    v
+    // [USDT]                                              [WETH]
+    //   ^                                                    |
+    //   \----(2. BUY 1 WETH for USDT if p(WETH) <= 1200)-----/
+
+    const encoder = new SettlementEncoder(domainSeparator);
+
+    await weth
+      .connect(traders[0])
+      .deposit({ value: ethers.utils.parseEther("1.001") });
+    await weth
+      .connect(traders[0])
+      .approve(allowanceManager.address, ethers.constants.MaxUint256);
+    await encoder.signEncodeTrade(
+      {
+        kind: OrderKind.SELL,
+        partiallyFillable: false,
+        sellToken: weth.address,
+        buyToken: usdt.address,
+        sellAmount: ethers.utils.parseEther("1.0"),
+        buyAmount: ethers.utils.parseUnits("1100.0", 6),
+        feeAmount: ethers.utils.parseEther("0.001"),
+        validTo: 0xffffffff,
+        appData: 1,
+      },
+      traders[0],
+      SigningScheme.TYPED_DATA,
+    );
+
+    await usdt.mint(traders[1].address, ethers.utils.parseUnits("1201.2", 6));
+    await usdt
+      .connect(traders[1])
+      .approve(allowanceManager.address, ethers.constants.MaxUint256);
+    await encoder.signEncodeTrade(
+      {
+        kind: OrderKind.BUY,
+        partiallyFillable: false,
+        buyToken: BUY_ETH_ADDRESS,
+        sellToken: usdt.address,
+        buyAmount: ethers.utils.parseEther("1.0"),
+        sellAmount: ethers.utils.parseUnits("1200.0", 6),
+        feeAmount: ethers.utils.parseUnits("1.2", 6),
+        validTo: 0xffffffff,
+        appData: 2,
+      },
+      traders[1],
+      SigningScheme.TYPED_DATA,
+    );
+
+    encoder.encodeInteraction({
+      target: weth.address,
+      callData: weth.interface.encodeFunctionData("withdraw", [
+        ethers.utils.parseEther("1.0"),
+      ]),
+    });
+
+    const trader1InitialBalance = await traders[1].getBalance();
+    await settlement.connect(solver).settle(
+      encoder.tokens,
+      encoder.clearingPrices({
+        [weth.address]: ethers.utils.parseUnits("1150.0", 6),
+        [BUY_ETH_ADDRESS]: ethers.utils.parseUnits("1150.0", 6),
+        [usdt.address]: ethers.utils.parseEther("1.0"),
+      }),
+      encoder.encodedTrades,
+      encoder.encodedInteractions,
+      "0x",
+    );
+
+    expect(await weth.balanceOf(settlement.address)).to.deep.equal(
+      ethers.utils.parseEther("0.001"),
+    );
+    expect(await weth.balanceOf(traders[0].address)).to.deep.equal(
+      ethers.constants.Zero,
+    );
+    expect(await traders[1].getBalance()).to.deep.equal(
+      trader1InitialBalance.add(ethers.utils.parseEther("1.0")),
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2314,6 +2314,11 @@ caniuse-lite@^1.0.30000844:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001173.tgz#3c47bbe3cd6d7a9eda7f50ac016d158005569f56"
   integrity sha512-R3aqmjrICdGCTAnSXtNyvWYMK3YtV5jwudbq0T7nN9k4kmE4CBuwPqyJ+KBzepSTh0huivV2gLbSMEzTTmfeYw==
 
+canonical-weth@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/canonical-weth/-/canonical-weth-1.4.0.tgz#e6b16574443e8ff0a132f1b4947bb2faf8c3e078"
+  integrity sha512-9rkLfAFndWALLhxd5lpyTX4RkV36WmVBZ92NYtYr1kWdAUmclRp7I5KkK4wvogzDcCI++yw53TLwx/GCPcocMg==
+
 caseless@^0.12.0, caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"


### PR DESCRIPTION
This PR introduces a special ETH marker address so orders can buy ETH and have it be automatically unwrapped. The unwrapping is done with the existing contract interaction support.

### Test Plan

Added unit test and an E2E test demonstrating a settlement where an EOA order buys ETH and gets it automatically unwrapped.
