### PR TITLE
Settlement Post-Interactions

### DIFF
--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -307,14 +307,7 @@ export class BenchFixture {
     debug(`executing settlement`);
     const transaction = await settlement
       .connect(solver)
-      .settle(
-        encoder.tokens,
-        encoder.clearingPrices(prices),
-        encoder.encodedPreparations,
-        encoder.encodedTrades,
-        encoder.encodedInteractions,
-        encoder.encodedOrderRefunds,
-      );
+      .settle(...encoder.encodedSettlement(prices));
 
     return await transaction.wait();
   }

--- a/src/ts/interaction.ts
+++ b/src/ts/interaction.ts
@@ -34,3 +34,7 @@ export function encodeInteraction(interaction: Interaction): string {
       );
   return encodedInteraction;
 }
+
+export function packInteractions(interactions: Interaction[]): string {
+  return ethers.utils.hexConcat(interactions.map(encodeInteraction));
+}

--- a/src/ts/settlement.ts
+++ b/src/ts/settlement.ts
@@ -17,7 +17,7 @@ import { TypedDataDomain } from "./types/ethers";
  */
 export enum InteractionStage {
   /**
-   * The interaction will be executed before any trading occur.
+   * The interaction will be executed before any trading occurs.
    *
    * This can be used, for example, to perform as EIP-2612 `permit` call for a
    * user trading in the current settlement.

--- a/src/ts/settlement.ts
+++ b/src/ts/settlement.ts
@@ -17,21 +17,25 @@ import { TypedDataDomain } from "./types/ethers";
  */
 export enum InteractionStage {
   /**
-   * The interaction will be executed before any trading occurs.
+   * A pre-settlement intraction.
    *
-   * This can be used, for example, to perform as EIP-2612 `permit` call for a
-   * user trading in the current settlement.
+   * The interaction will be executed before any trading occurs. This can be
+   * used, for example, to perform as EIP-2612 `permit` call for a user trading
+   * in the current settlement.
    */
   PRE = 0,
   /**
+   * An intra-settlement interaction.
+   *
    * The interaction will be executed after all trade sell amounts are
    * transferred into the settlement contract, but before the buy amounts are
-   * transferred out to the traders.
-   *
-   * This can be used, for example, to interact with on-chain AMMs.
+   * transferred out to the traders. This can be used, for example, to interact
+   * with on-chain AMMs.
    */
-  INTER = 1,
+  INTRA = 1,
   /**
+   * A post-settlement interaction.
+   *
    * The interaction will be executed after all trading has completed.
    */
   POST = 2,
@@ -117,7 +121,7 @@ export class SettlementEncoder {
   private _encodedTrades = "0x";
   private _encodedInteractions = {
     [InteractionStage.PRE]: "0x",
-    [InteractionStage.INTER]: "0x",
+    [InteractionStage.INTRA]: "0x",
     [InteractionStage.POST]: "0x",
   };
   private _encodedOrderRefunds = "0x";
@@ -158,7 +162,7 @@ export class SettlementEncoder {
   public get encodedInteractions(): [string, string, string] {
     return [
       this._encodedInteractions[InteractionStage.PRE],
-      this._encodedInteractions[InteractionStage.INTER],
+      this._encodedInteractions[InteractionStage.INTRA],
       this._encodedInteractions[InteractionStage.POST],
     ];
   }
@@ -292,7 +296,7 @@ export class SettlementEncoder {
    */
   public encodeInteraction(
     interaction: Interaction,
-    stage: InteractionStage = InteractionStage.INTER,
+    stage: InteractionStage = InteractionStage.INTRA,
   ): void {
     this._encodedInteractions[stage] = ethers.utils.hexConcat([
       this._encodedInteractions[stage],

--- a/src/ts/settlement.ts
+++ b/src/ts/settlement.ts
@@ -13,6 +13,31 @@ import {
 import { TypedDataDomain } from "./types/ethers";
 
 /**
+ * The stage an interaction should be executed in.
+ */
+export enum InteractionStage {
+  /**
+   * The interaction will be executed before any trading occur.
+   *
+   * This can be used, for example, to perform as EIP-2612 `permit` call for a
+   * user trading in the current settlement.
+   */
+  PRE = 0,
+  /**
+   * The interaction will be executed after all trade sell amounts are
+   * transferred into the settlement contract, but before the buy amounts are
+   * transferred out to the traders.
+   *
+   * This can be used, for example, to interact with on-chain AMMs.
+   */
+  INTER = 1,
+  /**
+   * The interaction will be executed after all trading has completed.
+   */
+  POST = 2,
+}
+
+/**
  * Details representing how an order was executed.
  */
 export interface TradeExecution {
@@ -35,6 +60,27 @@ export interface TradeExecution {
    */
   feeDiscount: number;
 }
+
+/**
+ * Table mapping token addresses to their respective clearing prices.
+ */
+export type Prices = Record<string, BigNumberish | undefined>;
+
+/**
+ * Encoded settlement parameters.
+ */
+export type EncodedSettlement = [
+  /** Tokens. */
+  string[],
+  /** Clearing prices. */
+  BigNumberish[],
+  /** Encoded trades. */
+  BytesLike,
+  /** Encoded interactions. */
+  [BytesLike, BytesLike, BytesLike],
+  /** Encoded order refunds. */
+  BytesLike,
+];
 
 /**
  * Fee discount value used to indicate that all fees should be waived.
@@ -68,9 +114,12 @@ function encodeOrderFlags(flags: OrderFlags): number {
 export class SettlementEncoder {
   private readonly _tokens: string[] = [];
   private readonly _tokenMap: Record<string, number | undefined> = {};
-  private _encodedPreparations = "0x";
   private _encodedTrades = "0x";
-  private _encodedInteractions = "0x";
+  private _encodedInteractions = {
+    [InteractionStage.PRE]: "0x",
+    [InteractionStage.INTER]: "0x",
+    [InteractionStage.POST]: "0x",
+  };
   private _encodedOrderRefunds = "0x";
 
   /**
@@ -96,13 +145,6 @@ export class SettlementEncoder {
   }
 
   /**
-   * Gets the encoded settlement preparations as a hex-encoded string.
-   */
-  public get encodedPreparations(): string {
-    return this._encodedPreparations;
-  }
-
-  /**
    * Gets the encoded trades as a hex-encoded string.
    */
   public get encodedTrades(): string {
@@ -110,10 +152,15 @@ export class SettlementEncoder {
   }
 
   /**
-   * Gets the encoded interactions as a hex-encoded string.
+   * Gets the encoded interactions for the specified stage as a hex-encoded
+   * string.
    */
-  public get encodedInteractions(): string {
-    return this._encodedInteractions;
+  public get encodedInteractions(): [string, string, string] {
+    return [
+      this._encodedInteractions[InteractionStage.PRE],
+      this._encodedInteractions[InteractionStage.INTER],
+      this._encodedInteractions[InteractionStage.POST],
+    ];
   }
 
   /**
@@ -146,9 +193,7 @@ export class SettlementEncoder {
    * @param prices The price map from token address to price.
    * @return The price vector.
    */
-  public clearingPrices(
-    prices: Record<string, BigNumberish | undefined>,
-  ): BigNumberish[] {
+  public clearingPrices(prices: Prices): BigNumberish[] {
     return this.tokens.map((token) => {
       const price = prices[token];
       if (price === undefined) {
@@ -156,19 +201,6 @@ export class SettlementEncoder {
       }
       return price;
     });
-  }
-
-  /**
-   * Encodes the input preparation in the packed format accepted by the smart
-   * contract and adds it to the settlement preparations encoded so far.
-   *
-   * @param preparation The preparation to encode.
-   */
-  public encodePreparation(preparation: Interaction): void {
-    this._encodedPreparations = ethers.utils.hexConcat([
-      this._encodedPreparations,
-      encodeInteraction(preparation),
-    ]);
   }
 
   /**
@@ -255,11 +287,15 @@ export class SettlementEncoder {
    * Encodes the input interaction in the packed format accepted by the smart
    * contract and adds it to the interactions encoded so far.
    *
+   * @param stage The stage the interaction should be executed.
    * @param interaction The interaction to encode.
    */
-  public encodeInteraction(interaction: Interaction): void {
-    this._encodedInteractions = ethers.utils.hexConcat([
-      this._encodedInteractions,
+  public encodeInteraction(
+    interaction: Interaction,
+    stage: InteractionStage = InteractionStage.INTER,
+  ): void {
+    this._encodedInteractions[stage] = ethers.utils.hexConcat([
+      this._encodedInteractions[stage],
       encodeInteraction(interaction),
     ]);
   }
@@ -282,6 +318,19 @@ export class SettlementEncoder {
       this._encodedOrderRefunds,
       ...orderUids,
     ]);
+  }
+
+  /**
+   * Returns the encoded settlement parameters.
+   */
+  public encodedSettlement(prices: Prices): EncodedSettlement {
+    return [
+      this.tokens,
+      this.clearingPrices(prices),
+      this.encodedTrades,
+      this.encodedInteractions,
+      this.encodedOrderRefunds,
+    ];
   }
 
   private tokenIndex(token: string): number {

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -8,6 +8,7 @@ import {
   SettlementEncoder,
   SigningScheme,
   computeOrderUid,
+  encodeInteraction,
   extractOrderUidParams,
   hashOrder,
 } from "../src/ts";
@@ -367,12 +368,9 @@ describe("GPv2Encoding", () => {
         callData: fillDistinctBytes(42, 0x11 + 52),
       };
 
-      const encoder = new SettlementEncoder(testDomain);
-      await encoder.encodeInteraction(interaction);
-
       const numInteractions = 1;
       const decodedInteractions = await encoding.decodeInteractionsTest(
-        encoder.encodedInteractions,
+        encodeInteraction(interaction),
         numInteractions,
       );
 
@@ -412,13 +410,12 @@ describe("GPv2Encoding", () => {
         },
       ];
 
-      const encoder = new SettlementEncoder(testDomain);
-      for (const interaction of interactions) {
-        encoder.encodeInteraction(interaction);
-      }
+      const encodedInteractions = ethers.utils.hexConcat(
+        interactions.map(encodeInteraction),
+      );
 
       const decodedInteractions = await encoding.decodeInteractionsTest(
-        encoder.encodedInteractions,
+        encodedInteractions,
         interactions.length,
       );
 
@@ -454,12 +451,9 @@ describe("GPv2Encoding", () => {
         ),
       };
 
-      const encoder = new SettlementEncoder(testDomain);
-      await encoder.encodeInteraction(interaction);
-
       const numInteractions = 1;
       const decodedInteractions = await encoding.decodeInteractionsTest(
-        encoder.encodedInteractions,
+        encodeInteraction(interaction),
         numInteractions,
       );
 
@@ -477,12 +471,9 @@ describe("GPv2Encoding", () => {
           callData: fillDistinctBytes(10, 0x00),
         };
 
-        const encoder = new SettlementEncoder(testDomain);
-        await encoder.encodeInteraction(interaction);
-
         const numInteractions = 1;
         const decoding = encoding.decodeInteractionsTest(
-          encoder.encodedInteractions.slice(0, -2),
+          encodeInteraction(interaction).slice(0, -2),
           numInteractions,
         );
 
@@ -496,12 +487,9 @@ describe("GPv2Encoding", () => {
           callData: fillDistinctBytes(10, 0x00),
         };
 
-        const encoder = new SettlementEncoder(testDomain);
-        await encoder.encodeInteraction(interaction);
-
         const numInteractions = 1;
         const decoding = encoding.decodeInteractionsTest(
-          encoder.encodedInteractions + "00",
+          encodeInteraction(interaction) + "00",
           numInteractions,
         );
 

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -8,9 +8,9 @@ import {
   SettlementEncoder,
   SigningScheme,
   computeOrderUid,
-  encodeInteraction,
   extractOrderUidParams,
   hashOrder,
+  packInteractions,
 } from "../src/ts";
 
 import { decodeTrade } from "./encoding";
@@ -370,7 +370,7 @@ describe("GPv2Encoding", () => {
 
       const numInteractions = 1;
       const decodedInteractions = await encoding.decodeInteractionsTest(
-        encodeInteraction(interaction),
+        packInteractions([interaction]),
         numInteractions,
       );
 
@@ -410,12 +410,8 @@ describe("GPv2Encoding", () => {
         },
       ];
 
-      const encodedInteractions = ethers.utils.hexConcat(
-        interactions.map(encodeInteraction),
-      );
-
       const decodedInteractions = await encoding.decodeInteractionsTest(
-        encodedInteractions,
+        packInteractions(interactions),
         interactions.length,
       );
 
@@ -453,7 +449,7 @@ describe("GPv2Encoding", () => {
 
       const numInteractions = 1;
       const decodedInteractions = await encoding.decodeInteractionsTest(
-        encodeInteraction(interaction),
+        packInteractions([interaction]),
         numInteractions,
       );
 
@@ -473,7 +469,7 @@ describe("GPv2Encoding", () => {
 
         const numInteractions = 1;
         const decoding = encoding.decodeInteractionsTest(
-          encodeInteraction(interaction).slice(0, -2),
+          packInteractions([interaction]).slice(0, -2),
           numInteractions,
         );
 
@@ -489,7 +485,7 @@ describe("GPv2Encoding", () => {
 
         const numInteractions = 1;
         const decoding = encoding.decodeInteractionsTest(
-          encodeInteraction(interaction) + "00",
+          packInteractions([interaction]) + "00",
           numInteractions,
         );
 

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -184,7 +184,7 @@ describe("GPv2Settlement", () => {
       const stages = [
         InteractionStage.POST,
         InteractionStage.PRE,
-        InteractionStage.INTER,
+        InteractionStage.INTRA,
       ];
 
       const encoder = new SettlementEncoder(testDomain);
@@ -209,7 +209,7 @@ describe("GPv2Settlement", () => {
         stageTarget(InteractionStage.PRE),
       );
       expect(events[1].args?.target).to.equal(
-        stageTarget(InteractionStage.INTER),
+        stageTarget(InteractionStage.INTRA),
       );
       expect(events[2].args?.target).to.equal(
         stageTarget(InteractionStage.POST),

--- a/test/e2e/burnFees.test.ts
+++ b/test/e2e/burnFees.test.ts
@@ -1,0 +1,119 @@
+import ERC20 from "@openzeppelin/contracts/build/contracts/ERC20PresetMinterPauser.json";
+import { expect } from "chai";
+import { Contract, Wallet } from "ethers";
+import { ethers, waffle } from "hardhat";
+
+import {
+  InteractionStage,
+  OrderKind,
+  SettlementEncoder,
+  SigningScheme,
+  TypedDataDomain,
+  domain,
+} from "../../src/ts";
+
+import { deployTestContracts } from "./fixture";
+
+describe("E2E: Burn fees", () => {
+  let deployer: Wallet;
+  let solver: Wallet;
+  let traders: Wallet[];
+
+  let settlement: Contract;
+  let allowanceManager: Contract;
+  let domainSeparator: TypedDataDomain;
+
+  let owl: Contract;
+  let dai: Contract;
+
+  beforeEach(async () => {
+    const deployment = await deployTestContracts();
+
+    ({
+      deployer,
+      settlement,
+      allowanceManager,
+      wallets: [solver, ...traders],
+    } = deployment);
+
+    const { authenticator, owner } = deployment;
+    await authenticator.connect(owner).addSolver(solver.address);
+
+    const { chainId } = await ethers.provider.getNetwork();
+    domainSeparator = domain(chainId, settlement.address);
+
+    owl = await waffle.deployContract(deployer, ERC20, ["OWL", 18]);
+    dai = await waffle.deployContract(deployer, ERC20, ["DAI", 18]);
+  });
+
+  it("permits trader allowance with settlement", async () => {
+    // Settle a trivial 1:1 trade between DAI and OWL.
+
+    const ONE_USD = ethers.utils.parseEther("1.0");
+
+    const encoder = new SettlementEncoder(domainSeparator);
+
+    await owl.mint(traders[0].address, ONE_USD.mul(1001));
+    await owl
+      .connect(traders[0])
+      .approve(allowanceManager.address, ethers.constants.MaxUint256);
+    await encoder.signEncodeTrade(
+      {
+        kind: OrderKind.SELL,
+        partiallyFillable: false,
+        sellToken: owl.address,
+        buyToken: dai.address,
+        sellAmount: ONE_USD.mul(1000),
+        buyAmount: ONE_USD.mul(1000),
+        feeAmount: ONE_USD,
+        validTo: 0xffffffff,
+        appData: 1,
+      },
+      traders[0],
+      SigningScheme.TYPED_DATA,
+    );
+
+    await dai.mint(traders[1].address, ONE_USD.mul(1000));
+    await dai
+      .connect(traders[1])
+      .approve(allowanceManager.address, ethers.constants.MaxUint256);
+
+    await encoder.signEncodeTrade(
+      {
+        kind: OrderKind.BUY,
+        partiallyFillable: false,
+        buyToken: owl.address,
+        sellToken: dai.address,
+        buyAmount: ONE_USD.mul(1000),
+        sellAmount: ONE_USD.mul(1000),
+        feeAmount: ethers.constants.Zero,
+        validTo: 0xffffffff,
+        appData: 2,
+      },
+      traders[1],
+      SigningScheme.TYPED_DATA,
+    );
+
+    encoder.encodeInteraction(
+      {
+        target: owl.address,
+        callData: owl.interface.encodeFunctionData("burn", [ONE_USD]),
+      },
+      InteractionStage.POST,
+    );
+
+    const tx = settlement.connect(solver).settle(
+      ...encoder.encodedSettlement({
+        [owl.address]: 1,
+        [dai.address]: 1,
+      }),
+    );
+
+    await expect(tx)
+      .to.emit(owl, "Transfer")
+      .withArgs(settlement.address, ethers.constants.AddressZero, ONE_USD);
+    expect(await dai.balanceOf(settlement.address)).to.deep.equal(
+      ethers.constants.Zero,
+    );
+  });
+});

--- a/test/e2e/buyEth.test.ts
+++ b/test/e2e/buyEth.test.ts
@@ -109,16 +109,11 @@ describe("E2E: Buy Ether", () => {
 
     const trader1InitialBalance = await traders[1].getBalance();
     await settlement.connect(solver).settle(
-      encoder.tokens,
-      encoder.clearingPrices({
+      ...encoder.encodedSettlement({
         [weth.address]: ethers.utils.parseUnits("1150.0", 6),
         [BUY_ETH_ADDRESS]: ethers.utils.parseUnits("1150.0", 6),
         [usdt.address]: ethers.utils.parseEther("1.0"),
       }),
-      "0x",
-      encoder.encodedTrades,
-      encoder.encodedInteractions,
-      "0x",
     );
 
     expect(await weth.balanceOf(settlement.address)).to.deep.equal(

--- a/test/e2e/orderRefunds.test.ts
+++ b/test/e2e/orderRefunds.test.ts
@@ -132,15 +132,10 @@ describe("E2E: Expired Order Gas Refunds", () => {
     const [encoder1, orderUids] = await prepareBatch();
 
     const txWithoutRefunds = await settlement.connect(solver).settle(
-      encoder1.tokens,
-      encoder1.clearingPrices({
+      ...encoder1.encodedSettlement({
         [owl.address]: ethers.utils.parseEther("1.05"),
         [dai.address]: ethers.utils.parseEther("1.0"),
       }),
-      "0x",
-      encoder1.encodedTrades,
-      "0x",
-      "0x",
     );
     const { gasUsed: gasUsedWithoutRefunds } = await txWithoutRefunds.wait();
 
@@ -151,15 +146,10 @@ describe("E2E: Expired Order Gas Refunds", () => {
     encoder2.encodeOrderRefunds(...orderUids);
 
     const txWithRefunds = await settlement.connect(solver).settle(
-      encoder2.tokens,
-      encoder2.clearingPrices({
+      ...encoder2.encodedSettlement({
         [owl.address]: ethers.utils.parseEther("1.05"),
         [dai.address]: ethers.utils.parseEther("1.0"),
       }),
-      "0x",
-      encoder2.encodedTrades,
-      "0x",
-      encoder2.encodedOrderRefunds,
     );
     const { gasUsed: gasUsedWithRefunds } = await txWithRefunds.wait();
 

--- a/test/e2e/uniswapTrade.test.ts
+++ b/test/e2e/uniswapTrade.test.ts
@@ -168,15 +168,10 @@ describe("E2E: Should Trade Surplus With Uniswap", () => {
     });
 
     await settlement.connect(solver).settle(
-      encoder.tokens,
-      encoder.clearingPrices({
+      ...encoder.encodedSettlement({
         [weth.address]: uniswapUsdtOutAmount,
         [usdt.address]: uniswapWethInAmount,
       }),
-      "0x",
-      encoder.encodedTrades,
-      encoder.encodedInteractions,
-      "0x",
     );
 
     // NOTE: Half of the trader 0's fees were discounted. This is reflected in

--- a/test/e2e/wineOilMarket.test.ts
+++ b/test/e2e/wineOilMarket.test.ts
@@ -139,16 +139,11 @@ describe("E2E: RetrETH Red Wine and Olive Oil Market", () => {
     );
 
     await settlement.connect(solver).settle(
-      encoder.tokens,
-      encoder.clearingPrices({
+      ...encoder.encodedSettlement({
         [eur.address]: ethers.utils.parseEther("1.0"),
         [oil.address]: ethers.utils.parseEther("13.0"),
         [wine.address]: ethers.utils.parseEther("14.0"),
       }),
-      "0x",
-      encoder.encodedTrades,
-      "0x",
-      "0x",
     );
 
     expect(await wine.balanceOf(traders[0].address)).to.deep.equal(


### PR DESCRIPTION
Closes #347 

This PR adds post-interactions to run call into a SC after the settlement finishes. This has some applications such as:
- Converting remaining balance of a long-tail token into something the Settlement contract wants to hold in fees.
- Enabling fancy things like (combined with a trade recipient) transferring buy amount to an account that can bridge to a different network (for trading on Mainnet and bridging proceeds automatically to xDai to an account).
- Perform additional post-settlement checks (if we choose to add any).

Note that the `settlement` function was changed to accept a `bytes[3] calldata` instead of just adding another `postInteraction` field. This is because the generated ABI decoding code was causing `Stack too deep when compiling inline assembly: Variable dataEnd is 1 slot(s) too deep inside the stack.` error, where `dataEnd` seems to be comming from Solidity generated code (looking at the intermediate build output, it appears in functions like: `abi_decode_tuple_t_struct$_Data_$4129_calldata_ptrt_address`).

### Test Plan

A new E2E test that demonstrates using post-interactions for burning fees.
