### PR TITLE
Extended trace bench

### DIFF
--- a/bench/trace/gas.ts
+++ b/bench/trace/gas.ts
@@ -115,10 +115,7 @@ function callName({ address, bytecode, calldata }: CallMessageTrace): string {
       "function transferFrom(address, address, uint256)",
       "function transfer(address, uint256)",
     ],
-    UniswapV2Pair: [
-      "function swap(uint256, uint256, address, bytes)",
-      "function swap(uint256, uint256, address, bytes)",
-    ],
+    UniswapV2Pair: ["function swap(uint256, uint256, address, bytes)"],
   });
 
   let contractName, functionName;

--- a/bench/trace/gas.ts
+++ b/bench/trace/gas.ts
@@ -1,4 +1,5 @@
 import { BigNumber, BigNumberish, ContractReceipt } from "ethers";
+import Debug from "debug";
 import { ethers } from "hardhat";
 import {
   CallMessageTrace,
@@ -6,20 +7,26 @@ import {
   isCallTrace,
   isEvmStep,
   isPrecompileTrace,
+  MessageTraceStep,
 } from "hardhat/internal/hardhat-network/stack-traces/message-trace";
+import { JumpType } from "hardhat/internal/hardhat-network/stack-traces/model";
+
+const debug = Debug("bench:trace:gas");
 
 export interface GasTrace {
   name: string;
   gas: BigNumber;
+  cumulativeGas: BigNumber;
   children: GasTrace[];
 }
 
 function node(
   name: string,
   gas: BigNumberish,
+  cumulativeGas: BigNumberish,
   children?: GasTrace[],
 ): GasTrace {
-  return { name, gas: BigNumber.from(gas), children: children || [] };
+  return { name, gas: BigNumber.from(gas), cumulativeGas: BigNumber.from(cumulativeGas), children: children || [] };
 }
 
 export function decodeGasTrace(
@@ -37,10 +44,10 @@ export function decodeGasTrace(
     0,
   );
 
-  return node(callName(trace), tx.gasUsed, [
-    node("<base>", baseGas),
-    node("<calldata>", calldataGas),
-    entrypoint(trace),
+  return node(callName(trace), tx.gasUsed, 0, [
+    node("<base>", baseGas, 0),
+    node("<calldata>", calldataGas, baseGas),
+    entrypoint(trace, baseGas + calldataGas),
   ]);
 }
 
@@ -64,27 +71,86 @@ function callName({ address, bytecode, calldata }: CallMessageTrace): string {
   }`;
 }
 
-function entrypoint({ steps, gasUsed }: CallMessageTrace): GasTrace {
-  const children = [];
-  for (const step of steps) {
-    if (isEvmStep(step)) {
-      // TODO: Try and keep an internal function stack trace, although this
-      // has proven quite challenging with optimizations turned on.
-    } else if (isCallTrace(step)) {
-      children.push(externFunction(step));
-    } else if (isPrecompileTrace(step)) {
-      children.push(
-        node(`<precompile 0x${step.precompile}>`, step.gasUsed.toString()),
-      );
-    }
-  }
-
-  return node("<entrypoint>", gasUsed.toString(), children);
+function entrypoint(trace: CallMessageTrace, startingGas: BigNumberish): GasTrace {
+  const tracer = new CodeTracer(trace, startingGas);
+  const name = "<entrypoint>";
+  return node(name, trace.gasUsed.toString(), 0, tracer.traceToEnd(name));
 }
 
-function externFunction(
-  trace: CallMessageTrace | DecodedCallMessageTrace,
-): GasTrace {
-  const { children } = entrypoint(trace);
-  return node(callName(trace), trace.gasUsed.toString(), children);
+type GasExtended<T> = T & {
+  gasLeft?: unknown;
+  gasRefund?: unknown;
+}
+
+class CodeTracer {
+  private stepIndex = -1;
+
+  constructor(
+    public readonly trace: CallMessageTrace,
+    private readonly startingGas: BigNumberish,
+  ) {}
+
+  get step(): GasExtended<MessageTraceStep> {
+    return this.trace.steps[this.stepIndex];
+  }
+
+  private get cumulativeGas(): BigNumber {
+    return BigNumber.from(this.startingGas);
+  }
+
+  private nextStep(): GasExtended<MessageTraceStep> {
+    this.stepIndex++;
+    return this.step;
+  }
+
+  public traceToEnd(name: string): GasTrace[] {
+    const nodes = this.traceLocal(name);
+    if (this.step) {
+      throw new Error("trace to end with remaining steps")
+    }
+
+    return nodes;
+  }
+
+  private traceLocal(name: string): GasTrace[] {
+    debug(`>>> entering ${name}`);
+    
+    const nodes = [];
+    let step;
+    while (step = this.nextStep()) {
+      const { gasLeft, gasRefund } = step;
+      if (isEvmStep(step)) {
+        // TODO: Stack trace is not very accurate with optimizations turned on.
+        const instruction = this.trace.bytecode?.getInstruction(step.pc)
+        const jumpType = instruction?.jumpType;
+        if (jumpType == JumpType.INTO_FUNCTION) {
+            const name = instruction?.location?.getContainingFunction()?.name || "<unknown>";
+            const startingGas = BigNumber.from(`${gasLeft || 0}`);
+            const children = this.traceLocal(name);
+            const endingGas = BigNumber.from(`${this.step?.gasLeft || 0}`);
+            nodes.push(node(
+              name,
+              startingGas.sub(endingGas),
+              this.cumulativeGas,
+              children,
+            ))
+        } else if (jumpType == JumpType.OUTOF_FUNCTION) {
+          break;
+        }
+      } else if (isCallTrace(step)) {
+        const subTracer = new CodeTracer(step, this.startingGas);
+        const name = callName(step);
+        nodes.push(
+          node(name, step.gasUsed.toString(), this.cumulativeGas, subTracer.traceToEnd(name)),
+        );
+      } else if (isPrecompileTrace(step)) {
+        nodes.push(
+          node(`<precompile 0x${step.precompile}>`, step.gasUsed.toString(), this.cumulativeGas),
+        );
+      }
+    }
+
+    debug(`<<< exiting ${name}`);
+    return nodes;
+  }
 }

--- a/bench/trace/gas.ts
+++ b/bench/trace/gas.ts
@@ -177,9 +177,9 @@ function computeGasTrace(
       continue;
     }
 
-    const [prevStep, nextStep] = [steps[i - 1], steps[i + 1]];
-    if (!isEvmStep(prevStep) || !isEvmStep(nextStep)) {
-      throw new Error("expected EVM step surrounding sub trace");
+    const nextStep = steps[i + 1];
+    if (!isEvmStep(nextStep)) {
+      throw new Error("expected EVM step after sub trace");
     }
 
     const { gasLeft: gasLeftAfterCall } = (nextStep as unknown) as GasExtension;

--- a/bench/trace/hook/register.ts
+++ b/bench/trace/hook/register.ts
@@ -30,11 +30,16 @@ experimentalAddHardhatNetworkMessageTraceHook(async ({ ethers }, trace) => {
 });
 
 // NOTE: Leverage how hacky you can get with NodeJS and modify the tracer to
-// include gas information for instructions.
+// include additional gas information for instructions and subtraces. This code
+// should ideally be upstreamed and the experimental tracing extended to include
+// additional gas usage data.
+/* eslint-disable @typescript-eslint/no-explicit-any */
 const VMTracerPrototype = VMTracer.prototype as any;
-const { _stepHandler, _afterMessageHandler,  } = VMTracerPrototype;
+const { _stepHandler, _afterMessageHandler } = VMTracerPrototype;
 VMTracerPrototype._stepHandler = function (step: any, next: any) {
-  const trace = this._messageTraces[this._messageTraces.length - 1] || { steps: [] };
+  const trace = this._messageTraces[this._messageTraces.length - 1] || {
+    steps: [],
+  };
   const nsteps = trace.steps.length;
   return _stepHandler.call(this, step, (...args: unknown[]) => {
     // NOTE: Check if the step handler added a step, and if it did, the add gas
@@ -44,13 +49,14 @@ VMTracerPrototype._stepHandler = function (step: any, next: any) {
     }
     next(...args);
   });
-}
+};
 VMTracerPrototype._afterMessageHandler = function (result: any, next: any) {
   const trace = this._messageTraces[this._messageTraces.length - 1] || {};
   trace.gasLeft = result?.execResult?.gas;
   trace.gasRefund = result?.execResult?.gasRefund;
   return _afterMessageHandler.call(this, result, next);
-}
+};
+/* eslint-enable */
 
 export function getLastTrace(
   selector?: string,

--- a/bench/trace/hook/register.ts
+++ b/bench/trace/hook/register.ts
@@ -5,6 +5,7 @@ import {
   DecodedCallMessageTrace,
   isDecodedCallTrace,
 } from "hardhat/internal/hardhat-network/stack-traces/message-trace";
+import { VMTracer } from "hardhat/internal/hardhat-network/stack-traces/vm-tracer";
 
 const debug = Debug("bench:trace:hook:register");
 
@@ -27,6 +28,29 @@ experimentalAddHardhatNetworkMessageTraceHook(async ({ ethers }, trace) => {
 
   lastTrace = trace;
 });
+
+// NOTE: Leverage how hacky you can get with NodeJS and modify the tracer to
+// include gas information for instructions.
+const VMTracerPrototype = VMTracer.prototype as any;
+const { _stepHandler, _afterMessageHandler,  } = VMTracerPrototype;
+VMTracerPrototype._stepHandler = function (step: any, next: any) {
+  const trace = this._messageTraces[this._messageTraces.length - 1] || { steps: [] };
+  const nsteps = trace.steps.length;
+  return _stepHandler.call(this, step, (...args: unknown[]) => {
+    // NOTE: Check if the step handler added a step, and if it did, the add gas
+    // information to it.
+    if (trace.steps.length != nsteps) {
+      trace.steps[nsteps].gasLeft = step.gasLeft;
+    }
+    next(...args);
+  });
+}
+VMTracerPrototype._afterMessageHandler = function (result: any, next: any) {
+  const trace = this._messageTraces[this._messageTraces.length - 1] || {};
+  trace.gasLeft = result?.execResult?.gas;
+  trace.gasRefund = result?.execResult?.gasRefund;
+  return _afterMessageHandler.call(this, result, next);
+}
 
 export function getLastTrace(
   selector?: string,

--- a/bench/trace/index.ts
+++ b/bench/trace/index.ts
@@ -52,10 +52,12 @@ function formatGasTrace(gasTrace: GasTrace, path: GasTrace[] = []) {
 
   const { name, cumulativeGas, gasUsed, gasRefund, children } = gasTrace;
   const chalkedName = name.match(/^<.*>$/)
-    ? chalk.gray(name)
+    ? chalk.bold(chalk.gray(name))
     : name.match(/^@/)
     ? chalk.magenta(name)
-    : chalk.cyan(name);
+    : name.match(/\[.*\]\./)
+    ? chalk.cyan(name)
+    : chalk.bold(chalk.cyan(name));
 
   let gas = `${chalk.yellow(cumulativeGas)}`;
   if (gasUsed) {

--- a/bench/trace/index.ts
+++ b/bench/trace/index.ts
@@ -50,12 +50,22 @@ function formatGasTrace(gasTrace: GasTrace, path: GasTrace[] = []) {
     },
   );
 
-  const { name, gas, children } = gasTrace;
+  const { name, cumulativeGas, gasUsed, gasRefund, children } = gasTrace;
   const chalkedName = name.match(/^<.*>$/)
     ? chalk.gray(name)
+    : name.match(/^@/)
+    ? chalk.magenta(name)
     : chalk.cyan(name);
 
-  console.log(`${padding}${chalkedName} ${chalk.yellow(gas)}`);
+  let gas = `${chalk.yellow(cumulativeGas)}`;
+  if (gasUsed) {
+    gas = `${gas} ${chalk.red(`-${gasUsed}`)}`;
+  }
+  if (gasRefund) {
+    gas = `${gas} ${chalk.green(`+${gasRefund}`)}`;
+  }
+
+  console.log(`${padding}${chalkedName} ${gas}`);
   const subpath = [...path, gasTrace];
   for (const child of children) {
     formatGasTrace(child, subpath);


### PR DESCRIPTION
This PR extends the tracing code so that it can include additional information such as gas refunds and cumulative gas usage.

This was non-trivial since the tracing hooks lack a lot of information WRT gas statistics. That being said, I was able to hack something together that kind of works. While the solution is extremely hacky, this is just for tracing code that can be used for diagnosing gas usage in a settlement. This makes this, unfortunately, quite susceptible to bit-rot, but I think this was true of the previous code as well.

This works (because JS is... well... crazy) by modifying the `prototype` of the tracing internal Hardhat tracer class to extend it in order to add additional information passed from its inner `ethereumvm-js` runtime to gather more gas usage information.

Also, at the request of @fedgiac almost nothing is gray anymore (just things that aren't really worth reading, and its **bold** now :smile:).

One thing I noted is that the gas refund numbers seem off. I'm not sure exactly how the `ethereumvm-js` reports gas refunds, so I just blindly log what it gives me.

**edit**: Looks like the gas values make sense according to [EIP-2200](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2200.md) where `SSTORE` costs not only depend on whether or not the value was reset, but also on the original storage value before the transaction. These weird multiples of 4200 come from that.

### Test Plan

![image](https://user-images.githubusercontent.com/4210206/104638767-e024cc80-56a6-11eb-89e1-c6ed98452719.png)

