### PR TITLE
Consider fee discount in limit price check

### DIFF
--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -218,7 +218,7 @@ export class BenchFixture {
         (i + Math.floor(i / 4)) % 2 == 0
           ? SigningScheme.TYPED_DATA
           : SigningScheme.MESSAGE;
-      const feeDiscount = (i % 3) * (FULL_FEE_DISCOUNT / 2); // 0% | 50% | 100%
+      const feeDiscountBps = (i % 3) * (FULL_FEE_DISCOUNT / 2); // 0% | 50% | 100%
 
       const dbg = {
         fill: orderSpice.partiallyFillable
@@ -227,7 +227,7 @@ export class BenchFixture {
         kind: orderSpice.kind == OrderKind.SELL ? "sell" : "buy",
         sign:
           signingScheme == SigningScheme.TYPED_DATA ? "typed-data" : "message",
-        fee: 100 * (1 - feeDiscount / FULL_FEE_DISCOUNT),
+        fee: 100 * (1 - feeDiscountBps / FULL_FEE_DISCOUNT),
       };
       debug(
         `encoding ${dbg.fill} ${dbg.kind} order with ${dbg.sign} signature and ${dbg.fee}% fees`,
@@ -246,7 +246,7 @@ export class BenchFixture {
         signingScheme,
         {
           executedAmount: ethers.utils.parseEther("100.0"),
-          feeDiscount,
+          feeDiscountBps,
         },
       );
     }

--- a/src/ts/settlement.ts
+++ b/src/ts/settlement.ts
@@ -62,7 +62,7 @@ export interface TradeExecution {
    * taken for the order. A value of `10000` is used to indicate a full
    * discount, meaning no fees will be taken.
    */
-  feeDiscount: number;
+  feeDiscountBps: number;
 }
 
 /**
@@ -239,7 +239,7 @@ export class SettlementEncoder {
     }
     this._tradeCount++;
 
-    const { executedAmount, feeDiscount } = tradeExecution || {};
+    const { executedAmount, feeDiscountBps } = tradeExecution || {};
     if (order.partiallyFillable && executedAmount === undefined) {
       throw new Error("missing executed amount for partially fillable trade");
     }
@@ -273,7 +273,7 @@ export class SettlementEncoder {
         order.feeAmount,
         encodeOrderFlags(order),
         executedAmount || 0,
-        feeDiscount || 0,
+        feeDiscountBps || 0,
         signature,
       ],
     );

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -767,7 +767,7 @@ describe("GPv2Settlement", () => {
             kind: OrderKind.SELL,
             partiallyFillable: false,
           },
-          { feeDiscount: 100 }, // 1% discount.
+          { feeDiscountBps: 100 }, // 1% discount.
         );
 
         const executedFeeAmount = feeAmount.mul(99).div(100);
@@ -889,10 +889,11 @@ describe("GPv2Settlement", () => {
           ...partialOrder,
           kind: OrderKind.BUY,
           partiallyFillable: false,
+          feeAmount: ethers.utils.parseEther("1.0"),
         },
         traders[0],
         SigningScheme.TYPED_DATA,
-        { feeDiscount: FULL_FEE_DISCOUNT + 1 },
+        { feeDiscountBps: FULL_FEE_DISCOUNT + 1 },
       );
 
       await expect(

--- a/test/e2e/uniswapTrade.test.ts
+++ b/test/e2e/uniswapTrade.test.ts
@@ -123,7 +123,7 @@ describe("E2E: Should Trade Surplus With Uniswap", () => {
       SigningScheme.TYPED_DATA,
       // NOTE: Only take 50% of fees as the user traded half of their order
       // against Uniswap.
-      { feeDiscount: 5000 },
+      { feeDiscountBps: 5000 },
     );
 
     await usdt.mint(traders[1].address, ethers.utils.parseUnits("300.3", 6));


### PR DESCRIPTION
This PR implements @fleupold's suggestion of computing the limit price check including the fee discount. I decided to try it out to see how it would fit with the current code, and it does quite nicely. The computation of the `feeDiscount` moved to the decoding as we intend as a result of the encoding changes required for #343 to encode a full fee discount amount amount instead of using basis points.

My thoughts around checking the clearing price given a fee discount is that it allows the solver to include orders where clearing prices are *slightly* worse than the limit price if the solver agrees to give up some of its fees to make up the difference. Some arguments for including this are:
- Although this can be implemented exactly the same way using different clearing prices per order (by specifying more than one clearing price for a token), this way is "nicer" in that the call data does not need to be inspected in order to determine which clearing price is for which order
- I find the concept of the solver "giving up its fee to make up the clearing price difference" slightly more intuitive conceptually than "different clearing prices per order", even though they would theoretically yield the exact same result.
- This allows orders against Uniswap to eventually be represented as `sellAmount: unswapSellAmount - fee`. This way the SC can enforce that the order can only be traded at a clearing price equal to the Uniswap effective price if there is a full fee discount (I understand this might be very hard to model in the solver? @marcovc). This in theory can be done today already, but I find this way of expressing that settlement more intuitive.
- Small adjustments to the fee discount can be done to account for rounding errors without resorting to different prices per order
- Easier DAO rules (uniform clearing prices required).

I made this a draft PR so we can discuss this approach (and whether or not it should be implemented) before adding the extra tests. The code changes in the contract were fairly minimal.

### Test Plan

Unit tests still pass. **TODO**: Add a unit test demonstrating that the solver can clear at a price that does not respect the limit price if it discounts enough fees to make up the difference.
