### PR TITLE
Encode interaction Ether value

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -344,9 +344,12 @@ contract GPv2Settlement {
             interaction.target != address(allowanceManager),
             "GPv2: forbidden interaction"
         );
+
         // solhint-disable avoid-low-level-calls
         (bool success, bytes memory response) =
-            (interaction.target).call(interaction.callData);
+            (interaction.target).call{value: interaction.value}(
+                interaction.callData
+            );
         // solhint-enable avoid-low-level-calls
 
         // TODO - concatenate the following reponse "GPv2: Failed Interaction"

--- a/src/contracts/test/EventEmitter.sol
+++ b/src/contracts/test/EventEmitter.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.7.6;
 
 contract EventEmitter {
-    event Event(uint256 number);
+    event Event(uint256 value, uint256 number);
 
-    function emitEvent(uint256 number) external {
-        emit Event(number);
+    function emitEvent(uint256 number) external payable {
+        emit Event(msg.value, number);
     }
 }

--- a/src/ts/interaction.ts
+++ b/src/ts/interaction.ts
@@ -1,4 +1,4 @@
-import type { BytesLike } from "ethers";
+import type { BigNumberish, BytesLike } from "ethers";
 
 /**
  * Gnosis Protocol v2 interaction data.
@@ -9,7 +9,11 @@ export interface Interaction {
    */
   target: string;
   /**
+   * Call value in wei for the interaction, allowing Ether to be sent.
+   */
+  value?: BigNumberish;
+  /**
    * Call data used in the interaction with a smart contract.
    */
-  callData: BytesLike;
+  callData?: BytesLike;
 }

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -319,29 +319,42 @@ describe("GPv2Encoding", () => {
   });
 
   describe("decodeInteraction", () => {
-    it("decodes sample encoded interaction", async () => {
-      // Example from the documentation describing `decodeInteraction` in the
+    it("decodes sample encoded interactions", async () => {
+      // Examples from the documentation describing `decodeInteraction` in the
       // [`GPv2Encoding`] library.
-      const encodedInteraction =
-        "0x73c14081446bd1e4eb165250e826e80c5a523783000010000102030405060708090a0b0c0d0e0f";
-      const callData = "0x000102030405060708090a0b0c0d0e0f";
-      const target = ethers.utils.getAddress(
-        "0x73c14081446bd1e4eb165250e826e80c5a523783",
-      );
+      for (const sample of [
+        {
+          encodedInteraction:
+            "0x73c14081446bd1e4eb165250e826e80c5a52378300000010000102030405060708090a0b0c0d0e0f",
+          target: ethers.utils.getAddress(
+            "0x73c14081446bd1e4eb165250e826e80c5a523783",
+          ),
+          value: ethers.constants.Zero,
+          callData: "0x000102030405060708090a0b0c0d0e0f",
+        },
+        {
+          encodedInteraction:
+            "0x0000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000de0b6b3a7640000",
+          target: ethers.constants.AddressZero,
+          value: ethers.utils.parseEther("1.0"),
+          callData: "0x",
+        },
+      ]) {
+        // Note: the number of interactions is a convenience input used to
+        // preallocate the memory needed to store all interactions simultaneously.
+        // If this number does not correspond exactly to the amount recovered
+        // after decoding, then the test call reverts.
+        const numInteractions = 1;
+        const interactions = await encoding.decodeInteractionsTest(
+          sample.encodedInteraction,
+          numInteractions,
+        );
 
-      // Note: the number of interactions is a convenience input used to
-      // preallocate the memory needed to store all interactions simultaneously.
-      // If this number does not correspond exactly to the amount recovered
-      // after decoding, then the test call reverts.
-      const numInteractions = 1;
-      const interactions = await encoding.decodeInteractionsTest(
-        encodedInteraction,
-        numInteractions,
-      );
-
-      expect(interactions.length).to.equal(1);
-      expect(interactions[0].target).to.equal(target);
-      expect(interactions[0].callData).to.equal(callData);
+        expect(interactions.length).to.equal(1);
+        expect(interactions[0].target).to.equal(sample.target);
+        expect(interactions[0].callData).to.equal(sample.callData);
+        expect(interactions[0].value).to.deep.equal(sample.value);
+      }
     });
 
     it("should round-trip encode a single interaction", async () => {
@@ -350,7 +363,8 @@ describe("GPv2Encoding", () => {
       // hex representation.
       const interaction = {
         target: ethers.utils.getAddress(fillDistinctBytes(20, 0x11)),
-        callData: fillDistinctBytes(42, 0x11 + 20),
+        value: BigNumber.from(fillDistinctBytes(32, 0x11 + 20)),
+        callData: fillDistinctBytes(42, 0x11 + 52),
       };
 
       const encoder = new SettlementEncoder(testDomain);
@@ -369,53 +383,64 @@ describe("GPv2Encoding", () => {
 
     it("should round-trip encode multiple interactions", async () => {
       // Note: all fields should use distinct bytes as much as possible to make
-      // decoding errors easier to spot. 0x11 is used to avoid having bytes with
+      // decoding errors easier to spot. 0x01 is used to avoid having bytes with
       // zeroes in their hex representation.
-      const interaction1 = {
-        target: ethers.utils.getAddress(fillDistinctBytes(20, 0x11)),
-        callData: fillDistinctBytes(42, 0x11 + 20),
-      };
-      const interaction2 = {
-        target: ethers.utils.getAddress(fillDistinctBytes(20, 0x11 + 20 + 42)),
-        callData: fillDistinctBytes(1337, 0x11 + 2 * 20 + 42),
-      };
-      const interaction3 = {
-        target: ethers.utils.getAddress(
-          fillDistinctBytes(20, 0x11 + 2 * 20 + 42 + 1337),
-        ),
-        // Note: if the interaction decoding becomes significantly more
-        // inefficient, this test might fail with "tx has a higher gas limit
-        // than the block". In this case, the number of bytes below should be
-        // reduced.
-        callData: fillDistinctBytes(12000, 0x11 + 3 * 20 + 42 + 1337),
-      };
+      let seed = 0x01;
+      const nextBytes = (n: number) => fillDistinctBytes(n, (seed += n) - n);
+      const nextAddress = () => ethers.utils.getAddress(nextBytes(20));
+      const nextUint = () => BigNumber.from(nextBytes(32));
+      const interactions = [
+        {
+          target: nextAddress(),
+          value: nextUint(),
+          callData: nextBytes(42),
+        },
+        {
+          target: nextAddress(),
+          value: nextUint(),
+        },
+        {
+          target: nextAddress(),
+          // Note: if the interaction decoding becomes significantly more
+          // inefficient, this test might fail with "tx has a higher gas limit
+          // than the block". In this case, the number of bytes below should be
+          // reduced.
+          callData: nextBytes(12000),
+        },
+        {
+          target: nextAddress(),
+        },
+      ];
 
       const encoder = new SettlementEncoder(testDomain);
-      await encoder.encodeInteraction(interaction1);
-      await encoder.encodeInteraction(interaction2);
-      await encoder.encodeInteraction(interaction3);
+      for (const interaction of interactions) {
+        encoder.encodeInteraction(interaction);
+      }
 
-      const numInteractions = 3;
       const decodedInteractions = await encoding.decodeInteractionsTest(
         encoder.encodedInteractions,
-        numInteractions,
+        interactions.length,
       );
 
-      expect(decodedInteractions.length).to.equal(3);
-      expect(decodedInteractions[0].target).to.equal(interaction1.target);
-      expect(decodedInteractions[0].callData).to.equal(interaction1.callData);
-      expect(decodedInteractions[1].target).to.equal(interaction2.target);
-      expect(decodedInteractions[1].callData).to.equal(interaction2.callData);
-      expect(decodedInteractions[2].target).to.equal(interaction3.target);
-      expect(decodedInteractions[2].callData).to.equal(interaction3.callData);
+      expect(decodedInteractions.length).to.equal(interactions.length);
+      for (let i = 0; i < interactions.length; i++) {
+        const decodedInteraction = decodedInteractions[0];
+        const interaction = interactions[0];
+
+        expect(decodedInteraction.target).to.equal(interaction.target);
+        expect(decodedInteraction.value).to.equal(
+          interaction.value || ethers.constants.Zero,
+        );
+        expect(decodedInteraction.callData).to.equal(
+          interaction.callData || "0x",
+        );
+      }
     });
 
-    // Skipped because this test takes a surprisingly long time to complete.
-    // It is supposed to be passing without any change.
-    it.skip("encoder fails to add interactions with too much calldata", async () => {
+    it("encoder fails to add interactions with too much calldata", async () => {
       const interaction = {
         target: ethers.utils.getAddress(fillBytes(20, 0x00)),
-        callData: fillDistinctBytes(2 ** (8 * 3), 0x00),
+        callData: new Uint8Array(2 ** 24),
       };
 
       const encoder = new SettlementEncoder(testDomain);
@@ -427,7 +452,6 @@ describe("GPv2Encoding", () => {
         target: ethers.utils.getAddress(
           "0x73c14081446bd1e4eb165250e826e80c5a523783",
         ),
-        callData: "0x",
       };
 
       const encoder = new SettlementEncoder(testDomain);
@@ -441,13 +465,15 @@ describe("GPv2Encoding", () => {
 
       expect(decodedInteractions.length).to.equal(1);
       expect(decodedInteractions[0].target).to.equal(interaction.target);
-      expect(decodedInteractions[0].callData).to.equal(interaction.callData);
+      expect(decodedInteractions[0].value).to.deep.equal(ethers.constants.Zero);
+      expect(decodedInteractions[0].callData).to.equal("0x");
     });
 
     describe("invalid encoded interaction", () => {
       it("calldata shorter than length", async () => {
         const interaction = {
           target: ethers.utils.getAddress(fillBytes(20, 0x00)),
+          value: ethers.utils.parseEther("42.1337"),
           callData: fillDistinctBytes(10, 0x00),
         };
 
@@ -466,6 +492,7 @@ describe("GPv2Encoding", () => {
       it("calldata longer than length", async () => {
         const interaction = {
           target: ethers.utils.getAddress(fillBytes(20, 0x00)),
+          value: ethers.utils.parseEther("42.1337"),
           callData: fillDistinctBytes(10, 0x00),
         };
 

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -783,47 +783,71 @@ describe("GPv2Settlement", () => {
   describe("executeInteractions", () => {
     it("executes valid interactions", async () => {
       const EventEmitter = await ethers.getContractFactory("EventEmitter");
-      const contract1 = await EventEmitter.deploy();
-      const contract2 = await EventEmitter.deploy();
-      const contract3 = await EventEmitter.deploy();
-      expect(contract1.address)
-        .not.to.equal(contract2.address)
-        .not.to.equal(contract3.address);
-      expect(contract2.address).not.to.equal(contract3.address);
+      const interactionParameters = [
+        {
+          target: await EventEmitter.deploy(),
+          value: ethers.utils.parseEther("0.42"),
+          number: 1,
+        },
+        {
+          target: await EventEmitter.deploy(),
+          value: ethers.utils.parseEther("0.1337"),
+          number: 1,
+        },
+        {
+          target: await EventEmitter.deploy(),
+          value: ethers.constants.Zero,
+          number: 1,
+        },
+      ];
+
+      const uniqueContractAddresses = new Set(
+        interactionParameters.map((params) => params.target.address),
+      );
+      expect(uniqueContractAddresses.size).to.equal(
+        interactionParameters.length,
+      );
 
       const encoder = new SettlementEncoder(testDomain);
-      encoder.encodeInteraction({
-        target: contract1.address,
-        callData: contract1.interface.encodeFunctionData("emitEvent", [1]),
-      });
-      encoder.encodeInteraction({
-        target: contract2.address,
-        callData: contract2.interface.encodeFunctionData("emitEvent", [2]),
-      });
-      encoder.encodeInteraction({
-        target: contract3.address,
-        callData: contract3.interface.encodeFunctionData("emitEvent", [3]),
+      for (const { target, value, number } of interactionParameters) {
+        encoder.encodeInteraction({
+          target: target.address,
+          value,
+          callData: target.interface.encodeFunctionData("emitEvent", [number]),
+        });
+      }
+
+      // Note: make sure to send some Ether to the settlement contract so that
+      // it can execute the interactions with values.
+      await deployer.sendTransaction({
+        to: settlement.address,
+        value: ethers.utils.parseEther("1.0"),
       });
 
       const settled = settlement.executeInteractionsTest(
         encoder.encodedInteractions,
       );
-      const events = (await (await settled).wait()).events;
+      const { events } = await (await settled).wait();
 
       // Note: all contracts were touched.
-      await expect(settled).to.emit(contract1, "Event");
-      await expect(settled).to.emit(contract2, "Event");
-      await expect(settled).to.emit(contract3, "Event");
-
-      const uint256ToBytes32 = (n: number) =>
-        ethers.utils.solidityPack(["uint256"], [n]);
-      // Note: the execution order was respected.
-      expect(events[0].data).to.equal(uint256ToBytes32(1));
-      expect(events[1].data).to.equal(uint256ToBytes32(2));
-      expect(events[2].data).to.equal(uint256ToBytes32(3));
+      for (const { target } of interactionParameters) {
+        await expect(settled).to.emit(target, "Event");
+      }
 
       // Note: no extra calls.
-      expect(events.length).to.equal(3);
+      expect(events.length).to.equal(interactionParameters.length);
+
+      // Note: the execution order was respected.
+      for (let i = 0; i < interactionParameters.length; i++) {
+        const params = interactionParameters[i];
+        const args = params.target.interface.decodeEventLog(
+          "Event",
+          events[i].data,
+        );
+
+        expect(args.value).to.equal(params.value);
+        expect(args.number).to.equal(params.number);
+      }
     });
 
     it("reverts if any of the interactions reverts", async () => {
@@ -849,26 +873,25 @@ describe("GPv2Settlement", () => {
       // TODO - update this error with concatenated version "GPv2 Interaction:
       // test error"
       await expect(
-        settlement.callStatic.executeInteractionsTest(
-          encoder.encodedInteractions,
-        ),
+        settlement.executeInteractionsTest(encoder.encodedInteractions),
       ).to.be.revertedWith("test error");
     });
   });
 
   describe("executeInteraction", () => {
-    it("should fail when target is allowanceManager", async () => {
+    it("should revert when target is allowanceManager", async () => {
       const invalidInteraction: Interaction = {
         target: await settlement.allowanceManager(),
         callData: [],
+        value: 0,
       };
 
       await expect(
-        settlement.callStatic.executeInteractionTest(invalidInteraction),
+        settlement.executeInteractionTest(invalidInteraction),
       ).to.be.revertedWith("GPv2: forbidden interaction");
     });
 
-    it("should fail when interaction reverts", async () => {
+    it("should revert when interaction reverts", async () => {
       const reverter = await waffle.deployMockContract(deployer, [
         "function alwaysReverts()",
       ]);
@@ -879,22 +902,39 @@ describe("GPv2Settlement", () => {
       const failingInteraction: Interaction = {
         target: reverter.address,
         callData: revertingCallData,
+        value: 0,
       };
 
       // TODO - update this error with concatenated version "GPv2 Interaction: test error"
       await expect(
-        settlement.callStatic.executeInteractionTest(failingInteraction),
+        settlement.executeInteractionTest(failingInteraction),
       ).to.be.revertedWith("test error");
+    });
+
+    it("reverts if the settlement contract does not have sufficient Ether balance", async () => {
+      const value = ethers.utils.parseEther("1000000.0");
+      expect(value.gt(await ethers.provider.getBalance(settlement.address))).to
+        .be.true;
+
+      const encoder = new SettlementEncoder(testDomain);
+      encoder.encodeInteraction({
+        target: ethers.constants.AddressZero,
+        value,
+      });
+
+      await expect(
+        settlement.executeInteractionsTest(encoder.encodedInteractions),
+      ).to.be.reverted;
     });
 
     it("should pass on successful execution", async () => {
       const passingInteraction: Interaction = {
         target: ethers.constants.AddressZero,
         callData: "0x",
+        value: 0,
       };
-      await expect(
-        settlement.callStatic.executeInteractionTest(passingInteraction),
-      ).to.not.be.reverted;
+      await expect(settlement.executeInteractionTest(passingInteraction)).to.not
+        .be.reverted;
     });
   });
 

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -792,12 +792,12 @@ describe("GPv2Settlement", () => {
         {
           target: await EventEmitter.deploy(),
           value: ethers.utils.parseEther("0.1337"),
-          number: 1,
+          number: 2,
         },
         {
           target: await EventEmitter.deploy(),
           value: ethers.constants.Zero,
-          number: 1,
+          number: 3,
         },
       ];
 


### PR DESCRIPTION
Closes #315 

This PR extends the SC interactions to specify an Ether value to use when executing a contract call. This allows the settlement contract to natively use Eth when interacting with other contracts.

### Test Plan

Unit tests.
