### PR TITLE
emit settlement event

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -69,6 +69,9 @@ contract GPv2Settlement {
         bytes orderUid
     );
 
+    /// @dev Event emitted when a settlement complets
+    event Settlement(address indexed solver);
+
     /// @dev Event emitted when an order is invalidated.
     event OrderInvalidated(address indexed owner, bytes orderUid);
 
@@ -151,6 +154,8 @@ contract GPv2Settlement {
         transferOut(executedTrades);
 
         claimOrderRefunds(encodedOrderRefunds);
+
+        emit Settlement(msg.sender);
     }
 
     /// @dev Invalidate onchain an order that has been signed offline.

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -160,6 +160,13 @@ describe("GPv2Settlement", () => {
       await expect(settlement.connect(solver).settle([], [], [], [], [])).to.not
         .be.reverted;
     });
+
+    it("emits a Settlement event", async () => {
+      await authenticator.connect(owner).addSolver(solver.address);
+      await expect(settlement.connect(solver).settle([], [], [], [], []))
+        .to.emit(settlement, "Settlement")
+        .withArgs(solver.address);
+    });
   });
 
   describe("invalidateOrder", () => {


### PR DESCRIPTION
Partially addresses #113 

This PR adds a `Settlement` event that gets emitted at the end of a settlement with the solver as the only parameter (and is indexed). I had considered including prices, but those can be directly recovered from the transaction call data, and can't really be searched for anyways (whereas it might be conceivable that querying all past settlements made by specific solvers might be useful).

### Test Plan

Added a unit test to verify event is emitted with correct parameters.
