### PR TITLE
Specify signing scheme with flags

### DIFF
--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -216,7 +216,7 @@ export class BenchFixture {
       }
       const signingScheme =
         (i + Math.floor(i / 4)) % 2 == 0
-          ? SigningScheme.ERC712
+          ? SigningScheme.EIP712
           : SigningScheme.ETHSIGN;
       const feeDiscount = (i % 3) * (FULL_FEE_DISCOUNT / 2); // 0% | 50% | 100%
 
@@ -225,7 +225,7 @@ export class BenchFixture {
           ? "partially fillable"
           : "fill-or-kill",
         kind: orderSpice.kind == OrderKind.SELL ? "sell" : "buy",
-        sign: signingScheme == SigningScheme.ERC712 ? "erc-712" : "eth_sign",
+        sign: signingScheme == SigningScheme.EIP712 ? "eip-712" : "eth_sign",
         fee: 100 * (1 - feeDiscount / FULL_FEE_DISCOUNT),
       };
       debug(

--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -216,8 +216,8 @@ export class BenchFixture {
       }
       const signingScheme =
         (i + Math.floor(i / 4)) % 2 == 0
-          ? SigningScheme.TYPED_DATA
-          : SigningScheme.MESSAGE;
+          ? SigningScheme.ERC712
+          : SigningScheme.ETHSIGN;
       const feeDiscount = (i % 3) * (FULL_FEE_DISCOUNT / 2); // 0% | 50% | 100%
 
       const dbg = {
@@ -225,8 +225,7 @@ export class BenchFixture {
           ? "partially fillable"
           : "fill-or-kill",
         kind: orderSpice.kind == OrderKind.SELL ? "sell" : "buy",
-        sign:
-          signingScheme == SigningScheme.TYPED_DATA ? "typed-data" : "message",
+        sign: signingScheme == SigningScheme.ERC712 ? "typed-data" : "message",
         fee: 100 * (1 - feeDiscount / FULL_FEE_DISCOUNT),
       };
       debug(

--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -225,7 +225,7 @@ export class BenchFixture {
           ? "partially fillable"
           : "fill-or-kill",
         kind: orderSpice.kind == OrderKind.SELL ? "sell" : "buy",
-        sign: signingScheme == SigningScheme.ERC712 ? "typed-data" : "message",
+        sign: signingScheme == SigningScheme.ERC712 ? "erc-712" : "eth_sign",
         fee: 100 * (1 - feeDiscount / FULL_FEE_DISCOUNT),
       };
       debug(

--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -149,18 +149,18 @@ library GPv2Encoding {
     /// ```
     ///
     /// The signature encoding depends on the scheme used to sign. The owner of
-    /// the order can be derived from the signature. See [`recoverEoaOwner`] for
-    /// encoding signatures originating from externally owned accounts (EOA).
+    /// the order can be derived from the signature. See the [`GPv2Signing`]
+    /// library to learn how signatures are encoded for each supported encoding.
     ///
     /// Trade flags are used to tightly encode information on how to decode
     /// an order. Examples that directly affect the structure of an order are
     /// the kind of order (either a sell or a buy order) as well as whether the
     /// order is partially fillable or if it is a "fill-or-kill" order. It also
-    /// encodes whether the order comes from a smart contract or an EOA, in
-    /// order to choose the right signature scheme when decoding. As the most
-    /// likely values are fill-or-kill sell orders by an EOA, the flags are
-    /// chosen such that `0x00` represents this kind of order. The flags byte
-    /// uses the following format:
+    /// encodes the signature scheme used to validate the order. As the most
+    /// likely values are fill-or-kill sell orders by an externally owned
+    /// account, the flags are chosen such that `0x00` represents this kind of
+    /// order. The flags byte uses the following format:
+    ///
     /// ```
     /// bit | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
     /// ----+-----------------------+---+---+

--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -85,8 +85,8 @@ library GPv2Encoding {
     bytes32 internal constant ORDER_TYPE_HASH =
         hex"b2b38b9dcbdeb41f7ad71dea9aed79fb47f7bbc3436576fe994b43d5b16ecdec";
 
-    /// @dev The stride of the fixed-length components in an encoded trade.
-    uint256 private constant FIXED_LENGTH_TRADE_STRIDE = 141;
+    /// @dev The length of the fixed-length components in an encoded trade.
+    uint256 private constant CONSTANT_SIZE_TRADE_LENGTH = 141;
 
     /// @dev The byte length of an order unique identifier.
     uint256 private constant ORDER_UID_LENGTH = 56;
@@ -194,7 +194,7 @@ library GPv2Encoding {
         Trade memory trade
     ) internal pure returns (bytes calldata remainingCalldata) {
         require(
-            encodedTrade.length >= FIXED_LENGTH_TRADE_STRIDE,
+            encodedTrade.length >= CONSTANT_SIZE_TRADE_LENGTH,
             "GPv2: invalid trade"
         );
 
@@ -296,11 +296,11 @@ library GPv2Encoding {
         assembly {
             signature.offset := add(
                 encodedTrade.offset,
-                FIXED_LENGTH_TRADE_STRIDE
+                CONSTANT_SIZE_TRADE_LENGTH
             )
             signature.length := sub(
                 encodedTrade.length,
-                FIXED_LENGTH_TRADE_STRIDE
+                CONSTANT_SIZE_TRADE_LENGTH
             )
         }
 

--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -307,7 +307,7 @@ library GPv2Encoding {
         address owner;
         flags = flags >> 6;
         if (flags == EIP712_SIGNATURE_ID) {
-            (owner, remainingCalldata) = signature.recoverErc712Signer(
+            (owner, remainingCalldata) = signature.recoverEip712Signer(
                 domainSeparator,
                 orderDigest
             );

--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -91,6 +91,11 @@ library GPv2Encoding {
     /// @dev The byte length of an order unique identifier.
     uint256 private constant ORDER_UID_LENGTH = 56;
 
+    /// @dev Flag identifying an order signed with ERC-712.
+    uint256 private constant ERC712_SIGNATURE_ID = 0x0;
+    /// @dev Flag identifying an order signed with eth_sign.
+    uint256 private constant ETHSIGN_SIGNATURE_ID = 0x1;
+
     /// @dev Returns the number of trades encoded in a calldata byte array.
     ///
     /// The number of interactions is encoded in the first two bytes, the
@@ -300,18 +305,17 @@ library GPv2Encoding {
         }
 
         address owner;
-        if (flags & 0x80 == 0) {
-            if (flags & 0x40 == 0) {
-                (owner, remainingCalldata) = signature.recoverErc712Signer(
-                    domainSeparator,
-                    orderDigest
-                );
-            } else {
-                (owner, remainingCalldata) = signature.recoverEthsignSigner(
-                    domainSeparator,
-                    orderDigest
-                );
-            }
+        flags = flags >> 6;
+        if (flags == ERC712_SIGNATURE_ID) {
+            (owner, remainingCalldata) = signature.recoverErc712Signer(
+                domainSeparator,
+                orderDigest
+            );
+        } else if (flags == ETHSIGN_SIGNATURE_ID) {
+            (owner, remainingCalldata) = signature.recoverEthsignSigner(
+                domainSeparator,
+                orderDigest
+            );
         } else {
             revert("unimplemented");
         }

--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -2,10 +2,13 @@
 pragma solidity ^0.7.6;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "./GPv2Signing.sol";
 
 /// @title Gnosis Protocol v2 Encoding Library.
 /// @author Gnosis Developers
 library GPv2Encoding {
+    using GPv2Signing for bytes;
+
     /// @dev A struct representing an order containing all order parameters that
     /// are signed by a user for submitting to GP.
     struct Order {
@@ -84,9 +87,6 @@ library GPv2Encoding {
 
     /// @dev The stride of the fixed-length components in an encoded trade.
     uint256 private constant FIXED_LENGTH_TRADE_STRIDE = 141;
-
-    /// @dev The stride of any signature from an externally owned account.
-    uint256 private constant EOA_SIGNATURE_STRIDE = 65;
 
     /// @dev The byte length of an order unique identifier.
     uint256 private constant ORDER_UID_LENGTH = 56;
@@ -302,16 +302,14 @@ library GPv2Encoding {
         address owner;
         if (flags & 0x80 == 0) {
             if (flags & 0x40 == 0) {
-                (owner, remainingCalldata) = recoverErc712Signer(
+                (owner, remainingCalldata) = signature.recoverErc712Signer(
                     domainSeparator,
-                    orderDigest,
-                    signature
+                    orderDigest
                 );
             } else {
-                (owner, remainingCalldata) = recoverEthsignSigner(
+                (owner, remainingCalldata) = signature.recoverEthsignSigner(
                     domainSeparator,
-                    orderDigest,
-                    signature
+                    orderDigest
                 );
             }
         } else {
@@ -348,198 +346,6 @@ library GPv2Encoding {
             mstore(add(orderUid, 24), validTo)
             mstore(add(orderUid, 20), owner)
             mstore(orderUid, orderDigest)
-        }
-    }
-
-    /// @dev Decodes ECDSA signatures from calldata.
-    ///
-    /// The first bytes of the input tightly pack the signature parameters
-    /// specified in the following struct:
-    ///
-    /// ```
-    /// struct EncodedSignature {
-    ///     bytes32 r;
-    ///     bytes32 s;
-    ///     uint8 v;
-    /// }
-    /// ```
-    ///
-    /// Unused signature data is returned along with the address of the signer.
-    /// If the encoding is not valid, for example because the calldata does not
-    /// suffice, the function reverts.
-    ///
-    /// @param encodedSignature Calldata pointing to tightly packed signature
-    /// bytes.
-    /// @return r r parameter of the ECDSA signature.
-    /// @return s s parameter of the ECDSA signature.
-    /// @return v v parameter of the ECDSA signature.
-    /// @return remainingCalldata Input calldata that has not been used to
-    /// decode the signature.
-    function decodeEcdsaSignature(bytes calldata encodedSignature)
-        internal
-        pure
-        returns (
-            bytes32 r,
-            bytes32 s,
-            uint8 v,
-            bytes calldata remainingCalldata
-        )
-    {
-        require(
-            encodedSignature.length >= EOA_SIGNATURE_STRIDE,
-            "GPv2: invalid encoding"
-        );
-
-        // NOTE: Use assembly to efficiently decode signature data.
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            // r = uint256(encodedSignature[0:32])
-            r := calldataload(encodedSignature.offset)
-            // s = uint256(encodedSignature[32:64])
-            s := calldataload(add(encodedSignature.offset, 32))
-            // v = uint8(encodedSignature[64])
-            v := shr(248, calldataload(add(encodedSignature.offset, 64)))
-        }
-
-        // NOTE: Use assembly to slice the calldata bytes without generating
-        // code for bounds checking.
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            remainingCalldata.offset := add(
-                encodedSignature.offset,
-                EOA_SIGNATURE_STRIDE
-            )
-            remainingCalldata.length := sub(
-                encodedSignature.length,
-                EOA_SIGNATURE_STRIDE
-            )
-        }
-    }
-
-    /// @dev Decodes signature bytes originating from an ERC-712-encoded
-    /// signature.
-    ///
-    /// ERC-712 signs typed data. The specifications are described in the
-    /// related EIP (<https://eips.ethereum.org/EIPS/eip-712>).
-    ///
-    /// ERC-712 signatures are encoded as standard ECDSA signatures as described
-    /// in the corresponding decoding function [`decodeEcdsaSignature`].
-    ///
-    /// Unused signature data is returned along with the address of the signer.
-    /// If the signature is not valid, the function reverts.
-    ///
-    /// @param domainSeparator The domain separator used for signing the order.
-    /// @param orderDigest The EIP-712 signing digest derived from the order
-    /// parameters.
-    /// @param encodedSignature Calldata pointing to tightly packed signature
-    /// bytes.
-    /// @return owner The address of the signer.
-    /// @return remainingCalldata Input calldata that has not been used to
-    /// decode the current order.
-    function recoverErc712Signer(
-        bytes32 domainSeparator,
-        bytes32 orderDigest,
-        bytes calldata encodedSignature
-    ) internal pure returns (address owner, bytes calldata remainingCalldata) {
-        bytes32 r;
-        bytes32 s;
-        uint8 v;
-        (r, s, v, remainingCalldata) = decodeEcdsaSignature(encodedSignature);
-
-        // NOTE: Solidity allocates, but does not free, memory when:
-        // - calling the ABI encoding methods
-        // - calling the `ecrecover` precompile.
-        // However, we can restore the free memory pointer to before we made
-        // allocations to effectively free the memory. This is safe as the
-        // memory used can be discarded, and the memory pointed to by the free
-        // memory pointer **does not have to point to zero-ed out memory**.
-        // <https://docs.soliditylang.org/en/v0.7.6/internals/layout_in_memory.html>
-        uint256 freeMemoryPointer;
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            freeMemoryPointer := mload(0x40)
-        }
-
-        bytes32 signingDigest =
-            keccak256(
-                abi.encodePacked("\x19\x01", domainSeparator, orderDigest)
-            );
-
-        owner = ecrecover(signingDigest, v, r, s);
-        require(owner != address(0), "GPv2: invalid erc712 signature");
-
-        // NOTE: Restore the free memory pointer to free temporary memory.
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            mstore(0x40, freeMemoryPointer)
-        }
-    }
-
-    /// @dev Decodes signature bytes originating from the output of the eth_sign
-    /// RPC call.
-    ///
-    /// The specifications are described in the Ethereum documentation
-    /// (<https://eth.wiki/json-rpc/API#eth_sign>).
-    ///
-    /// eth_sign signatures are encoded as standard ECDSA signatures as
-    /// described in the corresponding decoding function
-    /// [`decodeEcdsaSignature`].
-    ///
-    /// Unused signature data is returned along with the address of the signer.
-    /// If the signature is not valid, the function reverts.
-    ///
-    /// @param domainSeparator The domain separator used for signing the order.
-    /// @param orderDigest The EIP-712 signing digest derived from the order
-    /// parameters.
-    /// @param encodedSignature Calldata pointing to tightly packed signature
-    /// bytes.
-    /// @return owner The address of the signer.
-    /// @return remainingCalldata Input calldata that has not been used to
-    /// decode the current order.
-    function recoverEthsignSigner(
-        bytes32 domainSeparator,
-        bytes32 orderDigest,
-        bytes calldata encodedSignature
-    ) internal pure returns (address owner, bytes calldata remainingCalldata) {
-        bytes32 r;
-        bytes32 s;
-        uint8 v;
-        (r, s, v, remainingCalldata) = decodeEcdsaSignature(encodedSignature);
-
-        // NOTE: Solidity allocates, but does not free, memory when:
-        // - calling the ABI encoding methods
-        // - calling the `ecrecover` precompile.
-        // However, we can restore the free memory pointer to before we made
-        // allocations to effectively free the memory. This is safe as the
-        // memory used can be discarded, and the memory pointed to by the free
-        // memory pointer **does not have to point to zero-ed out memory**.
-        // <https://docs.soliditylang.org/en/v0.7.6/internals/layout_in_memory.html>
-        uint256 freeMemoryPointer;
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            freeMemoryPointer := mload(0x40)
-        }
-
-        // The signed message is encoded as:
-        // `"\x19Ethereum Signed Message:\n" || length || data`, where
-        // the length is a constant (64 bytes) and the data is defined as:
-        // `domainSeparator || orderDigest`.
-        bytes32 signingDigest =
-            keccak256(
-                abi.encodePacked(
-                    "\x19Ethereum Signed Message:\n64",
-                    domainSeparator,
-                    orderDigest
-                )
-            );
-
-        owner = ecrecover(signingDigest, v, r, s);
-        require(owner != address(0), "GPv2: invalid ethsign signature");
-
-        // NOTE: Restore the free memory pointer to free temporary memory.
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            mstore(0x40, freeMemoryPointer)
         }
     }
 

--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -159,18 +159,20 @@ library GPv2Encoding {
     /// ```
     /// bit | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
     /// ----+-----------------------+---+---+
-    ///     | * |      unsused      | * | * |
-    ///       ^                       |   |
-    ///       |                       |   +---- order kind bit, 0 for a sell
-    ///       |                       |         order and 1 for a buy order
-    ///       |                       |
-    ///       |                       +-------- order fill bit, 0 for fill-or-
-    ///       |                                 kill and 1 for a partially
-    ///       |                                 fillable order
-    ///       |
-    ///       +-------------------------------- constract signature bit, 0 for
-    ///                                         smart contract orders and 1 for
-    ///                                         EOA orders.
+    ///     | * | * |    unused     | * | * |
+    ///       |   |                   |   |
+    ///       |   |                   |   +---- order kind bit, 0 for a sell
+    ///       |   |                   |         order and 1 for a buy order
+    ///       |   |                   |
+    ///       |   |                   +-------- order fill bit, 0 for fill-or-
+    ///       |   |                             kill and 1 for a partially
+    ///       |   |                             fillable order
+    ///       |   |
+    ///       +---+---------------------------- signature-type bits:
+    ///                                         00: ERC-712
+    ///                                         01: eth_sign
+    ///                                         10: ERC-1271 (planned)
+    ///                                         11: unused
     /// ```
     ///
     /// @param domainSeparator The domain separator used for signing the order.
@@ -299,11 +301,19 @@ library GPv2Encoding {
 
         address owner;
         if (flags & 0x80 == 0) {
-            (owner, remainingCalldata) = recoverEoaOwner(
-                domainSeparator,
-                orderDigest,
-                signature
-            );
+            if (flags & 0x40 == 0) {
+                (owner, remainingCalldata) = recoverErc712Signer(
+                    domainSeparator,
+                    orderDigest,
+                    signature
+                );
+            } else {
+                (owner, remainingCalldata) = recoverEthsignSigner(
+                    domainSeparator,
+                    orderDigest,
+                    signature
+                );
+            }
         } else {
             revert("unimplemented");
         }
@@ -341,18 +351,10 @@ library GPv2Encoding {
         }
     }
 
-    /// @dev Decodes signature bytes originating from EOAs.
+    /// @dev Decodes ECDSA signatures from calldata.
     ///
-    /// Two schemes can be used to sign orders from an EOA:
-    /// - EIP-712 for signing typed data, this is the default scheme that will
-    ///   be used when recovering the signing address from the signature.
-    /// - Generic message signature, this scheme will be used **only** if the
-    ///   `v` signature parameter's most significant bit is set. This is done as
-    ///   there are only two possible values `v` can have: 27 or 28, which only
-    ///   take up the lower 5 bits of the `uint8`.
-    ///
-    /// The first bytes of the signature calldata are supposed to store the
-    /// signature parameters in the following tightly packed struct:
+    /// The first bytes of the input tightly pack the signature parameters
+    /// specified in the following struct:
     ///
     /// ```
     /// struct EncodedSignature {
@@ -361,6 +363,67 @@ library GPv2Encoding {
     ///     uint8 v;
     /// }
     /// ```
+    ///
+    /// Unused signature data is returned along with the address of the signer.
+    /// If the encoding is not valid, for example because the calldata does not
+    /// suffice, the function reverts.
+    ///
+    /// @param encodedSignature Calldata pointing to tightly packed signature
+    /// bytes.
+    /// @return r r parameter of the ECDSA signature.
+    /// @return s s parameter of the ECDSA signature.
+    /// @return v v parameter of the ECDSA signature.
+    /// @return remainingCalldata Input calldata that has not been used to
+    /// decode the signature.
+    function decodeEcdsaSignature(bytes calldata encodedSignature)
+        internal
+        pure
+        returns (
+            bytes32 r,
+            bytes32 s,
+            uint8 v,
+            bytes calldata remainingCalldata
+        )
+    {
+        require(
+            encodedSignature.length >= EOA_SIGNATURE_STRIDE,
+            "GPv2: invalid encoding"
+        );
+
+        // NOTE: Use assembly to efficiently decode signature data.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // r = uint256(encodedSignature[0:32])
+            r := calldataload(encodedSignature.offset)
+            // s = uint256(encodedSignature[32:64])
+            s := calldataload(add(encodedSignature.offset, 32))
+            // v = uint8(encodedSignature[64])
+            v := shr(248, calldataload(add(encodedSignature.offset, 64)))
+        }
+
+        // NOTE: Use assembly to slice the calldata bytes without generating
+        // code for bounds checking.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            remainingCalldata.offset := add(
+                encodedSignature.offset,
+                EOA_SIGNATURE_STRIDE
+            )
+            remainingCalldata.length := sub(
+                encodedSignature.length,
+                EOA_SIGNATURE_STRIDE
+            )
+        }
+    }
+
+    /// @dev Decodes signature bytes originating from an ERC-712-encoded
+    /// signature.
+    ///
+    /// ERC-712 signs typed data. The specifications are described in the
+    /// related EIP (<https://eips.ethereum.org/EIPS/eip-712>).
+    ///
+    /// ERC-712 signatures are encoded as standard ECDSA signatures as described
+    /// in the corresponding decoding function [`decodeEcdsaSignature`].
     ///
     /// Unused signature data is returned along with the address of the signer.
     /// If the signature is not valid, the function reverts.
@@ -373,29 +436,15 @@ library GPv2Encoding {
     /// @return owner The address of the signer.
     /// @return remainingCalldata Input calldata that has not been used to
     /// decode the current order.
-    function recoverEoaOwner(
+    function recoverErc712Signer(
         bytes32 domainSeparator,
         bytes32 orderDigest,
         bytes calldata encodedSignature
     ) internal pure returns (address owner, bytes calldata remainingCalldata) {
-        require(
-            encodedSignature.length >= EOA_SIGNATURE_STRIDE,
-            "GPv2: invalid encoding"
-        );
-
         bytes32 r;
         bytes32 s;
         uint8 v;
-        // NOTE: Use assembly to efficiently decode signature data.
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            // r = uint256(encodedTrade[0:32])
-            r := calldataload(encodedSignature.offset)
-            // s = uint256(encodedTrade[32:64])
-            s := calldataload(add(encodedSignature.offset, 32))
-            // v = uint8(encodedTrade[64])
-            v := shr(248, calldataload(add(encodedSignature.offset, 64)))
-        }
+        (r, s, v, remainingCalldata) = decodeEcdsaSignature(encodedSignature);
 
         // NOTE: Solidity allocates, but does not free, memory when:
         // - calling the ABI encoding methods
@@ -411,50 +460,86 @@ library GPv2Encoding {
             freeMemoryPointer := mload(0x40)
         }
 
-        bytes32 signingDigest;
-        if (v & 0x80 == 0) {
-            // NOTE: The most significant bit **is not set**, so the order
-            // is signed using the EIP-712 sheme, the signing hash is of:
-            // `"\x19\x01" || domainSeparator || orderDigest`.
-            signingDigest = keccak256(
+        bytes32 signingDigest =
+            keccak256(
                 abi.encodePacked("\x19\x01", domainSeparator, orderDigest)
             );
-        } else {
-            // NOTE: The most significant bit **is set**, so the order is
-            // signed using generic message scheme, the signing hash is of:
-            // `"\x19Ethereum Signed Message:\n" || length || data` where
-            // the length is a constant 64 bytes and the data is defined as:
-            // `domainSeparator || orderDigest`.
-            signingDigest = keccak256(
-                abi.encodePacked(
-                    "\x19Ethereum Signed Message:\n64",
-                    domainSeparator,
-                    orderDigest
-                )
-            );
-        }
 
-        owner = ecrecover(signingDigest, v & 0x1f, r, s);
-        require(owner != address(0), "GPv2: invalid eoa signature");
+        owner = ecrecover(signingDigest, v, r, s);
+        require(owner != address(0), "GPv2: invalid erc712 signature");
 
         // NOTE: Restore the free memory pointer to free temporary memory.
         // solhint-disable-next-line no-inline-assembly
         assembly {
             mstore(0x40, freeMemoryPointer)
         }
+    }
 
-        // NOTE: Use assembly to slice the calldata bytes without generating
-        // code for bounds checking.
+    /// @dev Decodes signature bytes originating from the output of the eth_sign
+    /// RPC call.
+    ///
+    /// The specifications are described in the Ethereum documentation
+    /// (<https://eth.wiki/json-rpc/API#eth_sign>).
+    ///
+    /// eth_sign signatures are encoded as standard ECDSA signatures as
+    /// described in the corresponding decoding function
+    /// [`decodeEcdsaSignature`].
+    ///
+    /// Unused signature data is returned along with the address of the signer.
+    /// If the signature is not valid, the function reverts.
+    ///
+    /// @param domainSeparator The domain separator used for signing the order.
+    /// @param orderDigest The EIP-712 signing digest derived from the order
+    /// parameters.
+    /// @param encodedSignature Calldata pointing to tightly packed signature
+    /// bytes.
+    /// @return owner The address of the signer.
+    /// @return remainingCalldata Input calldata that has not been used to
+    /// decode the current order.
+    function recoverEthsignSigner(
+        bytes32 domainSeparator,
+        bytes32 orderDigest,
+        bytes calldata encodedSignature
+    ) internal pure returns (address owner, bytes calldata remainingCalldata) {
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        (r, s, v, remainingCalldata) = decodeEcdsaSignature(encodedSignature);
+
+        // NOTE: Solidity allocates, but does not free, memory when:
+        // - calling the ABI encoding methods
+        // - calling the `ecrecover` precompile.
+        // However, we can restore the free memory pointer to before we made
+        // allocations to effectively free the memory. This is safe as the
+        // memory used can be discarded, and the memory pointed to by the free
+        // memory pointer **does not have to point to zero-ed out memory**.
+        // <https://docs.soliditylang.org/en/v0.7.6/internals/layout_in_memory.html>
+        uint256 freeMemoryPointer;
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            remainingCalldata.offset := add(
-                encodedSignature.offset,
-                EOA_SIGNATURE_STRIDE
-            )
-            remainingCalldata.length := sub(
-                encodedSignature.length,
-                EOA_SIGNATURE_STRIDE
-            )
+            freeMemoryPointer := mload(0x40)
+        }
+
+        // The signed message is encoded as:
+        // `"\x19Ethereum Signed Message:\n" || length || data`, where
+        // the length is a constant (64 bytes) and the data is defined as:
+        // `domainSeparator || orderDigest`.
+        bytes32 signingDigest =
+            keccak256(
+                abi.encodePacked(
+                    "\x19Ethereum Signed Message:\n64",
+                    domainSeparator,
+                    orderDigest
+                )
+            );
+
+        owner = ecrecover(signingDigest, v, r, s);
+        require(owner != address(0), "GPv2: invalid ethsign signature");
+
+        // NOTE: Restore the free memory pointer to free temporary memory.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            mstore(0x40, freeMemoryPointer)
         }
     }
 

--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -91,8 +91,8 @@ library GPv2Encoding {
     /// @dev The byte length of an order unique identifier.
     uint256 private constant ORDER_UID_LENGTH = 56;
 
-    /// @dev Flag identifying an order signed with ERC-712.
-    uint256 private constant ERC712_SIGNATURE_ID = 0x0;
+    /// @dev Flag identifying an order signed with EIP-712.
+    uint256 private constant EIP712_SIGNATURE_ID = 0x0;
     /// @dev Flag identifying an order signed with eth_sign.
     uint256 private constant ETHSIGN_SIGNATURE_ID = 0x1;
 
@@ -174,9 +174,9 @@ library GPv2Encoding {
     ///       |   |                             fillable order
     ///       |   |
     ///       +---+---------------------------- signature-type bits:
-    ///                                         00: ERC-712
+    ///                                         00: EIP-712
     ///                                         01: eth_sign
-    ///                                         10: ERC-1271 (planned)
+    ///                                         10: EIP-1271 (planned)
     ///                                         11: unused
     /// ```
     ///
@@ -306,7 +306,7 @@ library GPv2Encoding {
 
         address owner;
         flags = flags >> 6;
-        if (flags == ERC712_SIGNATURE_ID) {
+        if (flags == EIP712_SIGNATURE_ID) {
             (owner, remainingCalldata) = signature.recoverErc712Signer(
                 domainSeparator,
                 orderDigest

--- a/src/contracts/libraries/GPv2Signing.sol
+++ b/src/contracts/libraries/GPv2Signing.sol
@@ -72,13 +72,13 @@ library GPv2Signing {
         }
     }
 
-    /// @dev Decodes signature bytes originating from an ERC-712-encoded
+    /// @dev Decodes signature bytes originating from an EIP-712-encoded
     /// signature.
     ///
-    /// ERC-712 signs typed data. The specifications are described in the
+    /// EIP-712 signs typed data. The specifications are described in the
     /// related EIP (<https://eips.ethereum.org/EIPS/eip-712>).
     ///
-    /// ERC-712 signatures are encoded as standard ECDSA signatures as described
+    /// EIP-712 signatures are encoded as standard ECDSA signatures as described
     /// in the corresponding decoding function [`decodeEcdsaSignature`].
     ///
     /// Unused signature data is returned along with the address of the signer.
@@ -122,7 +122,7 @@ library GPv2Signing {
             );
 
         owner = ecrecover(signingDigest, v, r, s);
-        require(owner != address(0), "GPv2: invalid erc712 signature");
+        require(owner != address(0), "GPv2: invalid eip712 signature");
 
         // NOTE: Restore the free memory pointer to free temporary memory.
         // solhint-disable-next-line no-inline-assembly

--- a/src/contracts/libraries/GPv2Signing.sol
+++ b/src/contracts/libraries/GPv2Signing.sol
@@ -92,7 +92,7 @@ library GPv2Signing {
     /// @return owner The address of the signer.
     /// @return remainingCalldata Input calldata that has not been used to
     /// decode the current order.
-    function recoverErc712Signer(
+    function recoverEip712Signer(
         bytes calldata encodedSignature,
         bytes32 domainSeparator,
         bytes32 orderDigest

--- a/src/contracts/libraries/GPv2Signing.sol
+++ b/src/contracts/libraries/GPv2Signing.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.7.6;
 /// @title Gnosis Protocol v2 Signing Library.
 /// @author Gnosis Developers
 library GPv2Signing {
-    /// @dev The stride of any signature from an externally owned account.
-    uint256 private constant EOA_SIGNATURE_STRIDE = 65;
+    /// @dev The length of any signature from an externally owned account.
+    uint256 private constant ECDSA_SIGNATURE_LENGTH = 65;
 
     /// @dev Decodes ECDSA signatures from calldata.
     ///
@@ -42,7 +42,7 @@ library GPv2Signing {
         )
     {
         require(
-            encodedSignature.length >= EOA_SIGNATURE_STRIDE,
+            encodedSignature.length >= ECDSA_SIGNATURE_LENGTH,
             "GPv2: invalid encoding"
         );
 
@@ -63,11 +63,11 @@ library GPv2Signing {
         assembly {
             remainingCalldata.offset := add(
                 encodedSignature.offset,
-                EOA_SIGNATURE_STRIDE
+                ECDSA_SIGNATURE_LENGTH
             )
             remainingCalldata.length := sub(
                 encodedSignature.length,
-                EOA_SIGNATURE_STRIDE
+                ECDSA_SIGNATURE_LENGTH
             )
         }
     }

--- a/src/contracts/libraries/GPv2Signing.sol
+++ b/src/contracts/libraries/GPv2Signing.sol
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.7.6;
+
+/// @title Gnosis Protocol v2 Signing Library.
+/// @author Gnosis Developers
+library GPv2Signing {
+    /// @dev The stride of any signature from an externally owned account.
+    uint256 private constant EOA_SIGNATURE_STRIDE = 65;
+
+    /// @dev Decodes ECDSA signatures from calldata.
+    ///
+    /// The first bytes of the input tightly pack the signature parameters
+    /// specified in the following struct:
+    ///
+    /// ```
+    /// struct EncodedSignature {
+    ///     bytes32 r;
+    ///     bytes32 s;
+    ///     uint8 v;
+    /// }
+    /// ```
+    ///
+    /// Unused signature data is returned along with the address of the signer.
+    /// If the encoding is not valid, for example because the calldata does not
+    /// suffice, the function reverts.
+    ///
+    /// @param encodedSignature Calldata pointing to tightly packed signature
+    /// bytes.
+    /// @return r r parameter of the ECDSA signature.
+    /// @return s s parameter of the ECDSA signature.
+    /// @return v v parameter of the ECDSA signature.
+    /// @return remainingCalldata Input calldata that has not been used to
+    /// decode the signature.
+    function decodeEcdsaSignature(bytes calldata encodedSignature)
+        internal
+        pure
+        returns (
+            bytes32 r,
+            bytes32 s,
+            uint8 v,
+            bytes calldata remainingCalldata
+        )
+    {
+        require(
+            encodedSignature.length >= EOA_SIGNATURE_STRIDE,
+            "GPv2: invalid encoding"
+        );
+
+        // NOTE: Use assembly to efficiently decode signature data.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // r = uint256(encodedSignature[0:32])
+            r := calldataload(encodedSignature.offset)
+            // s = uint256(encodedSignature[32:64])
+            s := calldataload(add(encodedSignature.offset, 32))
+            // v = uint8(encodedSignature[64])
+            v := shr(248, calldataload(add(encodedSignature.offset, 64)))
+        }
+
+        // NOTE: Use assembly to slice the calldata bytes without generating
+        // code for bounds checking.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            remainingCalldata.offset := add(
+                encodedSignature.offset,
+                EOA_SIGNATURE_STRIDE
+            )
+            remainingCalldata.length := sub(
+                encodedSignature.length,
+                EOA_SIGNATURE_STRIDE
+            )
+        }
+    }
+
+    /// @dev Decodes signature bytes originating from an ERC-712-encoded
+    /// signature.
+    ///
+    /// ERC-712 signs typed data. The specifications are described in the
+    /// related EIP (<https://eips.ethereum.org/EIPS/eip-712>).
+    ///
+    /// ERC-712 signatures are encoded as standard ECDSA signatures as described
+    /// in the corresponding decoding function [`decodeEcdsaSignature`].
+    ///
+    /// Unused signature data is returned along with the address of the signer.
+    /// If the signature is not valid, the function reverts.
+    ///
+    /// @param encodedSignature Calldata pointing to tightly packed signature
+    /// bytes.
+    /// @param domainSeparator The domain separator used for signing the order.
+    /// @param orderDigest The EIP-712 signing digest derived from the order
+    /// parameters.
+    /// @return owner The address of the signer.
+    /// @return remainingCalldata Input calldata that has not been used to
+    /// decode the current order.
+    function recoverErc712Signer(
+        bytes calldata encodedSignature,
+        bytes32 domainSeparator,
+        bytes32 orderDigest
+    ) internal pure returns (address owner, bytes calldata remainingCalldata) {
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        (r, s, v, remainingCalldata) = decodeEcdsaSignature(encodedSignature);
+
+        // NOTE: Solidity allocates, but does not free, memory when:
+        // - calling the ABI encoding methods
+        // - calling the `ecrecover` precompile.
+        // However, we can restore the free memory pointer to before we made
+        // allocations to effectively free the memory. This is safe as the
+        // memory used can be discarded, and the memory pointed to by the free
+        // memory pointer **does not have to point to zero-ed out memory**.
+        // <https://docs.soliditylang.org/en/v0.7.6/internals/layout_in_memory.html>
+        uint256 freeMemoryPointer;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            freeMemoryPointer := mload(0x40)
+        }
+
+        bytes32 signingDigest =
+            keccak256(
+                abi.encodePacked("\x19\x01", domainSeparator, orderDigest)
+            );
+
+        owner = ecrecover(signingDigest, v, r, s);
+        require(owner != address(0), "GPv2: invalid erc712 signature");
+
+        // NOTE: Restore the free memory pointer to free temporary memory.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            mstore(0x40, freeMemoryPointer)
+        }
+    }
+
+    /// @dev Decodes signature bytes originating from the output of the eth_sign
+    /// RPC call.
+    ///
+    /// The specifications are described in the Ethereum documentation
+    /// (<https://eth.wiki/json-rpc/API#eth_sign>).
+    ///
+    /// eth_sign signatures are encoded as standard ECDSA signatures as
+    /// described in the corresponding decoding function
+    /// [`decodeEcdsaSignature`].
+    ///
+    /// Unused signature data is returned along with the address of the signer.
+    /// If the signature is not valid, the function reverts.
+    ///
+    /// @param encodedSignature Calldata pointing to tightly packed signature
+    /// bytes.
+    /// @param domainSeparator The domain separator used for signing the order.
+    /// @param orderDigest The EIP-712 signing digest derived from the order
+    /// parameters.
+    /// @return owner The address of the signer.
+    /// @return remainingCalldata Input calldata that has not been used to
+    /// decode the current order.
+    function recoverEthsignSigner(
+        bytes calldata encodedSignature,
+        bytes32 domainSeparator,
+        bytes32 orderDigest
+    ) internal pure returns (address owner, bytes calldata remainingCalldata) {
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        (r, s, v, remainingCalldata) = decodeEcdsaSignature(encodedSignature);
+
+        // NOTE: Solidity allocates, but does not free, memory when:
+        // - calling the ABI encoding methods
+        // - calling the `ecrecover` precompile.
+        // However, we can restore the free memory pointer to before we made
+        // allocations to effectively free the memory. This is safe as the
+        // memory used can be discarded, and the memory pointed to by the free
+        // memory pointer **does not have to point to zero-ed out memory**.
+        // <https://docs.soliditylang.org/en/v0.7.6/internals/layout_in_memory.html>
+        uint256 freeMemoryPointer;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            freeMemoryPointer := mload(0x40)
+        }
+
+        // The signed message is encoded as:
+        // `"\x19Ethereum Signed Message:\n" || length || data`, where
+        // the length is a constant (64 bytes) and the data is defined as:
+        // `domainSeparator || orderDigest`.
+        bytes32 signingDigest =
+            keccak256(
+                abi.encodePacked(
+                    "\x19Ethereum Signed Message:\n64",
+                    domainSeparator,
+                    orderDigest
+                )
+            );
+
+        owner = ecrecover(signingDigest, v, r, s);
+        require(owner != address(0), "GPv2: invalid ethsign signature");
+
+        // NOTE: Restore the free memory pointer to free temporary memory.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            mstore(0x40, freeMemoryPointer)
+        }
+    }
+}

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -24,4 +24,5 @@ export * from "./interaction";
 export * from "./settlement";
 export * from "./reader";
 export * from "./deploy";
+export * from "./sign";
 export * from "./types/ethers";

--- a/src/ts/order.ts
+++ b/src/ts/order.ts
@@ -1,6 +1,4 @@
-import { ethers, BigNumberish, Signer } from "ethers";
-
-import { TypedDataDomain, isTypedDataSigner } from "./types/ethers";
+import { ethers, BigNumberish } from "ethers";
 
 /**
  * Gnosis Protocol v2 order data.
@@ -134,96 +132,6 @@ export function hashOrder(order: Order): string {
     "Order",
     { Order: ORDER_TYPE_FIELDS },
     { ...order, validTo: timestamp(order.validTo) },
-  );
-}
-
-/**
- * The signing scheme used to sign the order.
- */
-export const enum SigningScheme {
-  /**
-   * The EIP-712 typed data signing scheme. This is the preferred scheme as it
-   * provides more infomation to wallets performing the signature on the data
-   * being signed.
-   *
-   * <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-domainseparator>
-   */
-  TYPED_DATA,
-  /**
-   * The generic message signing scheme.
-   */
-  MESSAGE,
-}
-
-function ecdsaSignOrder(
-  domain: TypedDataDomain,
-  order: Order,
-  owner: Signer,
-  scheme: SigningScheme,
-): Promise<string> {
-  switch (scheme) {
-    case SigningScheme.TYPED_DATA:
-      if (!isTypedDataSigner(owner)) {
-        throw new Error("signer does not support signing typed data");
-      }
-      return owner._signTypedData(
-        domain,
-        { Order: ORDER_TYPE_FIELDS },
-        { ...order, validTo: timestamp(order.validTo) },
-      );
-
-    case SigningScheme.MESSAGE:
-      return owner.signMessage(
-        ethers.utils.arrayify(
-          ethers.utils.hexConcat([
-            ethers.utils._TypedDataEncoder.hashDomain(domain),
-            hashOrder(order),
-          ]),
-        ),
-      );
-  }
-}
-
-function encodeSigningScheme(v: number, scheme: SigningScheme): number {
-  const ORDER_MESSAGE_SCHEME_FLAG = 0x80;
-  switch (scheme) {
-    case SigningScheme.TYPED_DATA:
-      return v;
-    case SigningScheme.MESSAGE:
-      return v | ORDER_MESSAGE_SCHEME_FLAG;
-  }
-}
-
-/**
- * Returns the signature for the specified order with the signing scheme encoded
- * into the signature bytes.
- * @param domain The domain to sign the order for. This is used by the smart
- * contract to ensure orders can't be replayed across different applications,
- * but also different deployments (as the contract chain ID and address are
- * mixed into to the domain value).
- * @param order The order to sign.
- * @param owner The owner for the order used to sign.
- * @param scheme The signing scheme to use. See {@link SigningScheme} for more
- * details.
- * @return Hex-encoded signature with encoded signing scheme for the order.
- */
-export async function signOrder(
-  domain: TypedDataDomain,
-  order: Order,
-  owner: Signer,
-  scheme: SigningScheme,
-): Promise<string> {
-  const ecdsaSignature = ethers.utils.splitSignature(
-    await ecdsaSignOrder(domain, order, owner, scheme),
-  );
-
-  return ethers.utils.solidityPack(
-    ["bytes32", "bytes32", "uint8"],
-    [
-      ecdsaSignature.r,
-      ecdsaSignature.s,
-      encodeSigningScheme(ecdsaSignature.v, scheme),
-    ],
   );
 }
 

--- a/src/ts/settlement.ts
+++ b/src/ts/settlement.ts
@@ -6,10 +6,14 @@ import {
   Order,
   OrderFlags,
   OrderKind,
-  SigningScheme,
-  signOrder,
   timestamp,
 } from "./order";
+import {
+  assertValidSignatureLength,
+  Signature,
+  SigningScheme,
+  signOrder,
+} from "./sign";
 import { TypedDataDomain } from "./types/ethers";
 
 /**
@@ -46,9 +50,9 @@ export enum InteractionStage {
  */
 export interface TradeFlags extends OrderFlags {
   /**
-   * True if and only if the owner of the order is a smart contract.
+   * The signing scheme used to encode the signature.
    */
-  contractOrder: boolean;
+  signingScheme: SigningScheme;
 }
 
 /**
@@ -73,13 +77,6 @@ export interface TradeExecution {
    * discount, meaning no fees will be taken.
    */
   feeDiscount: number;
-  /**
-   * Whether the trade was created by a smart contract.
-   *
-   * A smart contract order uses different signing schemes compared to
-   * externally owned accounts.
-   */
-  contractOrder: boolean;
 }
 
 /**
@@ -114,7 +111,18 @@ export const FULL_FEE_DISCOUNT = 10000;
  */
 export const MAX_TRADES_IN_SETTLEMENT = 2 ** 16 - 1;
 
-function encodeTradeFlags(flags: TradeFlags): number {
+function encodeSigningScheme(scheme: SigningScheme): number {
+  switch (scheme) {
+    case SigningScheme.ERC712:
+      return 0b00000000;
+    case SigningScheme.ETHSIGN:
+      return 0b01000000;
+    default:
+      throw new Error("Unsupported signing scheme");
+  }
+}
+
+function encodeOrderFlags(flags: OrderFlags): number {
   let kind;
   switch (flags.kind) {
     case OrderKind.SELL:
@@ -127,9 +135,12 @@ function encodeTradeFlags(flags: TradeFlags): number {
       throw new Error(`invalid error kind '${kind}'`);
   }
   const partiallyFillable = flags.partiallyFillable ? 0x02 : 0x00;
-  const contractOrder = flags.contractOrder ? 0x80 : 0x00;
 
-  return contractOrder | kind | partiallyFillable;
+  return kind | partiallyFillable;
+}
+
+function encodeTradeFlags(flags: TradeFlags): number {
+  return encodeOrderFlags(flags) | encodeSigningScheme(flags.signingScheme);
 }
 
 /**
@@ -249,7 +260,7 @@ export class SettlementEncoder {
    */
   public encodeTrade(
     order: Order,
-    signature: BytesLike,
+    signature: Signature,
     tradeExecution?: Partial<TradeExecution>,
   ): void {
     if (this._tradeCount >= MAX_TRADES_IN_SETTLEMENT) {
@@ -257,23 +268,17 @@ export class SettlementEncoder {
     }
     this._tradeCount++;
 
-    const { executedAmount, feeDiscount, contractOrder } = tradeExecution || {};
+    const { executedAmount, feeDiscount } = tradeExecution || {};
     if (order.partiallyFillable && executedAmount === undefined) {
       throw new Error("missing executed amount for partially fillable trade");
     }
 
+    assertValidSignatureLength(signature);
+
     const tradeFlags = {
       ...order,
-      contractOrder: contractOrder ?? false,
+      signingScheme: signature.scheme,
     };
-
-    const EOA_SIGNATURE_LENGTH = 65;
-    if (
-      !tradeFlags.contractOrder &&
-      ethers.utils.hexDataLength(signature) !== EOA_SIGNATURE_LENGTH
-    ) {
-      throw new Error("invalid eoa signature bytes");
-    }
 
     const encodedTrade = ethers.utils.solidityPack(
       [
@@ -300,7 +305,7 @@ export class SettlementEncoder {
         encodeTradeFlags(tradeFlags),
         executedAmount || 0,
         feeDiscount || 0,
-        signature,
+        signature.digest,
       ],
     );
 

--- a/src/ts/settlement.ts
+++ b/src/ts/settlement.ts
@@ -113,7 +113,7 @@ export const MAX_TRADES_IN_SETTLEMENT = 2 ** 16 - 1;
 
 function encodeSigningScheme(scheme: SigningScheme): number {
   switch (scheme) {
-    case SigningScheme.ERC712:
+    case SigningScheme.EIP712:
       return 0b00000000;
     case SigningScheme.ETHSIGN:
       return 0b01000000;

--- a/src/ts/settlement.ts
+++ b/src/ts/settlement.ts
@@ -305,7 +305,7 @@ export class SettlementEncoder {
         encodeTradeFlags(tradeFlags),
         executedAmount || 0,
         feeDiscount || 0,
-        signature.digest,
+        signature.data,
       ],
     );
 

--- a/src/ts/sign.ts
+++ b/src/ts/sign.ts
@@ -110,10 +110,10 @@ export async function signOrder(
  * @param sig The signature to check.
  */
 export function assertValidSignatureLength(sig: Signature): void {
-  const EOA_SIGNATURE_LENGTH = 65;
+  const ECDSA_SIGNATURE_LENGTH = 65;
   if (
     [SigningScheme.EIP712, SigningScheme.ETHSIGN].includes(sig.scheme) &&
-    ethers.utils.hexDataLength(sig.data) !== EOA_SIGNATURE_LENGTH
+    ethers.utils.hexDataLength(sig.data) !== ECDSA_SIGNATURE_LENGTH
   ) {
     throw new Error("invalid signature bytes");
   }

--- a/src/ts/sign.ts
+++ b/src/ts/sign.ts
@@ -1,0 +1,120 @@
+import { BytesLike, ethers, Signer } from "ethers";
+
+import { hashOrder, Order, ORDER_TYPE_FIELDS, timestamp } from "./order";
+import { isTypedDataSigner, TypedDataDomain } from "./types/ethers";
+
+/**
+ * The signing scheme used to sign the order.
+ */
+export const enum SigningScheme {
+  /**
+   * The EIP-712 typed data signing scheme. This is the preferred scheme as it
+   * provides more infomation to wallets performing the signature on the data
+   * being signed.
+   *
+   * <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-domainseparator>
+   */
+  ERC712,
+  /**
+   * Message signed using eth_sign RPC call.
+   */
+  ETHSIGN,
+}
+
+/**
+ * The signature of an order.
+ * It includes the information needed to determine which signing scheme is used.
+ */
+export interface Signature {
+  /**
+   * The signing scheme used in the signature.
+   */
+  scheme: SigningScheme;
+  /**
+   * The signature bytes as prescribed by the selected signing scheme.
+   */
+  digest: BytesLike;
+}
+
+function ecdsaSignOrder(
+  domain: TypedDataDomain,
+  order: Order,
+  owner: Signer,
+  scheme: SigningScheme,
+): Promise<string> {
+  switch (scheme) {
+    case SigningScheme.ERC712:
+      if (!isTypedDataSigner(owner)) {
+        throw new Error("signer does not support signing typed data");
+      }
+      return owner._signTypedData(
+        domain,
+        { Order: ORDER_TYPE_FIELDS },
+        { ...order, validTo: timestamp(order.validTo) },
+      );
+
+    case SigningScheme.ETHSIGN:
+      return owner.signMessage(
+        ethers.utils.arrayify(
+          ethers.utils.hexConcat([
+            ethers.utils._TypedDataEncoder.hashDomain(domain),
+            hashOrder(order),
+          ]),
+        ),
+      );
+  }
+}
+
+/**
+ * Returns the signature for the specified order with the signing scheme encoded
+ * into the signature bytes.
+ * @param domain The domain to sign the order for. This is used by the smart
+ * contract to ensure orders can't be replayed across different applications,
+ * but also different deployments (as the contract chain ID and address are
+ * mixed into to the domain value).
+ * @param order The order to sign.
+ * @param owner The owner for the order used to sign.
+ * @param scheme The signing scheme to use. See {@link SigningScheme} for more
+ * details.
+ * @return Encoded signature including signing scheme for the order.
+ */
+export async function signOrder(
+  domain: TypedDataDomain,
+  order: Order,
+  owner: Signer,
+  scheme: SigningScheme,
+): Promise<Signature> {
+  if (![SigningScheme.ERC712, SigningScheme.ETHSIGN].includes(scheme)) {
+    throw new Error(
+      "Cannot create a signature with the specified signing scheme",
+    );
+  }
+  const rawEcdsaSignature = await ecdsaSignOrder(domain, order, owner, scheme);
+  const ecdsaSignature = ethers.utils.splitSignature(rawEcdsaSignature);
+
+  const digest = ethers.utils.solidityPack(
+    ["bytes32", "bytes32", "uint8"],
+    [ecdsaSignature.r, ecdsaSignature.s, ecdsaSignature.v],
+  );
+
+  return {
+    digest,
+    scheme,
+  };
+}
+
+/**
+ * Throws an error if the signature length is incompatible with the signing
+ * scheme. It does not otherwise check the signature for validity.
+ *
+ * @param sig The signature to check.
+ */
+export function assertValidSignatureLength(sig: Signature): void {
+  const EOA_SIGNATURE_LENGTH = 65;
+  if (
+    [SigningScheme.ERC712, SigningScheme.ETHSIGN].includes(sig.scheme) &&
+    ethers.utils.hexDataLength(sig.digest) !== EOA_SIGNATURE_LENGTH
+  ) {
+    throw new Error("invalid signature bytes");
+  }
+}

--- a/src/ts/sign.ts
+++ b/src/ts/sign.ts
@@ -14,7 +14,7 @@ export const enum SigningScheme {
    *
    * <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-domainseparator>
    */
-  ERC712,
+  EIP712,
   /**
    * Message signed using eth_sign RPC call.
    */
@@ -43,7 +43,7 @@ function ecdsaSignOrder(
   scheme: SigningScheme,
 ): Promise<string> {
   switch (scheme) {
-    case SigningScheme.ERC712:
+    case SigningScheme.EIP712:
       if (!isTypedDataSigner(owner)) {
         throw new Error("signer does not support signing typed data");
       }
@@ -84,7 +84,7 @@ export async function signOrder(
   owner: Signer,
   scheme: SigningScheme,
 ): Promise<Signature> {
-  if (![SigningScheme.ERC712, SigningScheme.ETHSIGN].includes(scheme)) {
+  if (![SigningScheme.EIP712, SigningScheme.ETHSIGN].includes(scheme)) {
     throw new Error(
       "Cannot create a signature with the specified signing scheme",
     );
@@ -112,7 +112,7 @@ export async function signOrder(
 export function assertValidSignatureLength(sig: Signature): void {
   const EOA_SIGNATURE_LENGTH = 65;
   if (
-    [SigningScheme.ERC712, SigningScheme.ETHSIGN].includes(sig.scheme) &&
+    [SigningScheme.EIP712, SigningScheme.ETHSIGN].includes(sig.scheme) &&
     ethers.utils.hexDataLength(sig.data) !== EOA_SIGNATURE_LENGTH
   ) {
     throw new Error("invalid signature bytes");

--- a/src/ts/sign.ts
+++ b/src/ts/sign.ts
@@ -33,7 +33,7 @@ export interface Signature {
   /**
    * The signature bytes as prescribed by the selected signing scheme.
    */
-  digest: BytesLike;
+  data: BytesLike;
 }
 
 function ecdsaSignOrder(
@@ -92,13 +92,13 @@ export async function signOrder(
   const rawEcdsaSignature = await ecdsaSignOrder(domain, order, owner, scheme);
   const ecdsaSignature = ethers.utils.splitSignature(rawEcdsaSignature);
 
-  const digest = ethers.utils.solidityPack(
+  const data = ethers.utils.solidityPack(
     ["bytes32", "bytes32", "uint8"],
     [ecdsaSignature.r, ecdsaSignature.s, ecdsaSignature.v],
   );
 
   return {
-    digest,
+    data,
     scheme,
   };
 }
@@ -113,7 +113,7 @@ export function assertValidSignatureLength(sig: Signature): void {
   const EOA_SIGNATURE_LENGTH = 65;
   if (
     [SigningScheme.ERC712, SigningScheme.ETHSIGN].includes(sig.scheme) &&
-    ethers.utils.hexDataLength(sig.digest) !== EOA_SIGNATURE_LENGTH
+    ethers.utils.hexDataLength(sig.data) !== EOA_SIGNATURE_LENGTH
   ) {
     throw new Error("invalid signature bytes");
   }

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -77,7 +77,7 @@ describe("GPv2Encoding", () => {
         await encoder.signEncodeTrade(
           { ...sampleOrder, appData: i },
           traders[0],
-          SigningScheme.ERC712,
+          SigningScheme.EIP712,
         );
       }
 
@@ -95,7 +95,7 @@ describe("GPv2Encoding", () => {
         await encoder.signEncodeTrade(
           { ...sampleOrder, appData: i },
           traders[0],
-          SigningScheme.ERC712,
+          SigningScheme.EIP712,
         );
       }
 
@@ -140,7 +140,7 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         order,
         traders[0],
-        SigningScheme.ERC712,
+        SigningScheme.EIP712,
         tradeExecution,
       );
 
@@ -165,7 +165,7 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.ERC712,
+        SigningScheme.EIP712,
       );
 
       const { trades } = await encoding.decodeTradesTest(
@@ -186,7 +186,7 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.ERC712,
+        SigningScheme.EIP712,
       );
 
       const { trades } = await encoding.decodeTradesTest(
@@ -205,7 +205,7 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.ERC712,
+        SigningScheme.EIP712,
       );
 
       const { trades } = await encoding.decodeTradesTest(
@@ -225,7 +225,7 @@ describe("GPv2Encoding", () => {
 
     it("should recover signing address for all supported schemes", async () => {
       const encoder = new SettlementEncoder(testDomain);
-      for (const scheme of [SigningScheme.ERC712, SigningScheme.ETHSIGN]) {
+      for (const scheme of [SigningScheme.EIP712, SigningScheme.ETHSIGN]) {
         await encoder.signEncodeTrade(sampleOrder, traders[0], scheme);
       }
 
@@ -241,12 +241,12 @@ describe("GPv2Encoding", () => {
       }
     });
 
-    it("should revert for invalid erc712 order signatures", async () => {
+    it("should revert for invalid eip-712 order signatures", async () => {
       const encoder = new SettlementEncoder(testDomain);
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.ERC712,
+        SigningScheme.EIP712,
       );
 
       // NOTE: `v` must be either `27` or `28`, so just set it to something else
@@ -256,7 +256,7 @@ describe("GPv2Encoding", () => {
 
       await expect(
         encoding.decodeTradesTest(encoder.tokens, encodedTradeBytes),
-      ).to.be.revertedWith("invalid erc712 signature");
+      ).to.be.revertedWith("invalid eip712 signature");
     });
 
     it("should revert for invalid ethsign order signatures", async () => {
@@ -284,7 +284,7 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.ERC712,
+        SigningScheme.EIP712,
       );
       await encoder.signEncodeTrade(
         {
@@ -292,7 +292,7 @@ describe("GPv2Encoding", () => {
           sellToken: lastToken,
         },
         traders[1],
-        SigningScheme.ERC712,
+        SigningScheme.EIP712,
       );
 
       // NOTE: Remove the last sell token (0x0303...0303).
@@ -309,7 +309,7 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.ERC712,
+        SigningScheme.EIP712,
       );
       await encoder.signEncodeTrade(
         {
@@ -317,7 +317,7 @@ describe("GPv2Encoding", () => {
           buyToken: lastToken,
         },
         traders[1],
-        SigningScheme.ERC712,
+        SigningScheme.EIP712,
       );
 
       // NOTE: Remove the last buy token (0x0303...0303).
@@ -332,7 +332,7 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.ERC712,
+        SigningScheme.EIP712,
       );
 
       const encodedTrades = ethers.utils.arrayify(encoder.encodedTrades);
@@ -370,7 +370,7 @@ describe("GPv2Encoding", () => {
         await encoder.signEncodeTrade(
           order,
           traders[0],
-          SigningScheme.ERC712,
+          SigningScheme.EIP712,
           tradeExecution,
         );
 
@@ -402,7 +402,7 @@ describe("GPv2Encoding", () => {
         await encoder.signEncodeTrade(
           order,
           traders[0],
-          SigningScheme.ERC712,
+          SigningScheme.EIP712,
           tradeExecution,
         );
 
@@ -424,7 +424,7 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.ERC712,
+        SigningScheme.EIP712,
       );
       await encoder.signEncodeTrade(
         sampleOrder,

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -77,7 +77,7 @@ describe("GPv2Encoding", () => {
         await encoder.signEncodeTrade(
           { ...sampleOrder, appData: i },
           traders[0],
-          SigningScheme.TYPED_DATA,
+          SigningScheme.ERC712,
         );
       }
 
@@ -95,7 +95,7 @@ describe("GPv2Encoding", () => {
         await encoder.signEncodeTrade(
           { ...sampleOrder, appData: i },
           traders[0],
-          SigningScheme.TYPED_DATA,
+          SigningScheme.ERC712,
         );
       }
 
@@ -140,7 +140,7 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         order,
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.ERC712,
         tradeExecution,
       );
 
@@ -165,7 +165,7 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.ERC712,
       );
 
       const { trades } = await encoding.decodeTradesTest(
@@ -186,7 +186,7 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.ERC712,
       );
 
       const { trades } = await encoding.decodeTradesTest(
@@ -205,7 +205,7 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.ERC712,
       );
 
       const { trades } = await encoding.decodeTradesTest(
@@ -225,7 +225,7 @@ describe("GPv2Encoding", () => {
 
     it("should recover signing address for all supported schemes", async () => {
       const encoder = new SettlementEncoder(testDomain);
-      for (const scheme of [SigningScheme.TYPED_DATA, SigningScheme.MESSAGE]) {
+      for (const scheme of [SigningScheme.ERC712, SigningScheme.ETHSIGN]) {
         await encoder.signEncodeTrade(sampleOrder, traders[0], scheme);
       }
 
@@ -241,12 +241,12 @@ describe("GPv2Encoding", () => {
       }
     });
 
-    it("should revert for invalid order signatures", async () => {
+    it("should revert for invalid erc712 order signatures", async () => {
       const encoder = new SettlementEncoder(testDomain);
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.ERC712,
       );
 
       // NOTE: `v` must be either `27` or `28`, so just set it to something else
@@ -256,7 +256,25 @@ describe("GPv2Encoding", () => {
 
       await expect(
         encoding.decodeTradesTest(encoder.tokens, encodedTradeBytes),
-      ).to.be.revertedWith("invalid eoa signature");
+      ).to.be.revertedWith("invalid erc712 signature");
+    });
+
+    it("should revert for invalid ethsign order signatures", async () => {
+      const encoder = new SettlementEncoder(testDomain);
+      await encoder.signEncodeTrade(
+        sampleOrder,
+        traders[0],
+        SigningScheme.ETHSIGN,
+      );
+
+      // NOTE: `v` must be either `27` or `28`, so just set it to something else
+      // to generate an invalid signature.
+      const encodedTradeBytes = ethers.utils.arrayify(encoder.encodedTrades);
+      encodedTradeBytes[207] = 42;
+
+      await expect(
+        encoding.decodeTradesTest(encoder.tokens, encodedTradeBytes),
+      ).to.be.revertedWith("invalid ethsign signature");
     });
 
     it("should revert for invalid sell token indices", async () => {
@@ -266,7 +284,7 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.ERC712,
       );
       await encoder.signEncodeTrade(
         {
@@ -274,7 +292,7 @@ describe("GPv2Encoding", () => {
           sellToken: lastToken,
         },
         traders[1],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.ERC712,
       );
 
       // NOTE: Remove the last sell token (0x0303...0303).
@@ -291,7 +309,7 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.ERC712,
       );
       await encoder.signEncodeTrade(
         {
@@ -299,7 +317,7 @@ describe("GPv2Encoding", () => {
           buyToken: lastToken,
         },
         traders[1],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.ERC712,
       );
 
       // NOTE: Remove the last buy token (0x0303...0303).
@@ -309,17 +327,24 @@ describe("GPv2Encoding", () => {
         .be.reverted;
     });
 
-    it("should revert when encoding a smart contract order", async () => {
+    it("should revert when encoding an invalid signing scheme", async () => {
       const encoder = new SettlementEncoder(testDomain);
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.TYPED_DATA,
-        { contractOrder: true },
+        SigningScheme.ERC712,
       );
 
+      const encodedTrades = ethers.utils.arrayify(encoder.encodedTrades);
+
+      encodedTrades[2 + 106] |= 0b10000000;
       await expect(
-        encoding.decodeTradesTest(encoder.tokens, encoder.encodedTrades),
+        encoding.decodeTradesTest(encoder.tokens, encodedTrades),
+      ).to.be.revertedWith("unimplemented");
+
+      encodedTrades[2 + 106] |= 0b01000000;
+      await expect(
+        encoding.decodeTradesTest(encoder.tokens, encodedTrades),
       ).to.be.revertedWith("unimplemented");
     });
 
@@ -345,7 +370,7 @@ describe("GPv2Encoding", () => {
         await encoder.signEncodeTrade(
           order,
           traders[0],
-          SigningScheme.TYPED_DATA,
+          SigningScheme.ERC712,
           tradeExecution,
         );
 
@@ -377,7 +402,7 @@ describe("GPv2Encoding", () => {
         await encoder.signEncodeTrade(
           order,
           traders[0],
-          SigningScheme.TYPED_DATA,
+          SigningScheme.ERC712,
           tradeExecution,
         );
 
@@ -399,12 +424,12 @@ describe("GPv2Encoding", () => {
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.ERC712,
       );
       await encoder.signEncodeTrade(
         sampleOrder,
         traders[1],
-        SigningScheme.MESSAGE,
+        SigningScheme.ETHSIGN,
       );
 
       const { mem } = await encoding.decodeTradesTest(

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -358,7 +358,7 @@ describe("GPv2Settlement", () => {
             partiallyFillable: true,
           },
           traders[0],
-          SigningScheme.ERC712,
+          SigningScheme.EIP712,
           { executedAmount: ethers.utils.parseEther("0.7734") },
         );
       }
@@ -385,7 +385,7 @@ describe("GPv2Settlement", () => {
               partiallyFillable: true,
             },
             traders[0],
-            SigningScheme.ERC712,
+            SigningScheme.EIP712,
             { executedAmount: ethers.utils.parseEther("0.7734") },
           );
         }
@@ -415,7 +415,7 @@ describe("GPv2Settlement", () => {
               partiallyFillable: true,
             },
             traders[0],
-            SigningScheme.ERC712,
+            SigningScheme.EIP712,
             { executedAmount: ethers.utils.parseEther("0.7734") },
           );
         }
@@ -446,7 +446,7 @@ describe("GPv2Settlement", () => {
           partiallyFillable: false,
         },
         traders[0],
-        SigningScheme.ERC712,
+        SigningScheme.EIP712,
       );
 
       await expect(
@@ -474,7 +474,7 @@ describe("GPv2Settlement", () => {
           partiallyFillable: false,
         },
         traders[0],
-        SigningScheme.ERC712,
+        SigningScheme.EIP712,
       );
 
       expect(toNumberLossy(sellAmount.mul(sellPrice))).not.to.be.gte(
@@ -501,7 +501,7 @@ describe("GPv2Settlement", () => {
           partiallyFillable: false,
         },
         traders[0],
-        SigningScheme.ERC712,
+        SigningScheme.EIP712,
       );
 
       const { sellAmount, buyAmount } = partialOrder;
@@ -536,7 +536,7 @@ describe("GPv2Settlement", () => {
             partiallyFillable,
           },
           traders[0],
-          SigningScheme.ERC712,
+          SigningScheme.EIP712,
           { executedAmount },
         );
 
@@ -694,7 +694,7 @@ describe("GPv2Settlement", () => {
             partiallyFillable,
           },
           traders[0],
-          SigningScheme.ERC712,
+          SigningScheme.EIP712,
           tradeExecution,
         );
 
@@ -792,7 +792,7 @@ describe("GPv2Settlement", () => {
         await encoder.signEncodeTrade(
           order,
           traders[0],
-          SigningScheme.ERC712,
+          SigningScheme.EIP712,
           tradeExecution,
         );
 
@@ -862,12 +862,12 @@ describe("GPv2Settlement", () => {
       await encoder.signEncodeTrade(
         { ...order, appData: 0 },
         traders[0],
-        SigningScheme.ERC712,
+        SigningScheme.EIP712,
       );
       await encoder.signEncodeTrade(
         { ...order, appData: 1 },
         traders[0],
-        SigningScheme.ERC712,
+        SigningScheme.EIP712,
         { executedAmount: ethers.utils.parseEther("1.0") },
       );
 
@@ -891,7 +891,7 @@ describe("GPv2Settlement", () => {
           partiallyFillable: false,
         },
         traders[0],
-        SigningScheme.ERC712,
+        SigningScheme.EIP712,
         { feeDiscount: FULL_FEE_DISCOUNT + 1 },
       );
 
@@ -912,7 +912,7 @@ describe("GPv2Settlement", () => {
       };
 
       const encoder = new SettlementEncoder(testDomain);
-      await encoder.signEncodeTrade(order, traders[0], SigningScheme.ERC712);
+      await encoder.signEncodeTrade(order, traders[0], SigningScheme.EIP712);
 
       const executedSellAmount = order.sellAmount.add(order.feeAmount);
       const executedBuyAmount = order.sellAmount

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -358,7 +358,7 @@ describe("GPv2Settlement", () => {
             partiallyFillable: true,
           },
           traders[0],
-          SigningScheme.TYPED_DATA,
+          SigningScheme.ERC712,
           { executedAmount: ethers.utils.parseEther("0.7734") },
         );
       }
@@ -385,7 +385,7 @@ describe("GPv2Settlement", () => {
               partiallyFillable: true,
             },
             traders[0],
-            SigningScheme.TYPED_DATA,
+            SigningScheme.ERC712,
             { executedAmount: ethers.utils.parseEther("0.7734") },
           );
         }
@@ -415,7 +415,7 @@ describe("GPv2Settlement", () => {
               partiallyFillable: true,
             },
             traders[0],
-            SigningScheme.TYPED_DATA,
+            SigningScheme.ERC712,
             { executedAmount: ethers.utils.parseEther("0.7734") },
           );
         }
@@ -446,7 +446,7 @@ describe("GPv2Settlement", () => {
           partiallyFillable: false,
         },
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.ERC712,
       );
 
       await expect(
@@ -474,7 +474,7 @@ describe("GPv2Settlement", () => {
           partiallyFillable: false,
         },
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.ERC712,
       );
 
       expect(toNumberLossy(sellAmount.mul(sellPrice))).not.to.be.gte(
@@ -501,7 +501,7 @@ describe("GPv2Settlement", () => {
           partiallyFillable: false,
         },
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.ERC712,
       );
 
       const { sellAmount, buyAmount } = partialOrder;
@@ -536,7 +536,7 @@ describe("GPv2Settlement", () => {
             partiallyFillable,
           },
           traders[0],
-          SigningScheme.TYPED_DATA,
+          SigningScheme.ERC712,
           { executedAmount },
         );
 
@@ -694,7 +694,7 @@ describe("GPv2Settlement", () => {
             partiallyFillable,
           },
           traders[0],
-          SigningScheme.TYPED_DATA,
+          SigningScheme.ERC712,
           tradeExecution,
         );
 
@@ -792,7 +792,7 @@ describe("GPv2Settlement", () => {
         await encoder.signEncodeTrade(
           order,
           traders[0],
-          SigningScheme.TYPED_DATA,
+          SigningScheme.ERC712,
           tradeExecution,
         );
 
@@ -862,12 +862,12 @@ describe("GPv2Settlement", () => {
       await encoder.signEncodeTrade(
         { ...order, appData: 0 },
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.ERC712,
       );
       await encoder.signEncodeTrade(
         { ...order, appData: 1 },
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.ERC712,
         { executedAmount: ethers.utils.parseEther("1.0") },
       );
 
@@ -891,7 +891,7 @@ describe("GPv2Settlement", () => {
           partiallyFillable: false,
         },
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.ERC712,
         { feeDiscount: FULL_FEE_DISCOUNT + 1 },
       );
 
@@ -912,11 +912,7 @@ describe("GPv2Settlement", () => {
       };
 
       const encoder = new SettlementEncoder(testDomain);
-      await encoder.signEncodeTrade(
-        order,
-        traders[0],
-        SigningScheme.TYPED_DATA,
-      );
+      await encoder.signEncodeTrade(order, traders[0], SigningScheme.ERC712);
 
       const executedSellAmount = order.sellAmount.add(order.feeAmount);
       const executedBuyAmount = order.sellAmount

--- a/test/e2e/burnFees.test.ts
+++ b/test/e2e/burnFees.test.ts
@@ -70,7 +70,7 @@ describe("E2E: Burn fees", () => {
         appData: 1,
       },
       traders[0],
-      SigningScheme.ERC712,
+      SigningScheme.EIP712,
     );
 
     await dai.mint(traders[1].address, ONE_USD.mul(1000));
@@ -91,7 +91,7 @@ describe("E2E: Burn fees", () => {
         appData: 2,
       },
       traders[1],
-      SigningScheme.ERC712,
+      SigningScheme.EIP712,
     );
 
     encoder.encodeInteraction(

--- a/test/e2e/burnFees.test.ts
+++ b/test/e2e/burnFees.test.ts
@@ -70,7 +70,7 @@ describe("E2E: Burn fees", () => {
         appData: 1,
       },
       traders[0],
-      SigningScheme.TYPED_DATA,
+      SigningScheme.ERC712,
     );
 
     await dai.mint(traders[1].address, ONE_USD.mul(1000));
@@ -91,7 +91,7 @@ describe("E2E: Burn fees", () => {
         appData: 2,
       },
       traders[1],
-      SigningScheme.TYPED_DATA,
+      SigningScheme.ERC712,
     );
 
     encoder.encodeInteraction(

--- a/test/e2e/buyEth.test.ts
+++ b/test/e2e/buyEth.test.ts
@@ -77,7 +77,7 @@ describe("E2E: Buy Ether", () => {
         appData: 1,
       },
       traders[0],
-      SigningScheme.TYPED_DATA,
+      SigningScheme.ERC712,
     );
 
     await usdt.mint(traders[1].address, ethers.utils.parseUnits("1201.2", 6));
@@ -97,7 +97,7 @@ describe("E2E: Buy Ether", () => {
         appData: 2,
       },
       traders[1],
-      SigningScheme.TYPED_DATA,
+      SigningScheme.ERC712,
     );
 
     encoder.encodeInteraction({

--- a/test/e2e/buyEth.test.ts
+++ b/test/e2e/buyEth.test.ts
@@ -77,7 +77,7 @@ describe("E2E: Buy Ether", () => {
         appData: 1,
       },
       traders[0],
-      SigningScheme.ERC712,
+      SigningScheme.EIP712,
     );
 
     await usdt.mint(traders[1].address, ethers.utils.parseUnits("1201.2", 6));
@@ -97,7 +97,7 @@ describe("E2E: Buy Ether", () => {
         appData: 2,
       },
       traders[1],
-      SigningScheme.ERC712,
+      SigningScheme.EIP712,
     );
 
     encoder.encodeInteraction({

--- a/test/e2e/ercPermit.test.ts
+++ b/test/e2e/ercPermit.test.ts
@@ -66,7 +66,7 @@ describe("E2E: EIP-2612 Permit", () => {
         appData: 1,
       },
       traders[0],
-      SigningScheme.TYPED_DATA,
+      SigningScheme.ERC712,
     );
 
     await eurs[1].mint(traders[1].address, ONE_EUR);
@@ -140,7 +140,7 @@ describe("E2E: EIP-2612 Permit", () => {
         appData: 2,
       },
       traders[1],
-      SigningScheme.TYPED_DATA,
+      SigningScheme.ERC712,
     );
 
     await settlement.connect(solver).settle(

--- a/test/e2e/ercPermit.test.ts
+++ b/test/e2e/ercPermit.test.ts
@@ -66,7 +66,7 @@ describe("E2E: EIP-2612 Permit", () => {
         appData: 1,
       },
       traders[0],
-      SigningScheme.ERC712,
+      SigningScheme.EIP712,
     );
 
     await eurs[1].mint(traders[1].address, ONE_EUR);
@@ -140,7 +140,7 @@ describe("E2E: EIP-2612 Permit", () => {
         appData: 2,
       },
       traders[1],
-      SigningScheme.ERC712,
+      SigningScheme.EIP712,
     );
 
     await settlement.connect(solver).settle(

--- a/test/e2e/orderRefunds.test.ts
+++ b/test/e2e/orderRefunds.test.ts
@@ -105,13 +105,9 @@ describe("E2E: Expired Order Gas Refunds", () => {
       await encoder.signEncodeTrade(
         sellOrder,
         traders[0],
-        SigningScheme.TYPED_DATA,
+        SigningScheme.ERC712,
       );
-      await encoder.signEncodeTrade(
-        buyOrder,
-        traders[1],
-        SigningScheme.TYPED_DATA,
-      );
+      await encoder.signEncodeTrade(buyOrder, traders[1], SigningScheme.ERC712);
 
       const orderUids = [
         computeOrderUid({

--- a/test/e2e/orderRefunds.test.ts
+++ b/test/e2e/orderRefunds.test.ts
@@ -105,9 +105,9 @@ describe("E2E: Expired Order Gas Refunds", () => {
       await encoder.signEncodeTrade(
         sellOrder,
         traders[0],
-        SigningScheme.ERC712,
+        SigningScheme.EIP712,
       );
-      await encoder.signEncodeTrade(buyOrder, traders[1], SigningScheme.ERC712);
+      await encoder.signEncodeTrade(buyOrder, traders[1], SigningScheme.EIP712);
 
       const orderUids = [
         computeOrderUid({

--- a/test/e2e/uniswapTrade.test.ts
+++ b/test/e2e/uniswapTrade.test.ts
@@ -120,7 +120,7 @@ describe("E2E: Should Trade Surplus With Uniswap", () => {
         appData: 1,
       },
       traders[0],
-      SigningScheme.ERC712,
+      SigningScheme.EIP712,
       // NOTE: Only take 50% of fees as the user traded half of their order
       // against Uniswap.
       { feeDiscount: 5000 },
@@ -143,7 +143,7 @@ describe("E2E: Should Trade Surplus With Uniswap", () => {
         appData: 2,
       },
       traders[1],
-      SigningScheme.ERC712,
+      SigningScheme.EIP712,
     );
 
     encoder.encodeInteraction({

--- a/test/e2e/uniswapTrade.test.ts
+++ b/test/e2e/uniswapTrade.test.ts
@@ -120,7 +120,7 @@ describe("E2E: Should Trade Surplus With Uniswap", () => {
         appData: 1,
       },
       traders[0],
-      SigningScheme.TYPED_DATA,
+      SigningScheme.ERC712,
       // NOTE: Only take 50% of fees as the user traded half of their order
       // against Uniswap.
       { feeDiscount: 5000 },
@@ -143,7 +143,7 @@ describe("E2E: Should Trade Surplus With Uniswap", () => {
         appData: 2,
       },
       traders[1],
-      SigningScheme.TYPED_DATA,
+      SigningScheme.ERC712,
     );
 
     encoder.encodeInteraction({

--- a/test/e2e/wineOilMarket.test.ts
+++ b/test/e2e/wineOilMarket.test.ts
@@ -81,7 +81,7 @@ describe("E2E: RetrETH Red Wine and Olive Oil Market", () => {
         .connect(trader)
         .approve(allowanceManager.address, ethers.constants.MaxUint256);
 
-      await encoder.signEncodeTrade(order, trader, SigningScheme.TYPED_DATA, {
+      await encoder.signEncodeTrade(order, trader, SigningScheme.ERC712, {
         executedAmount,
       });
     };

--- a/test/e2e/wineOilMarket.test.ts
+++ b/test/e2e/wineOilMarket.test.ts
@@ -81,7 +81,7 @@ describe("E2E: RetrETH Red Wine and Olive Oil Market", () => {
         .connect(trader)
         .approve(allowanceManager.address, ethers.constants.MaxUint256);
 
-      await encoder.signEncodeTrade(order, trader, SigningScheme.ERC712, {
+      await encoder.signEncodeTrade(order, trader, SigningScheme.EIP712, {
         executedAmount,
       });
     };


### PR DESCRIPTION
Implements the suggestion by Nick [from here](https://github.com/gnosis/gp-v2-contracts/pull/365#discussion_r561644802).

I like the result in terms of readability, but it looks like we pay ~100 gas/trade more after these changes. Which implementation do we choose?

### Test Plan

New & old tests.

<details><summary>bench (at commit 0e640496ff49e25e8e09b18cc00238ea9d3fcc21)</summary>

```
$ yarn bench:compare contract-signing-flag
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
            2 |           10 |            0 |            0 |       746739  (change: 102 / trade)
            3 |           10 |            0 |            0 |       747295  (change: 100 / trade)
            4 |           10 |            0 |            0 |       756203  (change: 94 / trade)
            5 |           10 |            0 |            0 |       760935  (change: 101 / trade)
            6 |           10 |            0 |            0 |       757267  (change: 100 / trade)
            7 |           10 |            0 |            0 |       766163  (change: 102 / trade)
            8 |           10 |            0 |            0 |       770883  (change: 108 / trade)
            8 |           20 |            0 |            0 |      1460439  (change: 100 / trade)
            8 |           30 |            0 |            0 |      2103539  (change: 97 / trade)
            8 |           40 |            0 |            0 |      2751293  (change: 102 / trade)
            8 |           50 |            0 |            0 |      3398672  (change: 101 / trade)
            8 |           60 |            0 |            0 |      4042479  (change: 99 / trade)
            8 |           70 |            0 |            0 |      4690658  (change: 99 / trade)
            8 |           80 |            0 |            0 |      5338863  (change: 100 / trade)
            2 |           10 |            1 |            0 |       817245  (change: 94 / trade)
            2 |           10 |            2 |            0 |       863051  (change: 103 / trade)
            2 |           10 |            3 |            0 |       908774  (change: 101 / trade)
            2 |           10 |            4 |            0 |       954382  (change: 101 / trade)
            2 |           10 |            5 |            0 |      1000190  (change: 103 / trade)
            2 |           10 |            6 |            0 |      1045880  (change: 101 / trade)
            2 |           10 |            7 |            0 |      1091641  (change: 97 / trade)
            2 |           10 |            8 |            0 |      1137288  (change: 102 / trade)
            2 |           50 |            0 |           10 |      3124370  (change: 103 / trade)
            2 |           50 |            0 |           15 |      3080994  (change: 99 / trade)
            2 |           50 |            0 |           20 |      3037574  (change: 101 / trade)
            2 |           50 |            0 |           25 |      2994198  (change: 100 / trade)
            2 |           50 |            0 |           30 |      2950870  (change: 101 / trade)
            2 |           50 |            0 |           35 |      2907554  (change: 100 / trade)
            2 |           50 |            0 |           40 |      2864050  (change: 99 / trade)
            2 |           50 |            0 |           45 |      2820698  (change: 99 / trade)
            2 |           50 |            0 |           50 |      2777394  (change: 101 / trade)
            2 |            2 |            0 |            0 |       185201  (change: 87 / trade)
            2 |            1 |            1 |            0 |       185554  (change: 81 / trade)
           10 |          100 |           10 |           20 |      7142367  (change: 101 / trade)
```
</details>