### PR TITLE
make settlement non-reentrable

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -4,6 +4,7 @@ pragma abicoder v2;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 import "./GPv2AllowanceManager.sol";
 import "./interfaces/GPv2Authentication.sol";
@@ -12,7 +13,7 @@ import "./libraries/GPv2TradeExecution.sol";
 
 /// @title Gnosis Protocol v2 Settlement Contract
 /// @author Gnosis Developers
-contract GPv2Settlement {
+contract GPv2Settlement is ReentrancyGuard {
     using GPv2Encoding for bytes;
     using GPv2TradeExecution for GPv2TradeExecution.Data;
     using SafeMath for uint256;
@@ -152,7 +153,7 @@ contract GPv2Settlement {
         bytes calldata encodedTrades,
         bytes[3] calldata encodedInteractions,
         bytes calldata encodedOrderRefunds
-    ) external onlySolver {
+    ) external onlySolver nonReentrant {
         executeInteractions(encodedInteractions[0]);
 
         GPv2TradeExecution.Data[] memory executedTrades =

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -153,7 +153,7 @@ contract GPv2Settlement is ReentrancyGuard {
         bytes calldata encodedTrades,
         bytes[3] calldata encodedInteractions,
         bytes calldata encodedOrderRefunds
-    ) external onlySolver nonReentrant {
+    ) external nonReentrant onlySolver {
         executeInteractions(encodedInteractions[0]);
 
         GPv2TradeExecution.Data[] memory executedTrades =

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -160,6 +160,19 @@ describe("GPv2Settlement", () => {
       );
     });
 
+    it("rejects reentrancy attempts via interactions", async () => {
+      await authenticator.connect(owner).addSolver(solver.address);
+      const encoder = new SettlementEncoder(testDomain);
+      encoder.encodeInteraction({
+        target: settlement.address,
+        callData: settlement.interface.encodeFunctionData("settle", empty),
+      });
+
+      await expect(
+        settlement.connect(solver).settle(...encoder.encodedSettlement({})),
+      ).to.be.revertedWith("ReentrancyGuard: reentrant call");
+    });
+
     it("accepts transactions from solvers", async () => {
       await authenticator.connect(owner).addSolver(solver.address);
       await expect(settlement.connect(solver).settle(...empty)).to.not.be


### PR DESCRIPTION
Closes #223

Making the Settlement contract "ReentrancyGuard" so to include the nonReentrant modifier on `settle`.

Funny story, we had to change the order of the modifiers for the case when settlement contract is not a registered solver, since the only owner modifier fails first (resulting in undesired unexpected revert message).

### Test Plan

Introduced new non-reentrancy unit test.
