### PR TITLE
[nit] Moving struct declarations into own group

### DIFF
--- a/src/contracts/GPv2AllowListAuthentication.sol
+++ b/src/contracts/GPv2AllowListAuthentication.sol
@@ -15,10 +15,10 @@ contract GPv2AllowListAuthentication is
 {
     using EnumerableSet for EnumerableSet.AddressSet;
 
+    EnumerableSet.AddressSet private solvers;
+
     // solhint-disable-next-line no-empty-blocks
     constructor(address initialOwner) CustomInitiallyOwnable(initialOwner) {}
-
-    EnumerableSet.AddressSet private solvers;
 
     function addSolver(address solver) external onlyOwner {
         solvers.add(solver);

--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -20,6 +20,26 @@ library GPv2Encoding {
         bool partiallyFillable;
     }
 
+    /// @dev A struct representing a trade to be executed as part a batch
+    /// settlement.
+    struct Trade {
+        Order order;
+        uint8 sellTokenIndex;
+        uint8 buyTokenIndex;
+        uint256 executedAmount;
+        uint16 feeDiscount;
+        address owner;
+        bytes orderUid;
+    }
+
+    /// @dev A struct representing arbitrary contract interactions.
+    /// Submitted to [`GPv2Settlement.settle`] for code execution.
+    struct Interaction {
+        address target;
+        uint256 value;
+        bytes callData;
+    }
+
     /// @dev The marker value for a sell order for computing the order struct
     /// hash. This allows the EIP-712 compatible wallets to display a
     /// descriptive string for the order kind (instead of 0 or 1).
@@ -62,31 +82,11 @@ library GPv2Encoding {
     bytes32 internal constant ORDER_TYPE_HASH =
         hex"b2b38b9dcbdeb41f7ad71dea9aed79fb47f7bbc3436576fe994b43d5b16ecdec";
 
-    /// @dev A struct representing a trade to be executed as part a batch
-    /// settlement.
-    struct Trade {
-        Order order;
-        uint8 sellTokenIndex;
-        uint8 buyTokenIndex;
-        uint256 executedAmount;
-        uint16 feeDiscount;
-        address owner;
-        bytes orderUid;
-    }
-
     /// @dev The stride of an encoded trade.
     uint256 private constant TRADE_STRIDE = 206;
 
     /// @dev The byte length of an order unique identifier.
     uint256 private constant ORDER_UID_LENGTH = 56;
-
-    /// @dev A struct representing arbitrary contract interactions.
-    /// Submitted to [`GPv2Settlement.settle`] for code execution.
-    struct Interaction {
-        address target;
-        uint256 value;
-        bytes callData;
-    }
 
     /// @dev Returns the number of trades encoded in a calldata byte array.
     ///

--- a/src/contracts/libraries/GPv2TradeExecution.sol
+++ b/src/contracts/libraries/GPv2TradeExecution.sol
@@ -9,10 +9,6 @@ import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 library GPv2TradeExecution {
     using SafeERC20 for IERC20;
 
-    /// @dev Ether marker address used to indicate an order is buying Ether.
-    address internal constant BUY_ETH_ADDRESS =
-        0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
-
     /// @dev Executed trade data.
     struct Data {
         address owner;
@@ -21,6 +17,10 @@ library GPv2TradeExecution {
         uint256 sellAmount;
         uint256 buyAmount;
     }
+
+    /// @dev Ether marker address used to indicate an order is buying Ether.
+    address internal constant BUY_ETH_ADDRESS =
+        0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
     /// @dev Executes the trade's sell amount, transferring it from the trade's
     /// owner to the specified recipient.


### PR DESCRIPTION
Not of immediate importance, but I noticed that we had a few places where we had struct declaration followed by constants, then more struct, more constants and another struct. In particular some of the constants we not particularly relevant to the structs they were grouped with. This PR just moves a few declarations around into their own respective groups according to the ["Order of Layout"](https://docs.soliditylang.org/en/v0.5.3/style-guide.html#order-of-layout) section in the solidity style guide:

- **AllowListAuthentication:** move `solvers` above constructor
- **GPv2Encoding**: Move `Trade`, `Order` and `Interaction` structs to the top (above constants)
- **GPv2TradeExecution**: Move struct above constant



### Test Plan

CI
