### PR TITLE
E2e 0x integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "ethers": "~5.0.18"
   },
   "devDependencies": {
+    "@0x/contract-artifacts": "^3.11.0",
     "@gnosis.pm/util-contracts": "3.0.1-solc-7",
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-waffle": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "ethers": "~5.0.18"
   },
   "devDependencies": {
-    "@0x/contract-artifacts": "^3.11.0",
-    "@gnosis.pm/util-contracts": "3.0.1-solc-7",
+    "@0x/contract-artifacts": "=2.2.2",
+    "@gnosis.pm/util-contracts": "=3.0.1-solc-7",
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "^3.3.0",

--- a/src/ts/order.ts
+++ b/src/ts/order.ts
@@ -107,12 +107,10 @@ export const ORDER_TYPE_FIELDS = [
 /**
  * The EIP-712 type hash for a Gnosis Protocol v2 order.
  */
-export const ORDER_TYPE_HASH = ethers.utils.keccak256(
-  ethers.utils.toUtf8Bytes(
-    `Order(${ORDER_TYPE_FIELDS.map(({ name, type }) => `${type} ${name}`).join(
-      ",",
-    )})`,
-  ),
+export const ORDER_TYPE_HASH = ethers.utils.id(
+  `Order(${ORDER_TYPE_FIELDS.map(({ name, type }) => `${type} ${name}`).join(
+    ",",
+  )})`,
 );
 
 /**

--- a/test/e2e/0xTrade.test.ts
+++ b/test/e2e/0xTrade.test.ts
@@ -1,12 +1,13 @@
-import { ERC20Proxy, Exchange } from "@0x/contract-artifacts";
 import ERC20 from "@openzeppelin/contracts/build/contracts/ERC20PresetMinterPauser.json";
 import { expect } from "chai";
 import Debug from "debug";
-import { BigNumberish, BytesLike, Contract, Wallet } from "ethers";
+import { BigNumber, Contract, Wallet } from "ethers";
 import { ethers, waffle } from "hardhat";
 
 import {
+  Order,
   OrderKind,
+  Prices,
   SettlementEncoder,
   SigningScheme,
   TypedDataDomain,
@@ -14,126 +15,10 @@ import {
 } from "../../src/ts";
 
 import { deployTestContracts } from "./fixture";
+import { SimpleOrder as ZeroExSimpleOrder } from "./zero-ex";
+import * as ZeroExV2 from "./zero-ex/v2";
 
 const debug = Debug("test:e2e:0xTrade");
-
-// NOTE: Order type from:
-// <https://0x.org/docs/guides/v3-specification#order>
-interface ZeroExOrder {
-  makerAddress: string;
-  takerAddress: string;
-  feeRecipientAddress: string;
-  senderAddress: string;
-  makerAssetAmount: BigNumberish;
-  takerAssetAmount: BigNumberish;
-  makerFee: BigNumberish;
-  takerFee: BigNumberish;
-  expirationTimeSeconds: BigNumberish;
-  salt: BigNumberish;
-  makerAssetData: BytesLike;
-  takerAssetData: BytesLike;
-  makerFeeAssetData: BytesLike;
-  takerFeeAssetData: BytesLike;
-}
-
-const ZERO_EX_ORDER_TYPE_DESCRIPTOR = {
-  Order: [
-    { name: "makerAddress", type: "address" },
-    { name: "takerAddress", type: "address" },
-    { name: "feeRecipientAddress", type: "address" },
-    { name: "senderAddress", type: "address" },
-    { name: "makerAssetAmount", type: "uint256" },
-    { name: "takerAssetAmount", type: "uint256" },
-    { name: "makerFee", type: "uint256" },
-    { name: "takerFee", type: "uint256" },
-    { name: "expirationTimeSeconds", type: "uint256" },
-    { name: "salt", type: "uint256" },
-    { name: "makerAssetData", type: "bytes" },
-    { name: "takerAssetData", type: "bytes" },
-    { name: "makerFeeAssetData", type: "bytes" },
-    { name: "takerFeeAssetData", type: "bytes" },
-  ],
-};
-
-interface ZeroExSignedOrder {
-  order: ZeroExOrder;
-  hash: BytesLike;
-  signature: BytesLike;
-}
-
-interface ZeroExSimpleOrder {
-  makerAssetAmount: BigNumberish;
-  takerAssetAmount: BigNumberish;
-  makerAssetAddress: BytesLike;
-  takerAssetAddress: BytesLike;
-}
-
-function encodeErc20AssetData(tokenAddress: BytesLike): string {
-  // NOTE: ERC20 proxy asset data defined in:
-  // <https://github.com/0xProject/0x-monorepo/blob/master/contracts/asset-proxy/contracts/src/ERC20Proxy.sol>
-
-  const { id, hexDataSlice } = ethers.utils;
-  const PROXY_ID = hexDataSlice(id("ERC20Token(address)"), 0, 4);
-
-  return ethers.utils.hexConcat([
-    PROXY_ID,
-    ethers.utils.defaultAbiCoder.encode(["address"], [tokenAddress]),
-  ]);
-}
-
-async function signZeroExSimpleOrder(
-  maker: Wallet,
-  domain: TypedDataDomain,
-  simpleOrder: ZeroExSimpleOrder,
-): Promise<ZeroExSignedOrder> {
-  const order = {
-    ...simpleOrder,
-    makerAddress: maker.address,
-    makerAssetData: encodeErc20AssetData(simpleOrder.makerAssetAddress),
-    takerAssetData: encodeErc20AssetData(simpleOrder.takerAssetAddress),
-
-    // NOTE: Unused.
-    expirationTimeSeconds: 0xffffffff,
-    salt: ethers.constants.Zero,
-
-    // NOTE: Setting taker and sender address to `address(0)` means that the
-    // order can be executed (sender) against any counterparty (taker). For the
-    // purposes of GPv2, these need to be either `address(0)` or the settlement
-    // contract.
-    takerAddress: ethers.constants.AddressZero,
-    senderAddress: ethers.constants.AddressZero,
-
-    // NOTE: Include no additional fees. I am not sure how this is used by
-    // market makers, but in theory this can be used to assign an additional
-    // fee, on top of the 0x protocol fee, to the GPv2 settlement contract.
-    feeRecipientAddress: ethers.constants.AddressZero,
-    makerFee: 0,
-    takerFee: 0,
-    makerFeeAssetData: "0x",
-    takerFeeAssetData: "0x",
-  };
-
-  const hash = ethers.utils._TypedDataEncoder.hash(
-    domain,
-    ZERO_EX_ORDER_TYPE_DESCRIPTOR,
-    order,
-  );
-
-  // NOTE: Use EIP-712 signing scheme for the order. The signature is just the
-  // ECDSA signature post-fixed with the signature scheme ID (0x02):
-  // <https://0x.org/docs/guides/v3-specification#signature-types>
-
-  const EIP712_SIGNATURE_ID = 0x02;
-  const { v, r, s } = ethers.utils.splitSignature(
-    await maker._signTypedData(domain, ZERO_EX_ORDER_TYPE_DESCRIPTOR, order),
-  );
-  const signature = ethers.utils.solidityPack(
-    ["uint8", "bytes32", "bytes32", "uint8"],
-    [v, r, s, EIP712_SIGNATURE_ID],
-  );
-
-  return { order, hash, signature };
-}
 
 describe("E2E: Can settle a 0x trade", () => {
   let deployer: Wallet;
@@ -147,12 +32,6 @@ describe("E2E: Can settle a 0x trade", () => {
 
   let owl: Contract;
   let gno: Contract;
-
-  let zeroEx: {
-    exchange: Contract;
-    erc20Proxy: Contract;
-    domainSeparator: TypedDataDomain;
-  };
 
   beforeEach(async () => {
     const deployment = await deployTestContracts();
@@ -172,48 +51,16 @@ describe("E2E: Can settle a 0x trade", () => {
 
     owl = await waffle.deployContract(deployer, ERC20, ["OWL", 18]);
     gno = await waffle.deployContract(deployer, ERC20, ["GNO", 18]);
-
-    const exchange = await waffle.deployContract(
-      deployer,
-      Exchange.compilerOutput,
-      [chainId],
-    );
-    const erc20Proxy = await waffle.deployContract(
-      deployer,
-      ERC20Proxy.compilerOutput,
-    );
-
-    await erc20Proxy.addAuthorizedAddress(exchange.address);
-    await exchange.registerAssetProxy(erc20Proxy.address);
-
-    zeroEx = {
-      exchange,
-      erc20Proxy,
-      // NOTE: Domain separator parameters taken from:
-      // <https://0x.org/docs/guides/v3-specification#eip-712-usage>
-      domainSeparator: {
-        name: "0x Protocol",
-        version: "3.0.0",
-        chainId,
-        verifyingContract: exchange.address,
-      },
-    };
   });
 
-  it("should settle an EOA trade with a 0x trade", async () => {
-    // Settles a market order buying 1 GNO for 120 OWL and get matched with a
-    // market maker using 0x orders.
-
-    await owl.mint(trader.address, ethers.utils.parseEther("140"));
-    await owl
-      .connect(trader)
-      .approve(allowanceManager.address, ethers.constants.MaxUint256);
-
-    await gno.mint(marketMaker.address, ethers.utils.parseEther("1000.0"));
-    await gno
-      .connect(marketMaker)
-      .approve(zeroEx.erc20Proxy.address, ethers.constants.MaxUint256);
-
+  function generateSettlementSolution(): {
+    gpv2Order: Order;
+    zeroExOrder: ZeroExSimpleOrder;
+    zeroExTakerAmount: BigNumber;
+    clearingPrices: Prices;
+    gpv2OwlSurplus: BigNumber;
+    zeroExOwlSurplus: BigNumber;
+  } {
     const gpv2Order = {
       kind: OrderKind.BUY,
       partiallyFillable: false,
@@ -227,71 +74,119 @@ describe("E2E: Can settle a 0x trade", () => {
     };
 
     const zeroExGnoPrice = 110;
-    const zeroExSignedOrder = await signZeroExSimpleOrder(
-      marketMaker,
-      zeroEx.domainSeparator,
-      {
-        makerAssetAddress: gno.address,
-        makerAssetAmount: ethers.utils.parseEther("1000.0"),
-        takerAssetAddress: owl.address,
-        takerAssetAmount: ethers.utils.parseEther("1000.0").mul(zeroExGnoPrice),
-      },
-    );
-    expect(
-      await zeroEx.exchange.isValidOrderSignature(
-        zeroExSignedOrder.order,
-        zeroExSignedOrder.signature,
-      ),
-    ).to.be.true;
-
-    const encoder = new SettlementEncoder(domainSeparator);
-    await encoder.signEncodeTrade(gpv2Order, trader, SigningScheme.TYPED_DATA);
-    encoder.encodeInteraction({
-      target: owl.address,
-      callData: owl.interface.encodeFunctionData("approve", [
-        zeroEx.erc20Proxy.address,
-        gpv2Order.buyAmount.mul(zeroExGnoPrice),
-      ]),
-    });
-    encoder.encodeInteraction({
-      target: zeroEx.exchange.address,
-      callData: zeroEx.exchange.interface.encodeFunctionData("fillOrder", [
-        zeroExSignedOrder.order,
-        gpv2Order.buyAmount.mul(zeroExGnoPrice),
-        zeroExSignedOrder.signature,
-      ]),
-    });
+    const zeroExOrder = {
+      takerAddress: settlement.address,
+      makerAssetAddress: gno.address,
+      makerAssetAmount: ethers.utils.parseEther("1000.0"),
+      takerAssetAddress: owl.address,
+      takerAssetAmount: ethers.utils.parseEther("1000.0").mul(zeroExGnoPrice),
+    };
+    const zeroExTakerAmount = gpv2Order.buyAmount.mul(zeroExGnoPrice);
 
     const gpv2GnoPrice = 120;
-    const tx = await settlement.connect(solver).settle(
-      ...encoder.encodedSettlement({
-        [owl.address]: 1,
-        [gno.address]: gpv2GnoPrice,
-      }),
-    );
+    const clearingPrices = {
+      [owl.address]: 1,
+      [gno.address]: gpv2GnoPrice,
+    };
 
-    const { gasUsed } = await tx.wait();
-    debug(`gas used: ${gasUsed}`);
-
-    expect(await gno.balanceOf(trader.address)).to.deep.equal(
-      ethers.utils.parseEther("1.0"),
-    );
-    expect(await gno.balanceOf(marketMaker.address)).to.deep.equal(
-      ethers.utils.parseEther("999.0"),
-    );
-
-    // NOTE: The user keeps the surplus from their trade.
     const gpv2OwlSurplus = gpv2Order.sellAmount.sub(
       gpv2Order.buyAmount.mul(gpv2GnoPrice),
     );
-    expect(await owl.balanceOf(trader.address)).to.deep.equal(gpv2OwlSurplus);
-
-    // NOTE: The exchange keeps the surplus from the 0x order.
     const zeroExOwlSurplus = gpv2Order.buyAmount.mul(
       gpv2GnoPrice - zeroExGnoPrice,
     );
-    expect(await owl.balanceOf(settlement.address)).to.deep.equal(
-      gpv2Order.feeAmount.add(zeroExOwlSurplus),
-    );
+
+    return {
+      gpv2Order,
+      zeroExOrder,
+      zeroExTakerAmount,
+      clearingPrices,
+      gpv2OwlSurplus,
+      zeroExOwlSurplus,
+    };
+  }
+
+  describe("0x Protocol v2", () => {
+    it("should settle an EOA trade with a 0x trade", async () => {
+      // Settles a market order buying 1 GNO for 120 OWL and get matched with a
+      // market maker using 0x orders.
+
+      const {
+        gpv2Order,
+        zeroExOrder,
+        zeroExTakerAmount,
+        clearingPrices,
+        gpv2OwlSurplus,
+        zeroExOwlSurplus,
+      } = await generateSettlementSolution();
+
+      await owl.mint(trader.address, ethers.utils.parseEther("140"));
+      await owl
+        .connect(trader)
+        .approve(allowanceManager.address, ethers.constants.MaxUint256);
+
+      const zeroEx = await ZeroExV2.deployExchange(deployer);
+
+      await gno.mint(marketMaker.address, ethers.utils.parseEther("1000.0"));
+      await gno
+        .connect(marketMaker)
+        .approve(zeroEx.erc20Proxy.address, ethers.constants.MaxUint256);
+
+      const zeroExSignedOrder = await ZeroExV2.signSimpleOrder(
+        marketMaker,
+        zeroEx.domainSeparator,
+        zeroExOrder,
+      );
+      expect(
+        await zeroEx.exchange.isValidSignature(
+          zeroExSignedOrder.hash,
+          marketMaker.address,
+          zeroExSignedOrder.signature,
+        ),
+      ).to.be.true;
+
+      const encoder = new SettlementEncoder(domainSeparator);
+      await encoder.signEncodeTrade(
+        gpv2Order,
+        trader,
+        SigningScheme.TYPED_DATA,
+      );
+      encoder.encodeInteraction({
+        target: owl.address,
+        callData: owl.interface.encodeFunctionData("approve", [
+          zeroEx.erc20Proxy.address,
+          zeroExTakerAmount,
+        ]),
+      });
+      encoder.encodeInteraction({
+        target: zeroEx.exchange.address,
+        callData: zeroEx.exchange.interface.encodeFunctionData("fillOrder", [
+          zeroExSignedOrder.order,
+          zeroExTakerAmount,
+          zeroExSignedOrder.signature,
+        ]),
+      });
+
+      const tx = await settlement
+        .connect(solver)
+        .settle(...encoder.encodedSettlement(clearingPrices));
+
+      const { gasUsed } = await tx.wait();
+      debug(`gas used: ${gasUsed}`);
+
+      expect(await gno.balanceOf(trader.address)).to.deep.equal(
+        ethers.utils.parseEther("1.0"),
+      );
+      expect(await gno.balanceOf(marketMaker.address)).to.deep.equal(
+        ethers.utils.parseEther("999.0"),
+      );
+
+      // NOTE: The user keeps the surplus from their trade.
+      expect(await owl.balanceOf(trader.address)).to.deep.equal(gpv2OwlSurplus);
+      // NOTE: The exchange keeps the surplus from the 0x order.
+      expect(await owl.balanceOf(settlement.address)).to.deep.equal(
+        zeroExOwlSurplus.add(gpv2Order.feeAmount),
+      );
+    });
   });
 });

--- a/test/e2e/0xTrade.test.ts
+++ b/test/e2e/0xTrade.test.ts
@@ -280,6 +280,12 @@ describe("E2E: Can settle a 0x trade", () => {
       ethers.utils.parseEther("999.0"),
     );
 
+    // NOTE: The user keeps the surplus from their trade.
+    const gpv2OwlSurplus = gpv2Order.sellAmount.sub(
+      gpv2Order.buyAmount.mul(gpv2GnoPrice),
+    );
+    expect(await owl.balanceOf(trader.address)).to.deep.equal(gpv2OwlSurplus);
+
     // NOTE: The exchange keeps the surplus from the 0x order.
     const zeroExOwlSurplus = gpv2Order.buyAmount.mul(
       gpv2GnoPrice - zeroExGnoPrice,

--- a/test/e2e/0xTrade.test.ts
+++ b/test/e2e/0xTrade.test.ts
@@ -1,0 +1,285 @@
+import { ERC20Proxy, Exchange } from "@0x/contract-artifacts";
+import ERC20 from "@openzeppelin/contracts/build/contracts/ERC20PresetMinterPauser.json";
+import { expect } from "chai";
+import Debug from "debug";
+import { BigNumberish, BytesLike, Contract, Wallet } from "ethers";
+import { ethers, waffle } from "hardhat";
+
+import {
+  OrderKind,
+  SettlementEncoder,
+  SigningScheme,
+  TypedDataDomain,
+  domain,
+} from "../../src/ts";
+
+import { deployTestContracts } from "./fixture";
+
+const debug = Debug("test:e2e:0xTrade");
+
+interface ZeroExOrder {
+  makerAddress: string;
+  takerAddress: string;
+  feeRecipientAddress: string;
+  senderAddress: string;
+  makerAssetAmount: BigNumberish;
+  takerAssetAmount: BigNumberish;
+  makerFee: BigNumberish;
+  takerFee: BigNumberish;
+  expirationTimeSeconds: BigNumberish;
+  salt: BigNumberish;
+  makerAssetData: BytesLike;
+  takerAssetData: BytesLike;
+  makerFeeAssetData: BytesLike;
+  takerFeeAssetData: BytesLike;
+}
+
+const ZERO_EX_ORDER_TYPE_DESCRIPTOR = {
+  Order: [
+    { name: "makerAddress", type: "address" },
+    { name: "takerAddress", type: "address" },
+    { name: "feeRecipientAddress", type: "address" },
+    { name: "senderAddress", type: "address" },
+    { name: "makerAssetAmount", type: "uint256" },
+    { name: "takerAssetAmount", type: "uint256" },
+    { name: "makerFee", type: "uint256" },
+    { name: "takerFee", type: "uint256" },
+    { name: "expirationTimeSeconds", type: "uint256" },
+    { name: "salt", type: "uint256" },
+    { name: "makerAssetData", type: "bytes" },
+    { name: "takerAssetData", type: "bytes" },
+    { name: "makerFeeAssetData", type: "bytes" },
+    { name: "takerFeeAssetData", type: "bytes" },
+  ],
+};
+
+interface ZeroExSignedOrder {
+  order: ZeroExOrder;
+  hash: BytesLike;
+  signature: BytesLike;
+}
+
+interface ZeroExSimpleOrder {
+  makerAssetAmount: BigNumberish;
+  takerAssetAmount: BigNumberish;
+  makerAssetAddress: BytesLike;
+  takerAssetAddress: BytesLike;
+}
+
+function encodeErc20AssetData(tokenAddress: BytesLike): string {
+  // NOTE: ERC20 proxy asset data defined in:
+  // <https://github.com/0xProject/0x-monorepo/blob/master/contracts/asset-proxy/contracts/src/ERC20Proxy.sol>
+
+  const { id, hexDataSlice } = ethers.utils;
+  const PROXY_ID = hexDataSlice(id("ERC20Token(address)"), 0, 4);
+
+  return ethers.utils.hexConcat([
+    PROXY_ID,
+    ethers.utils.defaultAbiCoder.encode(["address"], [tokenAddress]),
+  ]);
+}
+
+async function signZeroExSimpleOrder(
+  maker: Wallet,
+  domain: TypedDataDomain,
+  simpleOrder: ZeroExSimpleOrder,
+): Promise<ZeroExSignedOrder> {
+  const order = {
+    ...simpleOrder,
+    makerAddress: maker.address,
+    makerAssetData: encodeErc20AssetData(simpleOrder.makerAssetAddress),
+    takerAssetData: encodeErc20AssetData(simpleOrder.takerAssetAddress),
+
+    // NOTE: Unused.
+    expirationTimeSeconds: 0xffffffff,
+    salt: ethers.constants.Zero,
+
+    // NOTE: Setting taker and sender address to `address(0)` means that the
+    // order can be executed (sender) against any counterparty (taker). For the
+    // purposes of GPv2, this needs to be either `address(0)` or the settlement
+    // contract.
+    takerAddress: ethers.constants.AddressZero,
+    senderAddress: ethers.constants.AddressZero,
+
+    // NOTE: Include no additional fees. I am not sure how this is used by
+    // market makers, but in theory this can be used to assign an additional
+    // fee, on top of the 0x protocol fee, to the GPv2 settlement contract.
+    feeRecipientAddress: ethers.constants.AddressZero,
+    makerFee: 0,
+    takerFee: 0,
+    makerFeeAssetData: "0x",
+    takerFeeAssetData: "0x",
+  };
+
+  const hash = ethers.utils._TypedDataEncoder.hash(
+    domain,
+    ZERO_EX_ORDER_TYPE_DESCRIPTOR,
+    order,
+  );
+
+  const ETHSIGN_SIGNATURE_ID = 0x03;
+  const { v, r, s } = ethers.utils.splitSignature(
+    //await maker._signTypedData(domain, ZERO_EX_ORDER_TYPE_DESCRIPTOR, order),
+    await maker.signMessage(hash),
+  );
+  const signature = ethers.utils.solidityPack(
+    ["uint8", "uint8", "bytes32", "bytes32"],
+    [ETHSIGN_SIGNATURE_ID, v, r, s],
+  );
+
+  return { order, hash, signature };
+}
+
+describe.only("E2E: Can settle a 0x trade", () => {
+  let deployer: Wallet;
+  let solver: Wallet;
+  let trader: Wallet;
+  let marketMaker: Wallet;
+
+  let settlement: Contract;
+  let allowanceManager: Contract;
+  let domainSeparator: TypedDataDomain;
+
+  let owl: Contract;
+  let gno: Contract;
+
+  let zeroEx: {
+    exchange: Contract;
+    erc20Proxy: Contract;
+    domainSeparator: TypedDataDomain;
+  };
+
+  beforeEach(async () => {
+    const deployment = await deployTestContracts();
+
+    ({
+      deployer,
+      settlement,
+      allowanceManager,
+      wallets: [solver, trader, marketMaker],
+    } = deployment);
+
+    const { authenticator, owner } = deployment;
+    await authenticator.connect(owner).addSolver(solver.address);
+
+    const { chainId } = await ethers.provider.getNetwork();
+    domainSeparator = domain(chainId, settlement.address);
+
+    owl = await waffle.deployContract(deployer, ERC20, ["OWL", 18]);
+    gno = await waffle.deployContract(deployer, ERC20, ["GNO", 18]);
+
+    const exchange = await waffle.deployContract(
+      deployer,
+      Exchange.compilerOutput,
+      [chainId],
+    );
+    const erc20Proxy = await waffle.deployContract(
+      deployer,
+      ERC20Proxy.compilerOutput,
+    );
+
+    await erc20Proxy.addAuthorizedAddress(exchange.address);
+    await exchange.registerAssetProxy(erc20Proxy.address);
+    zeroEx = {
+      exchange,
+      erc20Proxy,
+      domainSeparator: {
+        name: "0x Protocol",
+        version: "3.0.0",
+        chainId,
+        verifyingContract: exchange.address,
+      },
+    };
+  });
+
+  it("should settle an EOA trade with a 0x trade", async () => {
+    // Settles a market order buying 1 GNO for 120 OWL and get matched with a
+    // market maker using 0x orders.
+
+    const encoder = new SettlementEncoder(domainSeparator);
+
+    await owl.mint(trader.address, ethers.utils.parseEther("130"));
+    await owl
+      .connect(trader)
+      .approve(allowanceManager.address, ethers.constants.MaxUint256);
+    await encoder.signEncodeTrade(
+      {
+        kind: OrderKind.BUY,
+        partiallyFillable: false,
+        buyToken: gno.address,
+        sellToken: owl.address,
+        buyAmount: ethers.utils.parseEther("1.0"),
+        sellAmount: ethers.utils.parseEther("120.0"),
+        feeAmount: ethers.utils.parseEther("10.0"),
+        validTo: 0xffffffff,
+        appData: 1,
+      },
+      trader,
+      //SigningScheme.TYPED_DATA,
+      SigningScheme.MESSAGE,
+    );
+
+    await gno.mint(marketMaker.address, ethers.utils.parseEther("1000.0"));
+    await gno
+      .connect(marketMaker)
+      .approve(zeroEx.erc20Proxy.address, ethers.constants.MaxUint256);
+    encoder.encodeInteraction({
+      target: owl.address,
+      callData: owl.interface.encodeFunctionData("approve", [
+        zeroEx.erc20Proxy.address,
+        ethers.utils.parseEther("1.0"),
+      ]),
+    });
+    const zeroExSignedOrder = await signZeroExSimpleOrder(
+      marketMaker,
+      zeroEx.domainSeparator,
+      {
+        makerAssetAddress: gno.address,
+        makerAssetAmount: ethers.utils.parseEther("1000.0"),
+        takerAssetAddress: owl.address,
+        takerAssetAmount: ethers.utils.parseEther("1000.0").mul(110),
+      },
+    );
+    const { orderHash: zeroExOrderHash } = await zeroEx.exchange.getOrderInfo(
+      zeroExSignedOrder.order,
+    );
+    expect(zeroExOrderHash).to.equal(zeroExSignedOrder.hash);
+    encoder.encodeInteraction({
+      target: zeroEx.exchange.address,
+      callData: zeroEx.exchange.interface.encodeFunctionData("fillOrder", [
+        zeroExSignedOrder.order,
+        ethers.utils.parseEther("1.0"),
+        zeroExSignedOrder.signature,
+      ]),
+    });
+
+    await owl
+      .connect(trader)
+      .approve(zeroEx.erc20Proxy.address, ethers.constants.MaxUint256);
+    await zeroEx.exchange
+      .connect(trader)
+      .fillOrder(
+        zeroExSignedOrder.order,
+        ethers.utils.parseEther("110.0"),
+        zeroExSignedOrder.signature,
+        { gasLimit: 1e6 },
+      );
+
+    const tx = await settlement.connect(solver).settle(
+      ...encoder.encodedSettlement({
+        [owl.address]: 1,
+        [gno.address]: 120,
+      }),
+    );
+
+    const { gasUsed } = await tx.wait();
+    debug(`gas used: ${gasUsed}`);
+
+    expect(await gno.balanceOf(trader.address)).to.deep.equal(
+      ethers.utils.parseEther("1.0"),
+    );
+    expect(await gno.balanceOf(marketMaker.address)).to.deep.equal(
+      ethers.utils.parseEther("999.0"),
+    );
+  });
+});

--- a/test/e2e/zero-ex/index.ts
+++ b/test/e2e/zero-ex/index.ts
@@ -1,0 +1,9 @@
+import { BigNumberish, BytesLike } from "ethers";
+
+export interface SimpleOrder {
+  takerAddress: string;
+  makerAssetAmount: BigNumberish;
+  takerAssetAmount: BigNumberish;
+  makerAssetAddress: BytesLike;
+  takerAssetAddress: BytesLike;
+}

--- a/test/e2e/zero-ex/v2/index.ts
+++ b/test/e2e/zero-ex/v2/index.ts
@@ -1,0 +1,153 @@
+import { ERC20Proxy, Exchange, ZRXToken } from "@0x/contract-artifacts";
+import { BigNumberish, BytesLike, Contract, Wallet } from "ethers";
+import { ethers, waffle } from "hardhat";
+
+import { SimpleOrder } from "..";
+import { TypedDataDomain } from "../../../../src/ts";
+
+// NOTE: Order type from:
+// <https://0x.org/docs/guides/v2-specification#order>
+export interface Order {
+  makerAddress: string;
+  takerAddress: string;
+  feeRecipientAddress: string;
+  senderAddress: string;
+  makerAssetAmount: BigNumberish;
+  takerAssetAmount: BigNumberish;
+  makerFee: BigNumberish;
+  takerFee: BigNumberish;
+  expirationTimeSeconds: BigNumberish;
+  salt: BigNumberish;
+  makerAssetData: BytesLike;
+  takerAssetData: BytesLike;
+}
+
+const ORDER_TYPE_DESCRIPTOR = {
+  Order: [
+    { name: "makerAddress", type: "address" },
+    { name: "takerAddress", type: "address" },
+    { name: "feeRecipientAddress", type: "address" },
+    { name: "senderAddress", type: "address" },
+    { name: "makerAssetAmount", type: "uint256" },
+    { name: "takerAssetAmount", type: "uint256" },
+    { name: "makerFee", type: "uint256" },
+    { name: "takerFee", type: "uint256" },
+    { name: "expirationTimeSeconds", type: "uint256" },
+    { name: "salt", type: "uint256" },
+    { name: "makerAssetData", type: "bytes" },
+    { name: "takerAssetData", type: "bytes" },
+  ],
+};
+
+export interface SignedOrder {
+  order: Order;
+  hash: BytesLike;
+  signature: BytesLike;
+}
+
+function encodeErc20AssetData(tokenAddress: BytesLike): string {
+  // NOTE: ERC20 proxy asset data defined in:
+  // <https://github.com/0xProject/0x-monorepo/blob/master/contracts/asset-proxy/contracts/src/ERC20Proxy.sol>
+
+  const { id, hexDataSlice } = ethers.utils;
+  const PROXY_ID = hexDataSlice(id("ERC20Token(address)"), 0, 4);
+
+  return ethers.utils.hexConcat([
+    PROXY_ID,
+    ethers.utils.defaultAbiCoder.encode(["address"], [tokenAddress]),
+  ]);
+}
+
+export async function signSimpleOrder(
+  maker: Wallet,
+  domain: TypedDataDomain,
+  simpleOrder: SimpleOrder,
+): Promise<SignedOrder> {
+  const order = {
+    ...simpleOrder,
+    makerAddress: maker.address,
+    makerAssetData: encodeErc20AssetData(simpleOrder.makerAssetAddress),
+    takerAssetData: encodeErc20AssetData(simpleOrder.takerAssetAddress),
+
+    // NOTE: Unused.
+    expirationTimeSeconds: 0xffffffff,
+    salt: ethers.constants.Zero,
+
+    // NOTE: Setting taker and sender address to `address(0)` means that the
+    // order can be executed (sender) against any counterparty (taker). For the
+    // purposes of GPv2, these need to be either `address(0)` or the settlement
+    // contract.
+    takerAddress: ethers.constants.AddressZero,
+    senderAddress: ethers.constants.AddressZero,
+
+    // NOTE: Include no additional fees. I am not sure how this is used by
+    // market makers, but in theory this can be used to assign an additional
+    // fee, on top of the 0x protocol fee, to the GPv2 settlement contract.
+    feeRecipientAddress: ethers.constants.AddressZero,
+    makerFee: 0,
+    takerFee: 0,
+  };
+
+  const hash = ethers.utils._TypedDataEncoder.hash(
+    domain,
+    ORDER_TYPE_DESCRIPTOR,
+    order,
+  );
+
+  // NOTE: Use EIP-712 signing scheme for the order. The signature is just the
+  // ECDSA signature post-fixed with the signature scheme ID (0x02):
+  // <https://0x.org/docs/guides/v3-specification#signature-types>
+
+  const EIP712_SIGNATURE_ID = 0x02;
+  const { v, r, s } = ethers.utils.splitSignature(
+    await maker._signTypedData(domain, ORDER_TYPE_DESCRIPTOR, order),
+  );
+  const signature = ethers.utils.solidityPack(
+    ["uint8", "bytes32", "bytes32", "uint8"],
+    [v, r, s, EIP712_SIGNATURE_ID],
+  );
+
+  return { order, hash, signature };
+}
+
+export interface Deployment {
+  zrxToken: Contract;
+  exchange: Contract;
+  erc20Proxy: Contract;
+  domainSeparator: TypedDataDomain;
+}
+
+export async function deployExchange(deployer: Wallet): Promise<Deployment> {
+  const zrxToken = await waffle.deployContract(
+    deployer,
+    ZRXToken.compilerOutput,
+  );
+
+  const zrxAssetData = encodeErc20AssetData(zrxToken.address);
+  const exchange = await waffle.deployContract(
+    deployer,
+    Exchange.compilerOutput,
+    [zrxAssetData],
+  );
+
+  const erc20Proxy = await waffle.deployContract(
+    deployer,
+    ERC20Proxy.compilerOutput,
+  );
+
+  await erc20Proxy.addAuthorizedAddress(exchange.address);
+  await exchange.registerAssetProxy(erc20Proxy.address);
+
+  return {
+    zrxToken,
+    exchange,
+    erc20Proxy,
+    // NOTE: Domain separator parameters taken from:
+    // <https://0x.org/docs/guides/v2-specification#eip-712-usage>
+    domainSeparator: {
+      name: "0x Protocol",
+      version: "2",
+      verifyingContract: exchange.address,
+    },
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@0x/contract-artifacts@^3.11.0":
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/@0x/contract-artifacts/-/contract-artifacts-3.11.0.tgz#bb8f0512fb617c21ffcca9721221add3b3a68d2b"
-  integrity sha512-cY6qrbSQLAqVo7g72KbKjCFQKDCcvpcw8+jO9+lba/WgC7h85vlz/EE4eW+PIFlWvGxlsO4P+PHnEAu3K8XYoA==
+"@0x/contract-artifacts@=2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@0x/contract-artifacts/-/contract-artifacts-2.2.2.tgz#e6d771afb58d0b59c19c5364af5a42a3dfd17219"
+  integrity sha512-sbFnSXE6PlmYsbPXpKtEOR3YdVlSn63HhbPgQB3J5jm27wwQtnZ2Lf21I7BdiRBsHwwbf75C/s2pjNqafaRrgQ==
 
 "@babel/code-frame@^7.0.0":
   version "7.12.11"
@@ -513,7 +513,7 @@
     "@ethersproject/properties" "^5.0.7"
     "@ethersproject/strings" "^5.0.8"
 
-"@gnosis.pm/util-contracts@3.0.1-solc-7":
+"@gnosis.pm/util-contracts@=3.0.1-solc-7":
   version "3.0.1-solc-7"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/util-contracts/-/util-contracts-3.0.1-solc-7.tgz#453dd78e038bbb4b2db43672a8f1283969ac2ee2"
   integrity sha512-8/dlsGoxxaq9dn+7uBJupZECQJKVuW3H/eGumWuq31FOhWh3J0nTMQjFKxbpkM6CakOZd7VlQKfO4hHhWmtPxQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@0x/contract-artifacts@^3.11.0":
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/@0x/contract-artifacts/-/contract-artifacts-3.11.0.tgz#bb8f0512fb617c21ffcca9721221add3b3a68d2b"
+  integrity sha512-cY6qrbSQLAqVo7g72KbKjCFQKDCcvpcw8+jO9+lba/WgC7h85vlz/EE4eW+PIFlWvGxlsO4P+PHnEAu3K8XYoA==
+
 "@babel/code-frame@^7.0.0":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"


### PR DESCRIPTION
This PR adds E2E integration test where a GPv2 EOA order is matched against a 0x order.

This is implemented directly with the 0x contracts instead of using the `@0x/order-utils` and `@0x/migrations` packages (as the former installed more transient dependencies that I cared for, caused Yarn install errors with the NodeJS version we are using, did not seem to integrate nicely with the Ethers v5 hardhat provider we are using, and deployed **way** more 0x infrastructure than we need for our test). Instead I implemented order signing based on [the v3 specification](https://0x.org/docs/guides/v3-specification), and it turned out to not require too much additional code (Ethers.js is **awesome**).

### Test Plan

This is the test! One important aspect of this experiment was to gauge how much more expensive 0x order are compared to GPv2 orders. It turns out that the answer is ~90k gas more expensive (note that if additional order features such as adding additional fees can increase this cost):
```
$ yarn bench
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
...
            2 |            2 |            0 |            0 |       182267 
            2 |            1 |            1 |            0 |       182842 
...
$ DEBUG='test:e2e:0xTrade' yarn test
...
  E2E: Can settle a 0x trade
  test:e2e:0xTrade gas used: 271760 +0ms
    ✓ should settle an EOA trade with a 0x trade (362ms)
...
```

/cc @fleupold @josojo 