### PR TITLE
Separate signature schemes

### DIFF
--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -216,8 +216,8 @@ export class BenchFixture {
       }
       const signingScheme =
         (i + Math.floor(i / 4)) % 2 == 0
-          ? SigningScheme.TYPED_DATA
-          : SigningScheme.MESSAGE;
+          ? SigningScheme.EIP712
+          : SigningScheme.ETHSIGN;
       const feeDiscount = (i % 3) * (FULL_FEE_DISCOUNT / 2); // 0% | 50% | 100%
 
       const dbg = {
@@ -225,8 +225,7 @@ export class BenchFixture {
           ? "partially fillable"
           : "fill-or-kill",
         kind: orderSpice.kind == OrderKind.SELL ? "sell" : "buy",
-        sign:
-          signingScheme == SigningScheme.TYPED_DATA ? "typed-data" : "message",
+        sign: signingScheme == SigningScheme.EIP712 ? "eip-712" : "eth_sign",
         fee: 100 * (1 - feeDiscount / FULL_FEE_DISCOUNT),
       };
       debug(

--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -98,9 +98,9 @@ library GPv2Encoding {
 
     /// @dev Returns the number of trades encoded in a calldata byte array.
     ///
-    /// The number of interactions is encoded in the first two bytes, the
-    /// remaining calldata stores the encoded interactions. If no length is
-    /// found, this method reverts.
+    /// The number of trades is encoded in the first two bytes, the remaining
+    /// calldata stores the encoded trades. If no length is found, this method
+    /// reverts.
     ///
     /// @param encodedTrades The encoded trades including the number of trades.
     /// @return count The total number of trades encoded in the specified bytes.

--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -83,25 +83,28 @@ library GPv2Encoding {
         hex"b2b38b9dcbdeb41f7ad71dea9aed79fb47f7bbc3436576fe994b43d5b16ecdec";
 
     /// @dev The stride of the fixed-length components in an encoded trade.
-    uint256 private constant FIXED_LENGTH_TRADE_STRIDE = 206;
+    uint256 private constant FIXED_LENGTH_TRADE_STRIDE = 141;
+
+    /// @dev The stride of any signature from an externally owned account.
+    uint256 private constant EOA_SIGNATURE_STRIDE = 65;
 
     /// @dev The byte length of an order unique identifier.
     uint256 private constant ORDER_UID_LENGTH = 56;
 
     /// @dev Returns the number of trades encoded in a calldata byte array.
     ///
-    /// The number of interaction is encoded in the first two bytes, the
+    /// The number of interactions is encoded in the first two bytes, the
     /// remaining calldata stores the encoded interactions. If no length is
     /// found, this method reverts.
     ///
     /// @param encodedTrades The encoded trades including the number of trades.
     /// @return count The total number of trades encoded in the specified bytes.
-    /// @return encodedTradesWithoutLength The remaining calldata storing the
-    /// encoded trades.
+    /// @return unusedCalldata The remaining calldata storing the encoded
+    /// trades.
     function decodeTradeCount(bytes calldata encodedTrades)
         internal
         pure
-        returns (uint256 count, bytes calldata encodedTradesWithoutLength)
+        returns (uint256 count, bytes calldata unusedCalldata)
     {
         require(encodedTrades.length >= 2, "GPv2: malformed trade data");
 
@@ -109,10 +112,11 @@ library GPv2Encoding {
         // code for bounds checking.
         // solhint-disable-next-line no-inline-assembly
         assembly {
+            // count = uint256(encodedTrades[0:16])
             count := shr(240, calldataload(encodedTrades.offset))
-
-            encodedTradesWithoutLength.offset := add(encodedTrades.offset, 2)
-            encodedTradesWithoutLength.length := sub(encodedTrades.length, 2)
+            // unusedCalldata = encodedTrades[16:]
+            unusedCalldata.offset := add(encodedTrades.offset, 2)
+            unusedCalldata.length := sub(encodedTrades.length, 2)
         }
     }
 
@@ -135,54 +139,53 @@ library GPv2Encoding {
     ///     uint8 flags;
     ///     uint256 executedAmount;
     ///     uint16 feeDiscount;
-    ///     Signature {
-    ///         bytes32 r;
-    ///         bytes32 s;
-    ///         uint8 v;
-    ///     } signature;
+    ///     bytes signature;
     /// }
     /// ```
     ///
-    /// Order flags are used to encode additional order parameters such as the
-    /// kind of order, either a sell or a buy order, as well as whether the
-    /// order is partially fillable or if it is a "fill-or-kill" order. As the
-    /// most likely values are fill-or-kill sell orders, the flags are chosen
-    /// such that `0x00` represents this kind of order. The flags byte uses has
-    /// the following format:
+    /// The signature encoding depends on the scheme used to sign. The owner of
+    /// the order can be derived from the signature. See [`decodeEoaOwner`] for
+    /// encoding signatures originating from externally owned accounts (EOA).
+    ///
+    /// Trade flags are used to tightly encode information on how to decode
+    /// an order. Examples that directly affect the structure of an order are
+    /// the kind of order (either a sell or a buy order) as well as whether the
+    /// order is partially fillable or if it is a "fill-or-kill" order. It also
+    /// encodes whether the order comes from a smart contract or an EOA, in
+    /// order to choose the right signature scheme when decoding. As the most
+    /// likely values are fill-or-kill sell orders by an EOA, the flags are
+    /// chosen such that `0x00` represents this kind of order. The flags byte
+    /// uses the following format:
     /// ```
     /// bit | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
     /// ----+-----------------------+---+---+
-    ///     |        unsused        | * | * |
-    ///                               |   |
-    ///                               |   +---- order kind bit, 0 for a sell
-    ///                               |         order and 1 for a buy order
-    ///                               |
-    ///                               +-------- order fill bit, 0 for fill-or-
-    ///                                         kill and 1 for a partially
-    ///                                         fillable order
+    ///     | * |      unsused      | * | * |
+    ///       ^                       |   |
+    ///       |                       |   +---- order kind bit, 0 for a sell
+    ///       |                       |         order and 1 for a buy order
+    ///       |                       |
+    ///       |                       +-------- order fill bit, 0 for fill-or-
+    ///       |                                 kill and 1 for a partially
+    ///       |                                 fillable order
+    ///       |
+    ///       +-------------------------------- constract signature bit, 0 for
+    ///                                         smart contract orders and 1 for
+    ///                                         EOA orders.
     /// ```
-    ///
-    /// Order signatures support two schemes:
-    /// - EIP-712 for signing typed data, this is the default scheme that will
-    ///   be used when recovering the signing address from the signature.
-    /// - Generic message signature, this scheme will be used **only** if the
-    ///   `v` signature parameter's most significant bit is set. This is done as
-    ///   there are only two possible values `v` can have: 27 or 28, which only
-    ///   take up the lower 5 bits of the `uint8`.
     ///
     /// @param domainSeparator The domain separator used for signing the order.
     /// @param tokens The list of tokens included in the settlement. The token
     /// indices in the encoded order parameters map to tokens in this array.
     /// @param encodedTrade The trade as encoded calldata bytes.
     /// @param trade The memory location to decode trade to.
-    /// @return remainingEncodedTrades Input calldata that has not been used to
-    /// decode the current order.
+    /// @return unusedCalldata Input calldata that has not been used while
+    /// decoding the current order.
     function decodeTrade(
         bytes calldata encodedTrade,
         bytes32 domainSeparator,
         IERC20[] calldata tokens,
         Trade memory trade
-    ) internal pure returns (bytes calldata remainingEncodedTrades) {
+    ) internal pure returns (bytes calldata unusedCalldata) {
         require(
             encodedTrade.length >= FIXED_LENGTH_TRADE_STRIDE,
             "GPv2: invalid trade"
@@ -190,13 +193,13 @@ library GPv2Encoding {
 
         uint32 validTo;
         bytes32 orderDigest;
+        uint256 flags;
 
         // This scope is needed to clear variables from the stack after use and
         // avoids stack too deep errors.
         {
             uint8 sellTokenIndex;
             uint8 buyTokenIndex;
-            uint256 flags;
 
             GPv2Encoding.Order memory order = trade.order;
 
@@ -279,71 +282,32 @@ library GPv2Encoding {
             }
         }
 
-        // NOTE: Solidity allocates, but does not free, memory when:
-        // - calling the ABI encoding methods
-        // - calling the `ecrecover` precompile.
-        // However, we can restore the free memory pointer to before we made
-        // allocations to effectively free the memory. This is safe as the
-        // memory used can be discarded, and the memory pointed to by the free
-        // memory pointer **does not have to point to zero-ed out memory**.
-        // <https://docs.soliditylang.org/en/v0.7.6/internals/layout_in_memory.html>
-        uint256 freeMemoryPointer;
+        bytes calldata signature;
+        // NOTE: Use assembly to slice the calldata bytes without generating
+        // code for bounds checking.
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            freeMemoryPointer := mload(0x40)
+            signature.offset := add(
+                encodedTrade.offset,
+                FIXED_LENGTH_TRADE_STRIDE
+            )
+            signature.length := sub(
+                encodedTrade.length,
+                FIXED_LENGTH_TRADE_STRIDE
+            )
         }
 
         address owner;
-
-        {
-            uint8 v;
-            bytes32 r;
-            bytes32 s;
-            // NOTE: Use assembly to efficiently decode signature data.
-            // solhint-disable-next-line no-inline-assembly
-            assembly {
-                // r = uint256(encodedTrade[141:173])
-                r := calldataload(add(encodedTrade.offset, 141))
-                // s = uint256(encodedTrade[173:205])
-                s := calldataload(add(encodedTrade.offset, 173))
-                // v = uint8(encodedTrade[205])
-                v := shr(248, calldataload(add(encodedTrade.offset, 205)))
-            }
-
-            bytes32 signingDigest;
-            if (v & 0x80 == 0) {
-                // NOTE: The most significant bit **is not set**, so the order
-                // issigned using the EIP-712 sheme, the signing hash is of:
-                // `"\x19\x01" || domainSeparator || orderDigest`.
-                signingDigest = keccak256(
-                    abi.encodePacked("\x19\x01", domainSeparator, orderDigest)
-                );
-            } else {
-                // NOTE: The most significant bit **is set**, so the order is
-                // signed using generic message scheme, the signing hash is of:
-                // `"\x19Ethereum Signed Message:\n" || length || data` where
-                // the length is a constant 64 bytes and the data is defined as:
-                // `domainSeparator || orderDigest`.
-                signingDigest = keccak256(
-                    abi.encodePacked(
-                        "\x19Ethereum Signed Message:\n64",
-                        domainSeparator,
-                        orderDigest
-                    )
-                );
-            }
-
-            owner = ecrecover(signingDigest, v & 0x1f, r, s);
-            require(owner != address(0), "GPv2: invalid signature");
+        if (flags & 0x80 == 0) {
+            (owner, unusedCalldata) = decodeEoaOwner(
+                domainSeparator,
+                orderDigest,
+                signature
+            );
+        } else {
+            revert("unimplemented");
         }
-
         trade.owner = owner;
-
-        // NOTE: Restore the free memory pointer to free temporary memory.
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            mstore(0x40, freeMemoryPointer)
-        }
 
         // NOTE: Initialize the memory for the order UID if required.
         if (trade.orderUid.length != ORDER_UID_LENGTH) {
@@ -375,18 +339,121 @@ library GPv2Encoding {
             mstore(add(orderUid, 20), owner)
             mstore(orderUid, orderDigest)
         }
+    }
+
+    /// @dev Decodes signature bytes originating from EOAs.
+    ///
+    /// Two schemes can be used to sign orders from an EOA:
+    /// - EIP-712 for signing typed data, this is the default scheme that will
+    ///   be used when recovering the signing address from the signature.
+    /// - Generic message signature, this scheme will be used **only** if the
+    ///   `v` signature parameter's most significant bit is set. This is done as
+    ///   there are only two possible values `v` can have: 27 or 28, which only
+    ///   take up the lower 5 bits of the `uint8`.
+    ///
+    /// The first bytes of the signature calldata are supposed to store the
+    /// signature parameters in the following tightly packed struct:
+    ///
+    /// ```
+    /// struct EncodedSignature {
+    ///     bytes32 r;
+    ///     bytes32 s;
+    ///     uint8 v;
+    /// }
+    /// ```
+    ///
+    /// Unused signature data is returned along with the address of the signer.
+    /// If the signature is not valid, the function reverts.
+    ///
+    /// @param domainSeparator The domain separator used for signing the order.
+    /// @param orderDigest The EIP-712 signing digest derived from the order
+    /// parameters.
+    /// @param encodedSignature Calldata pointing to tightly packed signature
+    /// bytes.
+    /// @return owner The address of the signer.
+    /// @return unusedCalldata Input calldata that has not been used to decode
+    /// the current order.
+    function decodeEoaOwner(
+        bytes32 domainSeparator,
+        bytes32 orderDigest,
+        bytes calldata encodedSignature
+    ) internal pure returns (address owner, bytes calldata unusedCalldata) {
+        require(
+            encodedSignature.length >= EOA_SIGNATURE_STRIDE,
+            "GPv2: invalid encoding"
+        );
+
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        // NOTE: Use assembly to efficiently decode signature data.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // r = uint256(encodedTrade[0:32])
+            r := calldataload(encodedSignature.offset)
+            // s = uint256(encodedTrade[32:64])
+            s := calldataload(add(encodedSignature.offset, 32))
+            // v = uint8(encodedTrade[64])
+            v := shr(248, calldataload(add(encodedSignature.offset, 64)))
+        }
+
+        // NOTE: Solidity allocates, but does not free, memory when:
+        // - calling the ABI encoding methods
+        // - calling the `ecrecover` precompile.
+        // However, we can restore the free memory pointer to before we made
+        // allocations to effectively free the memory. This is safe as the
+        // memory used can be discarded, and the memory pointed to by the free
+        // memory pointer **does not have to point to zero-ed out memory**.
+        // <https://docs.soliditylang.org/en/v0.7.6/internals/layout_in_memory.html>
+        uint256 freeMemoryPointer;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            freeMemoryPointer := mload(0x40)
+        }
+
+        bytes32 signingDigest;
+        if (v & 0x80 == 0) {
+            // NOTE: The most significant bit **is not set**, so the order
+            // is signed using the EIP-712 sheme, the signing hash is of:
+            // `"\x19\x01" || domainSeparator || orderDigest`.
+            signingDigest = keccak256(
+                abi.encodePacked("\x19\x01", domainSeparator, orderDigest)
+            );
+        } else {
+            // NOTE: The most significant bit **is set**, so the order is
+            // signed using generic message scheme, the signing hash is of:
+            // `"\x19Ethereum Signed Message:\n" || length || data` where
+            // the length is a constant 64 bytes and the data is defined as:
+            // `domainSeparator || orderDigest`.
+            signingDigest = keccak256(
+                abi.encodePacked(
+                    "\x19Ethereum Signed Message:\n64",
+                    domainSeparator,
+                    orderDigest
+                )
+            );
+        }
+
+        owner = ecrecover(signingDigest, v & 0x1f, r, s);
+        require(owner != address(0), "GPv2: invalid eoa signature");
+
+        // NOTE: Restore the free memory pointer to free temporary memory.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            mstore(0x40, freeMemoryPointer)
+        }
 
         // NOTE: Use assembly to slice the calldata bytes without generating
         // code for bounds checking.
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            remainingEncodedTrades.offset := add(
-                encodedTrade.offset,
-                FIXED_LENGTH_TRADE_STRIDE
+            unusedCalldata.offset := add(
+                encodedSignature.offset,
+                EOA_SIGNATURE_STRIDE
             )
-            remainingEncodedTrades.length := sub(
-                encodedTrade.length,
-                FIXED_LENGTH_TRADE_STRIDE
+            unusedCalldata.length := sub(
+                encodedSignature.length,
+                EOA_SIGNATURE_STRIDE
             )
         }
     }
@@ -431,12 +498,12 @@ library GPv2Encoding {
     ///
     /// @param encodedInteractions The interactions as encoded calldata bytes.
     /// @param interaction The memory location to decode the interaction to.
-    /// @return remainingEncodedInteractions The part of encodedInteractions
-    /// that has not been decoded after this function is executed.
+    /// @return unusedCalldata The part of encodedInteractions that has not been
+    /// decoded after this function is executed.
     function decodeInteraction(
         bytes calldata encodedInteractions,
         Interaction memory interaction
-    ) internal pure returns (bytes calldata remainingEncodedInteractions) {
+    ) internal pure returns (bytes calldata unusedCalldata) {
         bool hasValue;
         uint256 dataLength;
 
@@ -497,11 +564,11 @@ library GPv2Encoding {
                 }
             interactionCallData.length := dataLength
 
-            remainingEncodedInteractions.offset := add(
+            unusedCalldata.offset := add(
                 encodedInteractions.offset,
                 encodedInteractionSize
             )
-            remainingEncodedInteractions.length := sub(
+            unusedCalldata.length := sub(
                 encodedInteractions.length,
                 encodedInteractionSize
             )

--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -144,7 +144,7 @@ library GPv2Encoding {
     /// ```
     ///
     /// The signature encoding depends on the scheme used to sign. The owner of
-    /// the order can be derived from the signature. See [`decodeEoaOwner`] for
+    /// the order can be derived from the signature. See [`recoverEoaOwner`] for
     /// encoding signatures originating from externally owned accounts (EOA).
     ///
     /// Trade flags are used to tightly encode information on how to decode
@@ -299,7 +299,7 @@ library GPv2Encoding {
 
         address owner;
         if (flags & 0x80 == 0) {
-            (owner, remainingCalldata) = decodeEoaOwner(
+            (owner, remainingCalldata) = recoverEoaOwner(
                 domainSeparator,
                 orderDigest,
                 signature
@@ -373,7 +373,7 @@ library GPv2Encoding {
     /// @return owner The address of the signer.
     /// @return remainingCalldata Input calldata that has not been used to
     /// decode the current order.
-    function decodeEoaOwner(
+    function recoverEoaOwner(
         bytes32 domainSeparator,
         bytes32 orderDigest,
         bytes calldata encodedSignature

--- a/src/contracts/libraries/GPv2Signing.sol
+++ b/src/contracts/libraries/GPv2Signing.sol
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.7.6;
+
+/// @title Gnosis Protocol v2 Signing Library.
+/// @author Gnosis Developers
+library GPv2Signing {
+    /// @dev The length of any signature from an externally owned account.
+    uint256 private constant ECDSA_SIGNATURE_LENGTH = 65;
+
+    /// @dev Decodes ECDSA signatures from calldata.
+    ///
+    /// The first bytes of the input tightly pack the signature parameters
+    /// specified in the following struct:
+    ///
+    /// ```
+    /// struct EncodedSignature {
+    ///     bytes32 r;
+    ///     bytes32 s;
+    ///     uint8 v;
+    /// }
+    /// ```
+    ///
+    /// Unused signature data is returned along with the address of the signer.
+    /// If the encoding is not valid, for example because the calldata does not
+    /// suffice, the function reverts.
+    ///
+    /// @param encodedSignature Calldata pointing to tightly packed signature
+    /// bytes.
+    /// @return r r parameter of the ECDSA signature.
+    /// @return s s parameter of the ECDSA signature.
+    /// @return v v parameter of the ECDSA signature.
+    /// @return remainingCalldata Input calldata that has not been used to
+    /// decode the signature.
+    function decodeEcdsaSignature(bytes calldata encodedSignature)
+        internal
+        pure
+        returns (
+            bytes32 r,
+            bytes32 s,
+            uint8 v,
+            bytes calldata remainingCalldata
+        )
+    {
+        require(
+            encodedSignature.length >= ECDSA_SIGNATURE_LENGTH,
+            "GPv2: invalid encoding"
+        );
+
+        // NOTE: Use assembly to efficiently decode signature data.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // r = uint256(encodedSignature[0:32])
+            r := calldataload(encodedSignature.offset)
+            // s = uint256(encodedSignature[32:64])
+            s := calldataload(add(encodedSignature.offset, 32))
+            // v = uint8(encodedSignature[64])
+            v := shr(248, calldataload(add(encodedSignature.offset, 64)))
+        }
+
+        // NOTE: Use assembly to slice the calldata bytes without generating
+        // code for bounds checking.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            remainingCalldata.offset := add(
+                encodedSignature.offset,
+                ECDSA_SIGNATURE_LENGTH
+            )
+            remainingCalldata.length := sub(
+                encodedSignature.length,
+                ECDSA_SIGNATURE_LENGTH
+            )
+        }
+    }
+
+    /// @dev Decodes signature bytes originating from an EIP-712-encoded
+    /// signature.
+    ///
+    /// EIP-712 signs typed data. The specifications are described in the
+    /// related EIP (<https://eips.ethereum.org/EIPS/eip-712>).
+    ///
+    /// EIP-712 signatures are encoded as standard ECDSA signatures as described
+    /// in the corresponding decoding function [`decodeEcdsaSignature`].
+    ///
+    /// Unused signature data is returned along with the address of the signer.
+    /// If the signature is not valid, the function reverts.
+    ///
+    /// @param encodedSignature Calldata pointing to tightly packed signature
+    /// bytes.
+    /// @param domainSeparator The domain separator used for signing the order.
+    /// @param orderDigest The EIP-712 signing digest derived from the order
+    /// parameters.
+    /// @return owner The address of the signer.
+    /// @return remainingCalldata Input calldata that has not been used to
+    /// decode the current order.
+    function recoverEip712Signer(
+        bytes calldata encodedSignature,
+        bytes32 domainSeparator,
+        bytes32 orderDigest
+    ) internal pure returns (address owner, bytes calldata remainingCalldata) {
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        (r, s, v, remainingCalldata) = decodeEcdsaSignature(encodedSignature);
+
+        uint256 freeMemoryPointer = getFreeMemoryPointer();
+
+        bytes32 signingDigest =
+            keccak256(
+                abi.encodePacked("\x19\x01", domainSeparator, orderDigest)
+            );
+
+        owner = ecrecover(signingDigest, v, r, s);
+        require(owner != address(0), "GPv2: invalid eip712 signature");
+
+        setFreeMemoryPointer(freeMemoryPointer);
+    }
+
+    /// @dev Decodes signature bytes originating from the output of the eth_sign
+    /// RPC call.
+    ///
+    /// The specifications are described in the Ethereum documentation
+    /// (<https://eth.wiki/json-rpc/API#eth_sign>).
+    ///
+    /// eth_sign signatures are encoded as standard ECDSA signatures as
+    /// described in the corresponding decoding function
+    /// [`decodeEcdsaSignature`].
+    ///
+    /// Unused signature data is returned along with the address of the signer.
+    /// If the signature is not valid, the function reverts.
+    ///
+    /// @param encodedSignature Calldata pointing to tightly packed signature
+    /// bytes.
+    /// @param domainSeparator The domain separator used for signing the order.
+    /// @param orderDigest The EIP-712 signing digest derived from the order
+    /// parameters.
+    /// @return owner The address of the signer.
+    /// @return remainingCalldata Input calldata that has not been used to
+    /// decode the current order.
+    function recoverEthsignSigner(
+        bytes calldata encodedSignature,
+        bytes32 domainSeparator,
+        bytes32 orderDigest
+    ) internal pure returns (address owner, bytes calldata remainingCalldata) {
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        (r, s, v, remainingCalldata) = decodeEcdsaSignature(encodedSignature);
+
+        uint256 freeMemoryPointer = getFreeMemoryPointer();
+
+        // The signed message is encoded as:
+        // `"\x19Ethereum Signed Message:\n" || length || data`, where
+        // the length is a constant (64 bytes) and the data is defined as:
+        // `domainSeparator || orderDigest`.
+        bytes32 signingDigest =
+            keccak256(
+                abi.encodePacked(
+                    "\x19Ethereum Signed Message:\n64",
+                    domainSeparator,
+                    orderDigest
+                )
+            );
+
+        owner = ecrecover(signingDigest, v, r, s);
+        require(owner != address(0), "GPv2: invalid ethsign signature");
+
+        setFreeMemoryPointer(freeMemoryPointer);
+    }
+
+    /// @dev Returns a pointer to the first location in memory that has not
+    /// been allocated by the code at this point in the code.
+    ///
+    /// @return pointer A pointer to the first unallocated location in memory.
+    function getFreeMemoryPointer() private pure returns (uint256 pointer) {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            pointer := mload(0x40)
+        }
+    }
+
+    /// @dev Manually sets the pointer that specifies the first location in
+    /// memory that is available to be allocated. It allows to free unused
+    /// allocated memory, but if used incorrectly it could lead to the same
+    /// address in memory being used twice.
+    ///
+    /// This function exists to deallocate memory for operations that allocate
+    /// memory during their execution but do not free it after use.
+    /// Examples are:
+    /// - calling the ABI encoding methods
+    /// - calling the `ecrecover` precompile.
+    /// If we reset the free memory pointer to what it was before the execution
+    /// of these operations, we effectively deallocated the memory used by them.
+    /// This is safe as the memory used can be discarded, and the memory pointed
+    /// to by the free memory pointer **does not have to point to zero-ed out
+    /// memory**.
+    /// <https://docs.soliditylang.org/en/v0.7.6/internals/layout_in_memory.html>
+    ///
+    /// @param pointer A pointer to a location in memory.
+    function setFreeMemoryPointer(uint256 pointer) private pure {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            mstore(0x40, pointer)
+        }
+    }
+}

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -24,4 +24,5 @@ export * from "./interaction";
 export * from "./settlement";
 export * from "./reader";
 export * from "./deploy";
+export * from "./sign";
 export * from "./types/ethers";

--- a/src/ts/order.ts
+++ b/src/ts/order.ts
@@ -1,6 +1,4 @@
-import { ethers, BigNumberish, Signer } from "ethers";
-
-import { TypedDataDomain, isTypedDataSigner } from "./types/ethers";
+import { ethers, BigNumberish } from "ethers";
 
 /**
  * Gnosis Protocol v2 order data.
@@ -134,96 +132,6 @@ export function hashOrder(order: Order): string {
     "Order",
     { Order: ORDER_TYPE_FIELDS },
     { ...order, validTo: timestamp(order.validTo) },
-  );
-}
-
-/**
- * The signing scheme used to sign the order.
- */
-export const enum SigningScheme {
-  /**
-   * The EIP-712 typed data signing scheme. This is the preferred scheme as it
-   * provides more infomation to wallets performing the signature on the data
-   * being signed.
-   *
-   * <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-domainseparator>
-   */
-  TYPED_DATA,
-  /**
-   * The generic message signing scheme.
-   */
-  MESSAGE,
-}
-
-function ecdsaSignOrder(
-  domain: TypedDataDomain,
-  order: Order,
-  owner: Signer,
-  scheme: SigningScheme,
-): Promise<string> {
-  switch (scheme) {
-    case SigningScheme.TYPED_DATA:
-      if (!isTypedDataSigner(owner)) {
-        throw new Error("signer does not support signing typed data");
-      }
-      return owner._signTypedData(
-        domain,
-        { Order: ORDER_TYPE_FIELDS },
-        { ...order, validTo: timestamp(order.validTo) },
-      );
-
-    case SigningScheme.MESSAGE:
-      return owner.signMessage(
-        ethers.utils.arrayify(
-          ethers.utils.hexConcat([
-            ethers.utils._TypedDataEncoder.hashDomain(domain),
-            hashOrder(order),
-          ]),
-        ),
-      );
-  }
-}
-
-function encodeSigningScheme(v: number, scheme: SigningScheme): number {
-  const ORDER_MESSAGE_SCHEME_FLAG = 0x80;
-  switch (scheme) {
-    case SigningScheme.TYPED_DATA:
-      return v;
-    case SigningScheme.MESSAGE:
-      return v | ORDER_MESSAGE_SCHEME_FLAG;
-  }
-}
-
-/**
- * Returns the signature for the specified order with the signing scheme encoded
- * into the signature bytes.
- * @param domain The domain to sign the order for. This is used by the smart
- * contract to ensure orders can't be replayed across different applications,
- * but also different deployments (as the contract chain ID and address are
- * mixed into to the domain value).
- * @param order The order to sign.
- * @param owner The owner for the order used to sign.
- * @param scheme The signing scheme to use. See {@link SigningScheme} for more
- * details.
- * @return Hex-encoded signature with encoded signing scheme for the order.
- */
-export async function signOrder(
-  domain: TypedDataDomain,
-  order: Order,
-  owner: Signer,
-  scheme: SigningScheme,
-): Promise<string> {
-  const ecdsaSignature = ethers.utils.splitSignature(
-    await ecdsaSignOrder(domain, order, owner, scheme),
-  );
-
-  return ethers.utils.solidityPack(
-    ["bytes32", "bytes32", "uint8"],
-    [
-      ecdsaSignature.r,
-      ecdsaSignature.s,
-      encodeSigningScheme(ecdsaSignature.v, scheme),
-    ],
   );
 }
 

--- a/src/ts/sign.ts
+++ b/src/ts/sign.ts
@@ -1,0 +1,120 @@
+import { BytesLike, ethers, Signer } from "ethers";
+
+import { hashOrder, Order, ORDER_TYPE_FIELDS, timestamp } from "./order";
+import { isTypedDataSigner, TypedDataDomain } from "./types/ethers";
+
+/**
+ * The signing scheme used to sign the order.
+ */
+export const enum SigningScheme {
+  /**
+   * The EIP-712 typed data signing scheme. This is the preferred scheme as it
+   * provides more infomation to wallets performing the signature on the data
+   * being signed.
+   *
+   * <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-domainseparator>
+   */
+  EIP712,
+  /**
+   * Message signed using eth_sign RPC call.
+   */
+  ETHSIGN,
+}
+
+/**
+ * The signature of an order.
+ * It includes the information needed to determine which signing scheme is used.
+ */
+export interface Signature {
+  /**
+   * The signing scheme used in the signature.
+   */
+  scheme: SigningScheme;
+  /**
+   * The signature bytes as prescribed by the selected signing scheme.
+   */
+  data: BytesLike;
+}
+
+function ecdsaSignOrder(
+  domain: TypedDataDomain,
+  order: Order,
+  owner: Signer,
+  scheme: SigningScheme,
+): Promise<string> {
+  switch (scheme) {
+    case SigningScheme.EIP712:
+      if (!isTypedDataSigner(owner)) {
+        throw new Error("signer does not support signing typed data");
+      }
+      return owner._signTypedData(
+        domain,
+        { Order: ORDER_TYPE_FIELDS },
+        { ...order, validTo: timestamp(order.validTo) },
+      );
+
+    case SigningScheme.ETHSIGN:
+      return owner.signMessage(
+        ethers.utils.arrayify(
+          ethers.utils.hexConcat([
+            ethers.utils._TypedDataEncoder.hashDomain(domain),
+            hashOrder(order),
+          ]),
+        ),
+      );
+  }
+}
+
+/**
+ * Returns the signature for the specified order with the signing scheme encoded
+ * into the signature bytes.
+ * @param domain The domain to sign the order for. This is used by the smart
+ * contract to ensure orders can't be replayed across different applications,
+ * but also different deployments (as the contract chain ID and address are
+ * mixed into to the domain value).
+ * @param order The order to sign.
+ * @param owner The owner for the order used to sign.
+ * @param scheme The signing scheme to use. See {@link SigningScheme} for more
+ * details.
+ * @return Encoded signature including signing scheme for the order.
+ */
+export async function signOrder(
+  domain: TypedDataDomain,
+  order: Order,
+  owner: Signer,
+  scheme: SigningScheme,
+): Promise<Signature> {
+  if (![SigningScheme.EIP712, SigningScheme.ETHSIGN].includes(scheme)) {
+    throw new Error(
+      "Cannot create a signature with the specified signing scheme",
+    );
+  }
+  const rawEcdsaSignature = await ecdsaSignOrder(domain, order, owner, scheme);
+  const ecdsaSignature = ethers.utils.splitSignature(rawEcdsaSignature);
+
+  const data = ethers.utils.solidityPack(
+    ["bytes32", "bytes32", "uint8"],
+    [ecdsaSignature.r, ecdsaSignature.s, ecdsaSignature.v],
+  );
+
+  return {
+    data,
+    scheme,
+  };
+}
+
+/**
+ * Throws an error if the signature length is incompatible with the signing
+ * scheme. It does not otherwise check the signature for validity.
+ *
+ * @param sig The signature to check.
+ */
+export function assertValidSignatureLength(sig: Signature): void {
+  const ECDSA_SIGNATURE_LENGTH = 65;
+  if (
+    [SigningScheme.EIP712, SigningScheme.ETHSIGN].includes(sig.scheme) &&
+    ethers.utils.hexDataLength(sig.data) !== ECDSA_SIGNATURE_LENGTH
+  ) {
+    throw new Error("invalid signature bytes");
+  }
+}

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -77,7 +77,7 @@ describe("GPv2Encoding", () => {
         await encoder.signEncodeTrade(
           { ...sampleOrder, appData: i },
           traders[0],
-          SigningScheme.TYPED_DATA,
+          SigningScheme.EIP712,
         );
       }
 
@@ -95,7 +95,7 @@ describe("GPv2Encoding", () => {
         await encoder.signEncodeTrade(
           { ...sampleOrder, appData: i },
           traders[0],
-          SigningScheme.TYPED_DATA,
+          SigningScheme.EIP712,
         );
       }
 
@@ -140,7 +140,7 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         order,
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.EIP712,
         tradeExecution,
       );
 
@@ -165,7 +165,7 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.EIP712,
       );
 
       const { trades } = await encoding.decodeTradesTest(
@@ -186,7 +186,7 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.EIP712,
       );
 
       const { trades } = await encoding.decodeTradesTest(
@@ -205,7 +205,7 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.EIP712,
       );
 
       const { trades } = await encoding.decodeTradesTest(
@@ -225,7 +225,7 @@ describe("GPv2Encoding", () => {
 
     it("should recover signing address for all supported schemes", async () => {
       const encoder = new SettlementEncoder(testDomain);
-      for (const scheme of [SigningScheme.TYPED_DATA, SigningScheme.MESSAGE]) {
+      for (const scheme of [SigningScheme.EIP712, SigningScheme.ETHSIGN]) {
         await encoder.signEncodeTrade(sampleOrder, traders[0], scheme);
       }
 
@@ -241,12 +241,12 @@ describe("GPv2Encoding", () => {
       }
     });
 
-    it("should revert for invalid order signatures", async () => {
+    it("should revert for invalid eip-712 order signatures", async () => {
       const encoder = new SettlementEncoder(testDomain);
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.EIP712,
       );
 
       // NOTE: `v` must be either `27` or `28`, so just set it to something else
@@ -256,7 +256,25 @@ describe("GPv2Encoding", () => {
 
       await expect(
         encoding.decodeTradesTest(encoder.tokens, encodedTradeBytes),
-      ).to.be.revertedWith("invalid eoa signature");
+      ).to.be.revertedWith("invalid eip712 signature");
+    });
+
+    it("should revert for invalid ethsign order signatures", async () => {
+      const encoder = new SettlementEncoder(testDomain);
+      await encoder.signEncodeTrade(
+        sampleOrder,
+        traders[0],
+        SigningScheme.ETHSIGN,
+      );
+
+      // NOTE: `v` must be either `27` or `28`, so just set it to something else
+      // to generate an invalid signature.
+      const encodedTradeBytes = ethers.utils.arrayify(encoder.encodedTrades);
+      encodedTradeBytes[207] = 42;
+
+      await expect(
+        encoding.decodeTradesTest(encoder.tokens, encodedTradeBytes),
+      ).to.be.revertedWith("invalid ethsign signature");
     });
 
     it("should revert for invalid sell token indices", async () => {
@@ -266,7 +284,7 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.EIP712,
       );
       await encoder.signEncodeTrade(
         {
@@ -274,7 +292,7 @@ describe("GPv2Encoding", () => {
           sellToken: lastToken,
         },
         traders[1],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.EIP712,
       );
 
       // NOTE: Remove the last sell token (0x0303...0303).
@@ -291,7 +309,7 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.EIP712,
       );
       await encoder.signEncodeTrade(
         {
@@ -299,7 +317,7 @@ describe("GPv2Encoding", () => {
           buyToken: lastToken,
         },
         traders[1],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.EIP712,
       );
 
       // NOTE: Remove the last buy token (0x0303...0303).
@@ -309,17 +327,24 @@ describe("GPv2Encoding", () => {
         .be.reverted;
     });
 
-    it("should revert when encoding a smart contract order", async () => {
+    it("should revert when encoding an invalid signing scheme", async () => {
       const encoder = new SettlementEncoder(testDomain);
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.TYPED_DATA,
-        { contractOrder: true },
+        SigningScheme.EIP712,
       );
 
+      const encodedTrades = ethers.utils.arrayify(encoder.encodedTrades);
+
+      encodedTrades[2 + 106] |= 0b10000000;
       await expect(
-        encoding.decodeTradesTest(encoder.tokens, encoder.encodedTrades),
+        encoding.decodeTradesTest(encoder.tokens, encodedTrades),
+      ).to.be.revertedWith("unimplemented");
+
+      encodedTrades[2 + 106] |= 0b01000000;
+      await expect(
+        encoding.decodeTradesTest(encoder.tokens, encodedTrades),
       ).to.be.revertedWith("unimplemented");
     });
 
@@ -345,7 +370,7 @@ describe("GPv2Encoding", () => {
         await encoder.signEncodeTrade(
           order,
           traders[0],
-          SigningScheme.TYPED_DATA,
+          SigningScheme.EIP712,
           tradeExecution,
         );
 
@@ -377,7 +402,7 @@ describe("GPv2Encoding", () => {
         await encoder.signEncodeTrade(
           order,
           traders[0],
-          SigningScheme.TYPED_DATA,
+          SigningScheme.EIP712,
           tradeExecution,
         );
 
@@ -399,12 +424,12 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.EIP712,
       );
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[1],
-        SigningScheme.MESSAGE,
+        SigningScheme.ETHSIGN,
       );
 
       const { mem } = await encoding.decodeTradesTest(

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -256,7 +256,7 @@ describe("GPv2Encoding", () => {
 
       await expect(
         encoding.decodeTradesTest(encoder.tokens, encodedTradeBytes),
-      ).to.be.revertedWith("invalid signature");
+      ).to.be.revertedWith("invalid eoa signature");
     });
 
     it("should revert for invalid sell token indices", async () => {
@@ -284,7 +284,7 @@ describe("GPv2Encoding", () => {
         .be.reverted;
     });
 
-    it("should revert for invalid sell token indices", async () => {
+    it("should revert for invalid buy token indices", async () => {
       const lastToken = fillBytes(20, 0x03);
 
       const encoder = new SettlementEncoder(testDomain);
@@ -307,6 +307,20 @@ describe("GPv2Encoding", () => {
       expect(tokens.pop()).to.equal(lastToken);
       await expect(encoding.decodeTradesTest(tokens, encoder.encodedTrades)).to
         .be.reverted;
+    });
+
+    it("should revert when encoding a smart contract order", async () => {
+      const encoder = new SettlementEncoder(testDomain);
+      await encoder.signEncodeTrade(
+        sampleOrder,
+        traders[0],
+        SigningScheme.TYPED_DATA,
+        { contractOrder: true },
+      );
+
+      await expect(
+        encoding.decodeTradesTest(encoder.tokens, encoder.encodedTrades),
+      ).to.be.revertedWith("unimplemented");
     });
 
     describe("invalid encoded trade", () => {
@@ -339,7 +353,7 @@ describe("GPv2Encoding", () => {
           encoder.tokens,
           encoder.encodedTrades.slice(0, -2),
         );
-        await expect(decoding).to.be.revertedWith("GPv2: invalid trade");
+        await expect(decoding).to.be.revertedWith("GPv2: invalid encoding");
       });
 
       it("calldata longer than single trade length", async () => {

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -358,7 +358,7 @@ describe("GPv2Settlement", () => {
             partiallyFillable: true,
           },
           traders[0],
-          SigningScheme.TYPED_DATA,
+          SigningScheme.EIP712,
           { executedAmount: ethers.utils.parseEther("0.7734") },
         );
       }
@@ -385,7 +385,7 @@ describe("GPv2Settlement", () => {
               partiallyFillable: true,
             },
             traders[0],
-            SigningScheme.TYPED_DATA,
+            SigningScheme.EIP712,
             { executedAmount: ethers.utils.parseEther("0.7734") },
           );
         }
@@ -415,7 +415,7 @@ describe("GPv2Settlement", () => {
               partiallyFillable: true,
             },
             traders[0],
-            SigningScheme.TYPED_DATA,
+            SigningScheme.EIP712,
             { executedAmount: ethers.utils.parseEther("0.7734") },
           );
         }
@@ -446,7 +446,7 @@ describe("GPv2Settlement", () => {
           partiallyFillable: false,
         },
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.EIP712,
       );
 
       await expect(
@@ -474,7 +474,7 @@ describe("GPv2Settlement", () => {
           partiallyFillable: false,
         },
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.EIP712,
       );
 
       expect(toNumberLossy(sellAmount.mul(sellPrice))).not.to.be.gte(
@@ -501,7 +501,7 @@ describe("GPv2Settlement", () => {
           partiallyFillable: false,
         },
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.EIP712,
       );
 
       const { sellAmount, buyAmount } = partialOrder;
@@ -536,7 +536,7 @@ describe("GPv2Settlement", () => {
             partiallyFillable,
           },
           traders[0],
-          SigningScheme.TYPED_DATA,
+          SigningScheme.EIP712,
           { executedAmount },
         );
 
@@ -694,7 +694,7 @@ describe("GPv2Settlement", () => {
             partiallyFillable,
           },
           traders[0],
-          SigningScheme.TYPED_DATA,
+          SigningScheme.EIP712,
           tradeExecution,
         );
 
@@ -792,7 +792,7 @@ describe("GPv2Settlement", () => {
         await encoder.signEncodeTrade(
           order,
           traders[0],
-          SigningScheme.TYPED_DATA,
+          SigningScheme.EIP712,
           tradeExecution,
         );
 
@@ -862,12 +862,12 @@ describe("GPv2Settlement", () => {
       await encoder.signEncodeTrade(
         { ...order, appData: 0 },
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.EIP712,
       );
       await encoder.signEncodeTrade(
         { ...order, appData: 1 },
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.EIP712,
         { executedAmount: ethers.utils.parseEther("1.0") },
       );
 
@@ -891,7 +891,7 @@ describe("GPv2Settlement", () => {
           partiallyFillable: false,
         },
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.EIP712,
         { feeDiscount: FULL_FEE_DISCOUNT + 1 },
       );
 
@@ -912,11 +912,7 @@ describe("GPv2Settlement", () => {
       };
 
       const encoder = new SettlementEncoder(testDomain);
-      await encoder.signEncodeTrade(
-        order,
-        traders[0],
-        SigningScheme.TYPED_DATA,
-      );
+      await encoder.signEncodeTrade(order, traders[0], SigningScheme.EIP712);
 
       const executedSellAmount = order.sellAmount.add(order.feeAmount);
       const executedBuyAmount = order.sellAmount

--- a/test/e2e/0xTrade.test.ts
+++ b/test/e2e/0xTrade.test.ts
@@ -146,11 +146,7 @@ describe("E2E: Can settle a 0x trade", () => {
       ).to.be.true;
 
       const encoder = new SettlementEncoder(domainSeparator);
-      await encoder.signEncodeTrade(
-        gpv2Order,
-        trader,
-        SigningScheme.TYPED_DATA,
-      );
+      await encoder.signEncodeTrade(gpv2Order, trader, SigningScheme.EIP712);
       encoder.encodeInteraction({
         target: owl.address,
         callData: owl.interface.encodeFunctionData("approve", [

--- a/test/e2e/burnFees.test.ts
+++ b/test/e2e/burnFees.test.ts
@@ -70,7 +70,7 @@ describe("E2E: Burn fees", () => {
         appData: 1,
       },
       traders[0],
-      SigningScheme.TYPED_DATA,
+      SigningScheme.EIP712,
     );
 
     await dai.mint(traders[1].address, ONE_USD.mul(1000));
@@ -91,7 +91,7 @@ describe("E2E: Burn fees", () => {
         appData: 2,
       },
       traders[1],
-      SigningScheme.TYPED_DATA,
+      SigningScheme.EIP712,
     );
 
     encoder.encodeInteraction(

--- a/test/e2e/buyEth.test.ts
+++ b/test/e2e/buyEth.test.ts
@@ -77,7 +77,7 @@ describe("E2E: Buy Ether", () => {
         appData: 1,
       },
       traders[0],
-      SigningScheme.TYPED_DATA,
+      SigningScheme.EIP712,
     );
 
     await usdt.mint(traders[1].address, ethers.utils.parseUnits("1201.2", 6));
@@ -97,7 +97,7 @@ describe("E2E: Buy Ether", () => {
         appData: 2,
       },
       traders[1],
-      SigningScheme.TYPED_DATA,
+      SigningScheme.EIP712,
     );
 
     encoder.encodeInteraction({

--- a/test/e2e/ercPermit.test.ts
+++ b/test/e2e/ercPermit.test.ts
@@ -66,7 +66,7 @@ describe("E2E: EIP-2612 Permit", () => {
         appData: 1,
       },
       traders[0],
-      SigningScheme.TYPED_DATA,
+      SigningScheme.EIP712,
     );
 
     await eurs[1].mint(traders[1].address, ONE_EUR);
@@ -140,7 +140,7 @@ describe("E2E: EIP-2612 Permit", () => {
         appData: 2,
       },
       traders[1],
-      SigningScheme.TYPED_DATA,
+      SigningScheme.EIP712,
     );
 
     await settlement.connect(solver).settle(

--- a/test/e2e/orderRefunds.test.ts
+++ b/test/e2e/orderRefunds.test.ts
@@ -105,13 +105,9 @@ describe("E2E: Expired Order Gas Refunds", () => {
       await encoder.signEncodeTrade(
         sellOrder,
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.EIP712,
       );
-      await encoder.signEncodeTrade(
-        buyOrder,
-        traders[1],
-        SigningScheme.TYPED_DATA,
-      );
+      await encoder.signEncodeTrade(buyOrder, traders[1], SigningScheme.EIP712);
 
       const orderUids = [
         computeOrderUid({

--- a/test/e2e/uniswapTrade.test.ts
+++ b/test/e2e/uniswapTrade.test.ts
@@ -120,7 +120,7 @@ describe("E2E: Should Trade Surplus With Uniswap", () => {
         appData: 1,
       },
       traders[0],
-      SigningScheme.TYPED_DATA,
+      SigningScheme.EIP712,
       // NOTE: Only take 50% of fees as the user traded half of their order
       // against Uniswap.
       { feeDiscount: 5000 },
@@ -143,7 +143,7 @@ describe("E2E: Should Trade Surplus With Uniswap", () => {
         appData: 2,
       },
       traders[1],
-      SigningScheme.TYPED_DATA,
+      SigningScheme.EIP712,
     );
 
     encoder.encodeInteraction({

--- a/test/e2e/wineOilMarket.test.ts
+++ b/test/e2e/wineOilMarket.test.ts
@@ -81,7 +81,7 @@ describe("E2E: RetrETH Red Wine and Olive Oil Market", () => {
         .connect(trader)
         .approve(allowanceManager.address, ethers.constants.MaxUint256);
 
-      await encoder.signEncodeTrade(order, trader, SigningScheme.TYPED_DATA, {
+      await encoder.signEncodeTrade(order, trader, SigningScheme.EIP712, {
         executedAmount,
       });
     };


### PR DESCRIPTION
Implements separate functions for each signature scheme used, and prepare the ground for introducing new signature schemes simply with an extra flag.

### Test plan
Old and new unit tests.

### Benchmark
It looks like this PR increase the gas cost for each trade by ~275 gas.

<details><summary>comparison at f2a70c6ba5b1491e0d6ed317c647c953eda35ffe</summary>

```
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
            2 |           10 |            0 |            0 |       747083  (change: 280 / trade)
            3 |           10 |            0 |            0 |       747627  (change: 274 / trade)
            4 |           10 |            0 |            0 |       756571  (change: 279 / trade)
            5 |           10 |            0 |            0 |       761279  (change: 278 / trade)
            6 |           10 |            0 |            0 |       757587  (change: 276 / trade)
            7 |           10 |            0 |            0 |       766507  (change: 280 / trade)
            8 |           10 |            0 |            0 |       771191  (change: 276 / trade)
            8 |           20 |            0 |            0 |      1461043  (change: 275 / trade)
            8 |           30 |            0 |            0 |      2104547  (change: 277 / trade)
            8 |           40 |            0 |            0 |      2752537  (change: 278 / trade)
            8 |           50 |            0 |            0 |      3400212  (change: 276 / trade)
            8 |           60 |            0 |            0 |      4044423  (change: 277 / trade)
            8 |           70 |            0 |            0 |      4693042  (change: 278 / trade)
            8 |           80 |            0 |            0 |      5341375  (change: 276 / trade)
            2 |           10 |            1 |            0 |       817589  (change: 274 / trade)
            2 |           10 |            2 |            0 |       863335  (change: 276 / trade)
            2 |           10 |            3 |            0 |       909106  (change: 279 / trade)
            2 |           10 |            4 |            0 |       954702  (change: 276 / trade)
            2 |           10 |            5 |            0 |      1000486  (change: 276 / trade)
            2 |           10 |            6 |            0 |      1046212  (change: 274 / trade)
            2 |           10 |            7 |            0 |      1091997  (change: 277 / trade)
            2 |           10 |            8 |            0 |      1137608  (change: 277 / trade)
            2 |           50 |            0 |           10 |      3125862  (change: 275 / trade)
            2 |           50 |            0 |           15 |      3082594  (change: 278 / trade)
            2 |           50 |            0 |           20 |      3039102  (change: 278 / trade)
            2 |           50 |            0 |           25 |      2995846  (change: 278 / trade)
            2 |           50 |            0 |           30 |      2952434  (change: 276 / trade)
            2 |           50 |            0 |           35 |      2909046  (change: 275 / trade)
            2 |           50 |            0 |           40 |      2865638  (change: 277 / trade)
            2 |           50 |            0 |           45 |      2822370  (change: 276 / trade)
            2 |           50 |            0 |           50 |      2778958  (change: 276 / trade)
            2 |            2 |            0 |            0 |       185277  (change: 270 / trade)
            2 |            1 |            1 |            0 |       185574  (change: 258 / trade)
           10 |          100 |           10 |           20 |      7145471  (change: 276 / trade)
```

</details>