### PR TITLE
Settlement "Preparations"

### DIFF
--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -310,6 +310,7 @@ export class BenchFixture {
       .settle(
         encoder.tokens,
         encoder.clearingPrices(prices),
+        encoder.encodedPreparations,
         encoder.encodedTrades,
         encoder.encodedInteractions,
         encoder.encodedOrderRefunds,

--- a/src/contracts/test/ERC20Permit.sol
+++ b/src/contracts/test/ERC20Permit.sol
@@ -29,6 +29,7 @@ contract ERC20Permit is ERC20PresetMinterPauser {
 
     mapping(address => Counters.Counter) private _nonces;
 
+    // solhint-disable-next-line var-name-mixedcase
     bytes32 public immutable DOMAIN_SEPARATOR;
 
     // solhint-disable-next-line var-name-mixedcase
@@ -42,9 +43,7 @@ contract ERC20Permit is ERC20PresetMinterPauser {
      *
      * It's a good idea to use the same `name` that is defined as the ERC20 token name.
      */
-    constructor(string memory symbol)
-        ERC20PresetMinterPauser(symbol, symbol)
-    {
+    constructor(string memory symbol) ERC20PresetMinterPauser(symbol, symbol) {
         DOMAIN_SEPARATOR = keccak256(
             abi.encode(
                 keccak256(

--- a/src/contracts/test/ERC20Permit.sol
+++ b/src/contracts/test/ERC20Permit.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+
+/**
+ * This file is adapted the OpenZeppelin implementation which is not yet
+ * released on npm to also allow minting.
+ *
+ * Once a new OpenZeppelin version is released, this contract should be removed.
+ *
+ * Origianl source:
+ * <https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/drafts/IERC20Permit.sol>
+ */
+
+pragma solidity >=0.6.5 <0.8.0;
+
+import "@openzeppelin/contracts/presets/ERC20PresetMinterPauser.sol";
+import "@openzeppelin/contracts/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/utils/Counters.sol";
+
+/**
+ * @dev Implementation of the ERC20 Permit extension allowing approvals to be made via signatures, as defined in
+ * https://eips.ethereum.org/EIPS/eip-2612[EIP-2612].
+ *
+ * Adds the {permit} method, which can be used to change an account's ERC20 allowance (see {IERC20-allowance}) by
+ * presenting a message signed by the account. By not relying on `{IERC20-approve}`, the token holder account doesn't
+ * need to send a transaction, and thus is not required to hold Ether at all.
+ */
+contract ERC20Permit is ERC20PresetMinterPauser {
+    using Counters for Counters.Counter;
+
+    mapping(address => Counters.Counter) private _nonces;
+
+    bytes32 public immutable DOMAIN_SEPARATOR;
+
+    // solhint-disable-next-line var-name-mixedcase
+    bytes32 private immutable _PERMIT_TYPEHASH =
+        keccak256(
+            "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
+        );
+
+    /**
+     * @dev Initializes the {EIP712} domain separator using the `name` parameter, and setting `version` to `"1"`.
+     *
+     * It's a good idea to use the same `name` that is defined as the ERC20 token name.
+     */
+    constructor(string memory symbol)
+        ERC20PresetMinterPauser(symbol, symbol)
+    {
+        DOMAIN_SEPARATOR = keccak256(
+            abi.encode(
+                keccak256(
+                    "EIP712Domain(string name,address verifyingContract)"
+                ),
+                keccak256(bytes(symbol)),
+                address(this)
+            )
+        );
+    }
+
+    /**
+     * @dev See {IERC20Permit-permit}.
+     */
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public virtual {
+        // solhint-disable-next-line not-rely-on-time
+        require(block.timestamp <= deadline, "ERC20Permit: expired deadline");
+
+        bytes32 structHash =
+            keccak256(
+                abi.encode(
+                    _PERMIT_TYPEHASH,
+                    owner,
+                    spender,
+                    value,
+                    _nonces[owner].current(),
+                    deadline
+                )
+            );
+
+        bytes32 hash =
+            keccak256(
+                abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash)
+            );
+
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        address signer = ECDSA.recover(hash, signature);
+        require(signer == owner, "ERC20Permit: invalid signature");
+
+        _nonces[owner].increment();
+        _approve(owner, spender, value);
+    }
+
+    /**
+     * @dev See {IERC20Permit-nonces}.
+     */
+    function nonces(address owner) public view returns (uint256) {
+        return _nonces[owner].current();
+    }
+}

--- a/src/ts/interaction.ts
+++ b/src/ts/interaction.ts
@@ -1,4 +1,4 @@
-import type { BigNumberish, BytesLike } from "ethers";
+import { BigNumber, BigNumberish, BytesLike, ethers } from "ethers";
 
 /**
  * Gnosis Protocol v2 interaction data.
@@ -16,4 +16,21 @@ export interface Interaction {
    * Call data used in the interaction with a smart contract.
    */
   callData?: BytesLike;
+}
+
+export function encodeInteraction(interaction: Interaction): string {
+  const value = BigNumber.from(interaction.value || 0);
+  const callData = interaction.callData || "0x";
+  const callDataLength = ethers.utils.hexDataLength(callData);
+
+  const encodedInteraction = value.isZero()
+    ? ethers.utils.solidityPack(
+        ["address", "bool", "uint24", "bytes"],
+        [interaction.target, false, callDataLength, callData],
+      )
+    : ethers.utils.solidityPack(
+        ["address", "bool", "uint24", "uint256", "bytes"],
+        [interaction.target, true, callDataLength, value, callData],
+      );
+  return encodedInteraction;
 }

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -150,21 +150,23 @@ describe("GPv2Settlement", () => {
   });
 
   describe("settle", () => {
+    const empty = [[], [], "0x", "0x", "0x", "0x"];
+
     it("rejects transactions from non-solvers", async () => {
-      await expect(settlement.settle([], [], [], [], [])).to.be.revertedWith(
+      await expect(settlement.settle(...empty)).to.be.revertedWith(
         "GPv2: not a solver",
       );
     });
 
     it("accepts transactions from solvers", async () => {
       await authenticator.connect(owner).addSolver(solver.address);
-      await expect(settlement.connect(solver).settle([], [], [], [], [])).to.not
-        .be.reverted;
+      await expect(settlement.connect(solver).settle(...empty)).to.not.be
+        .reverted;
     });
 
     it("emits a Settlement event", async () => {
       await authenticator.connect(owner).addSolver(solver.address);
-      await expect(settlement.connect(solver).settle([], [], [], [], []))
+      await expect(settlement.connect(solver).settle(...empty))
         .to.emit(settlement, "Settlement")
         .withArgs(solver.address);
     });

--- a/test/e2e/buyEth.test.ts
+++ b/test/e2e/buyEth.test.ts
@@ -115,6 +115,7 @@ describe("E2E: Buy Ether", () => {
         [BUY_ETH_ADDRESS]: ethers.utils.parseUnits("1150.0", 6),
         [usdt.address]: ethers.utils.parseEther("1.0"),
       }),
+      "0x",
       encoder.encodedTrades,
       encoder.encodedInteractions,
       "0x",

--- a/test/e2e/ercPermit.test.ts
+++ b/test/e2e/ercPermit.test.ts
@@ -1,0 +1,158 @@
+import { expect } from "chai";
+import { Contract, Wallet } from "ethers";
+import { ethers } from "hardhat";
+
+import {
+  OrderKind,
+  SettlementEncoder,
+  SigningScheme,
+  TypedDataDomain,
+  domain,
+} from "../../src/ts";
+
+import { deployTestContracts } from "./fixture";
+
+describe("E2E: EIP-2612 Permit", () => {
+  let solver: Wallet;
+  let traders: Wallet[];
+
+  let settlement: Contract;
+  let allowanceManager: Contract;
+  let domainSeparator: TypedDataDomain;
+
+  let eurs: [Contract, Contract];
+
+  beforeEach(async () => {
+    const deployment = await deployTestContracts();
+
+    ({
+      settlement,
+      allowanceManager,
+      wallets: [solver, ...traders],
+    } = deployment);
+
+    const { authenticator, owner } = deployment;
+    await authenticator.connect(owner).addSolver(solver.address);
+
+    const { chainId } = await ethers.provider.getNetwork();
+    domainSeparator = domain(chainId, settlement.address);
+
+    const ERC20Permit = await ethers.getContractFactory("ERC20Permit");
+    eurs = [await ERC20Permit.deploy("EUR1"), await ERC20Permit.deploy("EUR2")];
+  });
+
+  it("permits trader allowance with settlement", async () => {
+    // Settle a trivial where all € stable coins trade 1:1.
+
+    const ONE_EUR = ethers.utils.parseEther("1.0");
+
+    const encoder = new SettlementEncoder(domainSeparator);
+
+    await eurs[0].mint(traders[0].address, ONE_EUR);
+    await eurs[0]
+      .connect(traders[0])
+      .approve(allowanceManager.address, ethers.constants.MaxUint256);
+    await encoder.signEncodeTrade(
+      {
+        kind: OrderKind.SELL,
+        partiallyFillable: false,
+        sellToken: eurs[0].address,
+        buyToken: eurs[1].address,
+        sellAmount: ONE_EUR,
+        buyAmount: ONE_EUR,
+        feeAmount: ethers.constants.Zero,
+        validTo: 0xffffffff,
+        appData: 1,
+      },
+      traders[0],
+      SigningScheme.TYPED_DATA,
+    );
+
+    await eurs[1].mint(traders[1].address, ONE_EUR);
+
+    const permit = {
+      owner: traders[1].address,
+      spender: allowanceManager.address,
+      value: ONE_EUR,
+      nonce: await eurs[1].nonces(traders[1].address),
+      deadline: 0xffffffff,
+    };
+    const { r, s, v } = ethers.utils.splitSignature(
+      await traders[1]._signTypedData(
+        {
+          name: await eurs[1].name(),
+          verifyingContract: eurs[1].address,
+        },
+        {
+          Permit: [
+            {
+              name: "owner",
+              type: "address",
+            },
+            {
+              name: "spender",
+              type: "address",
+            },
+            {
+              name: "value",
+              type: "uint256",
+            },
+            {
+              name: "nonce",
+              type: "uint256",
+            },
+            {
+              name: "deadline",
+              type: "uint256",
+            },
+          ],
+        },
+        permit,
+      ),
+    );
+    encoder.encodePreparation({
+      target: eurs[1].address,
+      callData: eurs[1].interface.encodeFunctionData("permit", [
+        permit.owner,
+        permit.spender,
+        permit.value,
+        permit.deadline,
+        v,
+        r,
+        s,
+      ]),
+    });
+
+    await encoder.signEncodeTrade(
+      {
+        kind: OrderKind.BUY,
+        partiallyFillable: false,
+        buyToken: eurs[0].address,
+        sellToken: eurs[1].address,
+        buyAmount: ONE_EUR,
+        sellAmount: ONE_EUR,
+        feeAmount: ethers.constants.Zero,
+        validTo: 0xffffffff,
+        appData: 2,
+      },
+      traders[1],
+      SigningScheme.TYPED_DATA,
+    );
+
+    await settlement.connect(solver).settle(
+      encoder.tokens,
+      encoder.clearingPrices({
+        [eurs[0].address]: 1,
+        [eurs[1].address]: 1,
+      }),
+      encoder.encodedPreparations,
+      encoder.encodedTrades,
+      "0x",
+      "0x",
+    );
+
+    expect(await eurs[1].balanceOf(traders[1].address)).to.deep.equal(
+      ethers.constants.Zero,
+    );
+  });
+});

--- a/test/e2e/orderRefunds.test.ts
+++ b/test/e2e/orderRefunds.test.ts
@@ -137,8 +137,9 @@ describe("E2E: Expired Order Gas Refunds", () => {
         [owl.address]: ethers.utils.parseEther("1.05"),
         [dai.address]: ethers.utils.parseEther("1.0"),
       }),
+      "0x",
       encoder1.encodedTrades,
-      encoder1.encodedInteractions,
+      "0x",
       "0x",
     );
     const { gasUsed: gasUsedWithoutRefunds } = await txWithoutRefunds.wait();
@@ -155,8 +156,9 @@ describe("E2E: Expired Order Gas Refunds", () => {
         [owl.address]: ethers.utils.parseEther("1.05"),
         [dai.address]: ethers.utils.parseEther("1.0"),
       }),
+      "0x",
       encoder2.encodedTrades,
-      encoder2.encodedInteractions,
+      "0x",
       encoder2.encodedOrderRefunds,
     );
     const { gasUsed: gasUsedWithRefunds } = await txWithRefunds.wait();

--- a/test/e2e/uniswapTrade.test.ts
+++ b/test/e2e/uniswapTrade.test.ts
@@ -173,6 +173,7 @@ describe("E2E: Should Trade Surplus With Uniswap", () => {
         [weth.address]: uniswapUsdtOutAmount,
         [usdt.address]: uniswapWethInAmount,
       }),
+      "0x",
       encoder.encodedTrades,
       encoder.encodedInteractions,
       "0x",

--- a/test/e2e/wineOilMarket.test.ts
+++ b/test/e2e/wineOilMarket.test.ts
@@ -145,6 +145,7 @@ describe("E2E: RetrETH Red Wine and Olive Oil Market", () => {
         [oil.address]: ethers.utils.parseEther("13.0"),
         [wine.address]: ethers.utils.parseEther("14.0"),
       }),
+      "0x",
       encoder.encodedTrades,
       "0x",
       "0x",


### PR DESCRIPTION
This PR implements a concept of "preparations" for a settlement. That is, a set of smart contract interactions to run before the settlement starts.

This is useful for example for implementing EIP-2612 `permit` support for collecting ERC20 allowances off-chain instead of requiring users to set the allowance with an on-chain transaction.

That being said, this can alternatively be implemented with a wrapper contract, very roughly implemented like this:
```solidity
contract PermitWrapper {
    function wrappedSettle(bytes memory settlementParamters, address[] tokens, bytes[] memory permits) {
        for (uint256 i = 0; i < tokens.length; i++) {
            tokens[i].call(permits[i]);
        }
        settlement.call(settlementParameters);
    }
}
```

### Test Plan

Added new e2e test that demonstrates how to use this for EIP-2612 `permit` for specifying allowances off-chain.
