### PR TITLE
[Easy] Rename Error message on invalid fee discount

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -313,7 +313,7 @@ contract GPv2Settlement {
             );
         }
 
-        require(trade.feeDiscount <= BPS_BASE, "GPv2: invalid fee discount");
+        require(trade.feeDiscount <= BPS_BASE, "GPv2: fee discount too large");
         executedFeeAmount =
             executedFeeAmount.mul(BPS_BASE - trade.feeDiscount) /
             BPS_BASE;

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -731,7 +731,7 @@ describe("GPv2Settlement", () => {
           encoder.clearingPrices(prices),
           encoder.encodedTrades,
         ),
-      ).to.be.revertedWith("invalid fee discount");
+      ).to.be.revertedWith("fee discount too large");
     });
 
     it("should emit a trade event", async () => {


### PR DESCRIPTION
While reading through the contracts for the purpose of writing a specification, I ran into this confusing requirement. This new string give a bit more context to the error.

### Test Plan

CI
