### PR TITLE
Additional benches

### DIFF
--- a/bench/index.ts
+++ b/bench/index.ts
@@ -54,6 +54,8 @@ async function main() {
     [2, 50, 0, 40],
     [2, 50, 0, 45],
     [2, 50, 0, 50],
+    [2, 2, 0, 0],
+    [2, 1, 1, 0],
     [10, 100, 10, 20],
   ]) {
     const { gasUsed } = await fixture.settle({


### PR DESCRIPTION
This PR adds a couple of benchmarking cases for small patches, either trading two orders against eachother directly, or going through Uniswap.

### Test Plan

`yarn bench` shows two new rows:
```
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
            2 |            2 |            0 |            0 |       184759 
            2 |            1 |            1 |            0 |       183300 
```
