### PR TITLE
Make authenticator public

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -44,7 +44,7 @@ contract GPv2Settlement {
     /// That is, only authorised solvers have the ability to invoke settlements.
     /// Any valid authenticator implements an isSolver method called by the onlySolver
     /// modifier below.
-    GPv2Authentication private immutable authenticator;
+    GPv2Authentication public immutable authenticator;
 
     /// @dev The allowance manager which has access to EOA order funds. This
     /// contract is created during deployment

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -70,6 +70,12 @@ describe("GPv2Settlement", () => {
     });
   });
 
+  describe("authenticator", () => {
+    it("should be set to the authenticator the contract was initialized with", async () => {
+      expect(await settlement.authenticator()).to.equal(authenticator.address);
+    });
+  });
+
   describe("allowanceManager", () => {
     it("should deploy an allowance manager", async () => {
       const deployedAllowanceManager = await settlement.allowanceManager();


### PR DESCRIPTION
This PR just makes the `authenticator` immutable public. This can be useful if other on-chain components need to access to a settlement contract's authenticator address.

### Test Plan

Added unit test.
