### PR TITLE
Claim gas refunds from settlement function

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -147,7 +147,7 @@ contract GPv2Settlement {
 
         transferOut(executedTrades);
 
-        require(encodedOrderRefunds.length == 0, "not yet implemented");
+        claimOrderRefunds(encodedOrderRefunds);
     }
 
     /// @dev Invalidate onchain an order that has been signed offline.

--- a/src/ts/order.ts
+++ b/src/ts/order.ts
@@ -228,6 +228,11 @@ export async function signOrder(
 }
 
 /**
+ * The byte length of an order UID.
+ */
+export const ORDER_UID_LENGTH = 56;
+
+/**
  * Order unique identifier parameters.
  */
 export interface OrderUidParams {
@@ -272,7 +277,7 @@ export function computeOrderUid({
  */
 export function extractOrderUidParams(orderUid: string): OrderUidParams {
   const bytes = ethers.utils.arrayify(orderUid);
-  if (bytes.length != 56) {
+  if (bytes.length != ORDER_UID_LENGTH) {
     throw new Error("invalid order UID length");
   }
 
@@ -284,18 +289,4 @@ export function extractOrderUidParams(orderUid: string): OrderUidParams {
     ),
     validTo: view.getUint32(52),
   };
-}
-
-/**
- * Encodes order UIDs for gas refunds.
- *
- * @param orderUid The order UID encoded as a hexadecimal string.
- * @returns The extracted order UID parameters.
- */
-export function encodeOrderRefunds(orderUids: string[]): string {
-  if (!orderUids.every((orderUid) => ethers.utils.isHexString(orderUid, 56))) {
-    throw new Error("one or more invalid order UIDs");
-  }
-
-  return ethers.utils.hexConcat(orderUids);
 }

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -13,7 +13,6 @@ import {
   TypedDataDomain,
   computeOrderUid,
   domain,
-  encodeOrderRefunds,
   hashOrder,
 } from "../src/ts";
 
@@ -935,7 +934,7 @@ describe("GPv2Settlement", () => {
         );
       }
 
-      await settlement.claimOrderRefundsTest(encodeOrderRefunds(orderUids));
+      await settlement.claimOrderRefundsTest(ethers.utils.hexConcat(orderUids));
       for (const orderUid of orderUids) {
         expect(await settlement.filledAmount(orderUid)).to.deep.equal(
           ethers.constants.Zero,

--- a/test/e2e/orderRefunds.test.ts
+++ b/test/e2e/orderRefunds.test.ts
@@ -11,7 +11,6 @@ import {
   TypedDataDomain,
   computeOrderUid,
   domain,
-  encodeOrderRefunds,
   hashOrder,
 } from "../../src/ts";
 
@@ -131,6 +130,7 @@ describe("E2E: Expired Order Gas Refunds", () => {
     };
 
     const [encoder1, orderUids] = await prepareBatch();
+
     const txWithoutRefunds = await settlement.connect(solver).settle(
       encoder1.tokens,
       encoder1.clearingPrices({
@@ -147,6 +147,8 @@ describe("E2E: Expired Order Gas Refunds", () => {
     await ethers.provider.send("evm_mine", []);
 
     const [encoder2] = await prepareBatch();
+    encoder2.encodeOrderRefunds(...orderUids);
+
     const txWithRefunds = await settlement.connect(solver).settle(
       encoder2.tokens,
       encoder2.clearingPrices({
@@ -155,7 +157,7 @@ describe("E2E: Expired Order Gas Refunds", () => {
       }),
       encoder2.encodedTrades,
       encoder2.encodedInteractions,
-      encodeOrderRefunds(orderUids),
+      encoder2.encodedOrderRefunds,
     );
     const { gasUsed: gasUsedWithRefunds } = await txWithRefunds.wait();
 

--- a/test/e2e/orderRefunds.test.ts
+++ b/test/e2e/orderRefunds.test.ts
@@ -1,0 +1,169 @@
+import ERC20 from "@openzeppelin/contracts/build/contracts/ERC20PresetMinterPauser.json";
+import { expect } from "chai";
+import Debug from "debug";
+import { Contract, Wallet } from "ethers";
+import { ethers, waffle } from "hardhat";
+
+import {
+  OrderKind,
+  SettlementEncoder,
+  SigningScheme,
+  TypedDataDomain,
+  computeOrderUid,
+  domain,
+  encodeOrderRefunds,
+  hashOrder,
+} from "../../src/ts";
+
+import { deployTestContracts } from "./fixture";
+
+const debug = Debug("e2e:orderRefunds");
+
+describe("E2E: Expired Order Gas Refunds", () => {
+  let deployer: Wallet;
+  let solver: Wallet;
+  let traders: Wallet[];
+
+  let settlement: Contract;
+  let allowanceManager: Contract;
+  let domainSeparator: TypedDataDomain;
+
+  let owl: Contract;
+  let dai: Contract;
+
+  beforeEach(async () => {
+    const deployment = await deployTestContracts();
+
+    ({
+      deployer,
+      settlement,
+      allowanceManager,
+      wallets: [solver, ...traders],
+    } = deployment);
+
+    const { authenticator, owner } = deployment;
+    await authenticator.connect(owner).addSolver(solver.address);
+
+    const { chainId } = await ethers.provider.getNetwork();
+    domainSeparator = domain(chainId, settlement.address);
+
+    owl = await waffle.deployContract(deployer, ERC20, ["OWL", 18]);
+    dai = await waffle.deployContract(deployer, ERC20, ["DAI", 18]);
+  });
+
+  it("should claim a gas refund for expired orders", async () => {
+    // Settle the same trvial batch between two overlapping trades twice:
+    //
+    //   /--(1. SELL 100 OWL for DAI if p(OWL/DAI) >= 1)---\
+    //   |                                                 v
+    // [DAI]                                             [OWL]
+    //   ^                                                 |
+    //   \--(2. BUY 100 OWL for DAI if p(OWL/DAI) <= 1.1)--/
+
+    // NOTE: Mint extra tokens for all traders and the settlement contract to
+    // ensure that things like un-zeroing or zeroing a balance affects the gas
+    // results.
+    for (const token of [owl, dai]) {
+      await token.mint(settlement.address, ethers.utils.parseEther("1.0"));
+      for (const trader of traders.slice(0, 2)) {
+        await token.mint(trader.address, ethers.utils.parseEther("1000000.0"));
+        await token
+          .connect(trader)
+          .approve(allowanceManager.address, ethers.constants.MaxUint256);
+      }
+    }
+
+    const ORDER_VALIDITY = 60; // seconds
+    const prepareBatch = async () => {
+      const { timestamp } = await ethers.provider.getBlock("latest");
+      const validTo = timestamp + ORDER_VALIDITY;
+
+      const sellOrder = {
+        kind: OrderKind.SELL,
+        partiallyFillable: false,
+        sellToken: owl.address,
+        buyToken: dai.address,
+        sellAmount: ethers.utils.parseEther("100.0"),
+        buyAmount: ethers.utils.parseEther("100.0"),
+        feeAmount: ethers.utils.parseEther("0.1"),
+        validTo,
+        appData: 1,
+      };
+
+      const buyOrder = {
+        kind: OrderKind.BUY,
+        partiallyFillable: false,
+        buyToken: owl.address,
+        sellToken: dai.address,
+        buyAmount: ethers.utils.parseEther("100.0"),
+        sellAmount: ethers.utils.parseEther("110.0"),
+        feeAmount: ethers.utils.parseEther("0.1"),
+        validTo,
+        appData: 2,
+      };
+
+      const encoder = new SettlementEncoder(domainSeparator);
+      await encoder.signEncodeTrade(
+        sellOrder,
+        traders[0],
+        SigningScheme.TYPED_DATA,
+      );
+      await encoder.signEncodeTrade(
+        buyOrder,
+        traders[1],
+        SigningScheme.TYPED_DATA,
+      );
+
+      const orderUids = [
+        computeOrderUid({
+          orderDigest: hashOrder(sellOrder),
+          owner: traders[0].address,
+          validTo,
+        }),
+        computeOrderUid({
+          orderDigest: hashOrder(buyOrder),
+          owner: traders[1].address,
+          validTo,
+        }),
+      ];
+
+      return [encoder, orderUids] as const;
+    };
+
+    const [encoder1, orderUids] = await prepareBatch();
+    const txWithoutRefunds = await settlement.connect(solver).settle(
+      encoder1.tokens,
+      encoder1.clearingPrices({
+        [owl.address]: ethers.utils.parseEther("1.05"),
+        [dai.address]: ethers.utils.parseEther("1.0"),
+      }),
+      encoder1.encodedTrades,
+      encoder1.encodedInteractions,
+      "0x",
+    );
+    const { gasUsed: gasUsedWithoutRefunds } = await txWithoutRefunds.wait();
+
+    await ethers.provider.send("evm_increaseTime", [ORDER_VALIDITY + 1]);
+    await ethers.provider.send("evm_mine", []);
+
+    const [encoder2] = await prepareBatch();
+    const txWithRefunds = await settlement.connect(solver).settle(
+      encoder2.tokens,
+      encoder2.clearingPrices({
+        [owl.address]: ethers.utils.parseEther("1.05"),
+        [dai.address]: ethers.utils.parseEther("1.0"),
+      }),
+      encoder2.encodedTrades,
+      encoder2.encodedInteractions,
+      encodeOrderRefunds(orderUids),
+    );
+    const { gasUsed: gasUsedWithRefunds } = await txWithRefunds.wait();
+
+    const gasSavingsPerOrderRefund = gasUsedWithoutRefunds
+      .sub(gasUsedWithRefunds)
+      .div(orderUids.length);
+    debug(`Gas savings per order: ${gasSavingsPerOrderRefund}`);
+
+    expect(gasSavingsPerOrderRefund.gt(8000)).to.be.true;
+  });
+});

--- a/test/e2e/orderRefunds.test.ts
+++ b/test/e2e/orderRefunds.test.ts
@@ -61,8 +61,8 @@ describe("E2E: Expired Order Gas Refunds", () => {
     //   \--(2. BUY 100 OWL for DAI if p(OWL/DAI) <= 1.1)--/
 
     // NOTE: Mint extra tokens for all traders and the settlement contract to
-    // ensure that things like un-zeroing or zeroing a balance affects the gas
-    // results.
+    // ensure that things like un-zeroing or zeroing a balance does not affect
+    // the gas usage results.
     for (const token of [owl, dai]) {
       await token.mint(settlement.address, ethers.utils.parseEther("1.0"));
       for (const trader of traders.slice(0, 2)) {


### PR DESCRIPTION
Closes #124

This PR implements claiming order refunds as part of the settlement.

### Test Plan

An e2e test was added that also gives us a rough estimate of how much gas gets refunded per order:
```
$ DEBUG=e2e:orderRefunds yarn -s test
...
  e2e:orderRefunds Gas savings per order: 8521 +0ms
    ✓ should claim a gas refund for expired orders (644ms)
...
```

It claims around 8500-8600 gas per order (depending on how many 0's are in the calldata).
