### PR TITLE
Bump Solidity to v0.7.6

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -48,7 +48,7 @@ export default {
     sources: "src/contracts",
   },
   solidity: {
-    version: "0.7.5",
+    version: "0.7.6",
     settings: {
       optimizer: {
         enabled: true,

--- a/src/contracts/GPv2AllowListAuthentication.sol
+++ b/src/contracts/GPv2AllowListAuthentication.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0
-pragma solidity ^0.7.5;
+pragma solidity ^0.7.6;
 
 import "@gnosis.pm/util-contracts/contracts/StorageAccessible.sol";
 import "@openzeppelin/contracts/utils/EnumerableSet.sol";

--- a/src/contracts/GPv2AllowanceManager.sol
+++ b/src/contracts/GPv2AllowanceManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0
-pragma solidity ^0.7.5;
+pragma solidity ^0.7.6;
 pragma abicoder v2;
 
 import "./libraries/GPv2TradeExecution.sol";

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0
-pragma solidity ^0.7.5;
+pragma solidity ^0.7.6;
 pragma abicoder v2;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -204,16 +204,6 @@ contract GPv2Settlement {
         GPv2TradeExecution.Data memory executedTrade
     ) internal {
         GPv2Encoding.Order memory order = trade.order;
-        // NOTE: Currently, the above instantiation allocates an uninitialized
-        // `Order` that gets never used. Adjust the free memory pointer to free
-        // the unused memory by subtracting `sizeof(Order) == 288` bytes.
-        // <https://solidity.readthedocs.io/en/v0.7.5/internals/layout_in_memory.html>
-        // TODO: Remove this once the following fix is merged and released:
-        // <https://github.com/ethereum/solidity/pull/10341>
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            mstore(0x40, sub(mload(0x40), 288))
-        }
 
         // solhint-disable-next-line not-rely-on-time
         require(order.validTo >= block.timestamp, "GPv2: order expired");

--- a/src/contracts/interfaces/GPv2Authentication.sol
+++ b/src/contracts/interfaces/GPv2Authentication.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0
-pragma solidity ^0.7.5;
+pragma solidity ^0.7.6;
 
 /// @title Gnosis Protocol v2 Authentication Interface
 /// @author Gnosis Developers

--- a/src/contracts/libraries/GPv2TradeExecution.sol
+++ b/src/contracts/libraries/GPv2TradeExecution.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0
-pragma solidity ^0.7.5;
+pragma solidity ^0.7.6;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";

--- a/src/contracts/ownership/CustomInitiallyOwnable.sol
+++ b/src/contracts/ownership/CustomInitiallyOwnable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0
-pragma solidity ^0.7.5;
+pragma solidity ^0.7.6;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/src/contracts/reader/AllowListStorageReader.sol
+++ b/src/contracts/reader/AllowListStorageReader.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0
-pragma solidity ^0.7.5;
+pragma solidity ^0.7.6;
 
 import "@gnosis.pm/util-contracts/contracts/StorageAccessible.sol";
 import "@openzeppelin/contracts/utils/EnumerableSet.sol";

--- a/src/contracts/test/EventEmitter.sol
+++ b/src/contracts/test/EventEmitter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0
-pragma solidity ^0.7.5;
+pragma solidity ^0.7.6;
 
 contract EventEmitter {
     event Event(uint256 number);

--- a/src/contracts/test/GPv2EncodingTestInterface.sol
+++ b/src/contracts/test/GPv2EncodingTestInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0
-pragma solidity ^0.7.5;
+pragma solidity ^0.7.6;
 pragma abicoder v2;
 
 import "../libraries/GPv2Encoding.sol";

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0
-pragma solidity ^0.7.5;
+pragma solidity ^0.7.6;
 pragma abicoder v2;
 
 import "../GPv2Settlement.sol";

--- a/src/contracts/test/GPv2TradeExecutionTestInterface.sol
+++ b/src/contracts/test/GPv2TradeExecutionTestInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: LGPL-3.0
-pragma solidity ^0.7.5;
+pragma solidity ^0.7.6;
 pragma abicoder v2;
 
 import "../libraries/GPv2TradeExecution.sol";

--- a/test/bytecode.ts
+++ b/test/bytecode.ts
@@ -14,7 +14,7 @@ export async function builtAndDeployedMetadataCoincide(
   // NOTE: The last 53 bytes in a deployed contract's bytecode contains the
   // contract metadata. Compare the deployed contract's metadata with the
   // compiled contract's metadata.
-  // <https://docs.soliditylang.org/en/v0.7.5/metadata.html>
+  // <https://docs.soliditylang.org/en/v0.7.6/metadata.html>
   const metadata = (bytecode: string) => bytecode.slice(-106);
 
   return metadata(code) === metadata(contractArtifacts.deployedBytecode);


### PR DESCRIPTION
This PR upgrades `solc` to v0.7.6, a minor update with some fixes, specifically around preventing memory allocations in some cases. This has marginal performance benefits, but more critically, it allows to remove some assembly workaround that was previous included to patch one of issues that were fixed in the compiler.

### Test Plan

CI still passes, also benchmarks show some very marginal performance gains:
<details><summary>Benchmarks</summary>

```
$ git checkout solidity-v0.7.6
$ yarn -s bench:decodeTrade
5421 gas used for decoding 1 orders
26783 gas used for decoding 5 orders
53486 gas used for decoding 10 orders
133596 gas used for decoding 25 orders
267112 gas used for decoding 50 orders
534143 gas used for decoding 100 orders
$ git checkout main
$ yarn -s bench:decodeTrade
5458 gas used for decoding 1 orders
26968 gas used for decoding 5 orders
53856 gas used for decoding 10 orders
134521 gas used for decoding 25 orders
268962 gas used for decoding 50 orders
537843 gas used for decoding 100 orders
```

</details>
