### PR TITLE
Bench comparisons defaults to merge base

### DIFF
--- a/bench/compare.sh
+++ b/bench/compare.sh
@@ -16,7 +16,7 @@ trades() {
 
 tested_path="$(git branch --show-current)"
 tested_path="${tested_path:-HEAD}"
-comparison_path="${1:-origin/main}"
+comparison_path="${1:-"$(git merge-base origin/main HEAD)"}"
 if ! git rev-parse --verify "$comparison_path" >/dev/null; then
     echo "Invalid git reference $comparison_path" >&2
     exit 1


### PR DESCRIPTION
Changes default branch for comparing benches from `origin/master` to the merge base from the benched commit.
This PR assumes that every commit would eventually originate from `origin/main`, in case this becomes an issue we can change it.

### Test Plan

I added a commit containing these changes on top of the branch `compare-benches-test-plan` from #349.
Run:
```
bash>$ yarn bench:compare
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
            2 |           10 |            0 |            0 |       741033  (change: -2060 / trade)
            3 |           10 |            0 |            0 |       741613  (change: -2058 / trade)
            4 |           10 |            0 |            0 |       750521  (change: -2060 / trade)
            5 |           10 |            0 |            0 |       755289  (change: -2054 / trade)
...
```

Observe that the output is the same as the output in #349 despite `main` having changed quite a bit.