### PR TITLE
Add benchmark comparison script

### DIFF
--- a/bench/compare.sh
+++ b/bench/compare.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -o pipefail
+set -o errexit
+set -o nounset
+
+is_number() {
+    [[ "$1" =~ ^[0-9]+$ ]]
+}
+gas() {
+    printf '%s' "$1" | awk '{print $NF}'
+}
+trades() {
+    printf '%s' "$1" | awk '{print $3}'
+}
+
+tested_path="$(git branch --show-current)"
+tested_path="${tested_path:-HEAD}"
+comparison_path="${1:-origin/main}"
+if ! git rev-parse --verify "$comparison_path" >/dev/null; then
+    echo "Invalid git reference $comparison_path" >&2
+    exit 1
+fi
+
+echo "Running benchmark for $tested_path..."
+yarn --silent build >/dev/null
+new_bench="$(yarn --silent bench)"
+
+git checkout --quiet "$comparison_path"
+
+echo "Running benchmark for $comparison_path..."
+yarn --silent build >/dev/null
+old_bench="$(yarn --silent bench)"
+
+paste -d '|' <(trades "$new_bench") \
+             <(gas "$new_bench") \
+             <(gas "$old_bench") \
+             <(printf '%s' "$new_bench") |
+    while IFS='|' read -r num_trades gas_new gas_old bench_line; do
+        diff=""
+        if is_number "$num_trades" \
+            && is_number "$gas_new" \
+            && is_number "$gas_old"; then
+            diff=" (change: $(((gas_new - gas_old) / num_trades)) / trade)"
+        fi
+        printf '%s\n' "$bench_line$diff"
+    done
+
+if [[ "$tested_path" == 'HEAD' ]]; then
+    git checkout --quiet "HEAD@{1}"
+else
+    git checkout --quiet "$tested_path"    
+fi

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "solvers": "hardhat solvers",
     "test": "hardhat test",
     "bench": "hardhat run bench/index.ts",
+    "bench:compare": "bash bench/compare.sh",
     "bench:trace": "hardhat run bench/trace/index.ts",
     "lint": "yarn lint:sol && yarn lint:ts",
     "lint:sol": "solhint 'src/contracts/**/*.sol'",


### PR DESCRIPTION
Adds an easy way to measure changes in gas cost with other revisions.

The script can be run as `yarn bench:compare [<path>]`, where path is the git revision with which to compare the gas performance. 
Sample output:
```
$ yarn bench:compare HEAD~1
<snip>
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
            2 |           10 |            0 |            0 |       741033  (change: -2060 / trade)
            3 |           10 |            0 |            0 |       741613  (change: -2058 / trade)
            4 |           10 |            0 |            0 |       750521  (change: -2060 / trade)
            5 |           10 |            0 |            0 |       755289  (change: -2054 / trade)
            6 |           10 |            0 |            0 |       751549  (change: -2061 / trade)
            7 |           10 |            0 |            0 |       760493  (change: -2056 / trade)
            8 |           10 |            0 |            0 |       765177  (change: -2057 / trade)
            8 |           20 |            0 |            0 |      1452452  (change: -2060 / trade)
            8 |           30 |            0 |            0 |      2093355  (change: -2061 / trade)
            8 |           40 |            0 |            0 |      2738732  (change: -2062 / trade)
            8 |           50 |            0 |            0 |      3383770  (change: -2065 / trade)
            8 |           60 |            0 |            0 |      4025321  (change: -2066 / trade)
            8 |           70 |            0 |            0 |      4671171  (change: -2069 / trade)
            8 |           80 |            0 |            0 |      5317027  (change: -2067 / trade)
            2 |           10 |            1 |            0 |       811599  (change: -2060 / trade)
            2 |           10 |            2 |            0 |       857309  (change: -2062 / trade)
            2 |           10 |            3 |            0 |       903104  (change: -2059 / trade)
            2 |           10 |            4 |            0 |       948712  (change: -2062 / trade)
            2 |           10 |            5 |            0 |       994496  (change: -2059 / trade)
            2 |           10 |            6 |            0 |      1040245  (change: -2059 / trade)
            2 |           10 |            7 |            0 |      1086006  (change: -2058 / trade)
            2 |           10 |            8 |            0 |      1131629  (change: -2054 / trade)
            2 |           50 |            0 |           10 |      3109487  (change: -2063 / trade)
            2 |           50 |            0 |           15 |      3066171  (change: -2064 / trade)
            2 |           50 |            0 |           20 |      3022667  (change: -2063 / trade)
            2 |           50 |            0 |           25 |      2979351  (change: -2064 / trade)
            2 |           50 |            0 |           30 |      2935975  (change: -2064 / trade)
            2 |           50 |            0 |           35 |      2892599  (change: -2067 / trade)
            2 |           50 |            0 |           40 |      2849239  (change: -2064 / trade)
            2 |           50 |            0 |           45 |      2805887  (change: -2064 / trade)
            2 |           50 |            0 |           50 |      2762439  (change: -2066 / trade)
           10 |          100 |           10 |           20 |      7115944  (change: -2073 / trade)
```

I decided to leave all compilation warnings in the output, since eventually there should be none.

### Test Plan

I created a new branch `compare-benches-test-plan` that is a commit above the branch of this PR. This branch contains the squashed changes from #346 and can be used for testing. Here is an example with shortened output:
```
bash>$ git checkout compare-benches-test-plan
bash>$ yarn bench:compare compare-benches
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
            2 |           10 |            0 |            0 |       741033  (change: -2060 / trade)
            3 |           10 |            0 |            0 |       741613  (change: -2058 / trade)
            4 |           10 |            0 |            0 |       750521  (change: -2060 / trade)
bash>$ yarn bench:compare HEAD~1
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
            2 |           10 |            0 |            0 |       741033  (change: -2060 / trade)
            3 |           10 |            0 |            0 |       741613  (change: -2058 / trade)
            4 |           10 |            0 |            0 |       750521  (change: -2060 / trade)
bash>$ git checkout HEAD~1
bash>$ yarn bench:compare compare-benches-test-plan
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
            2 |           10 |            0 |            0 |       761633  (change: 2060 / trade)
            3 |           10 |            0 |            0 |       762201  (change: 2058 / trade)
            4 |           10 |            0 |            0 |       771121  (change: 2060 / trade)
bash>$ git status
HEAD detached at b13b495
nothing to commit, working tree clean
```