### PR TITLE
Send funds to receiver

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -242,6 +242,7 @@ contract GPv2Settlement is ReentrancyGuard {
         require(order.validTo >= block.timestamp, "GPv2: order expired");
 
         executedTrade.owner = trade.owner;
+        executedTrade.receiver = order.receiver;
         executedTrade.sellToken = order.sellToken;
         executedTrade.buyToken = order.buyToken;
 

--- a/src/contracts/libraries/GPv2TradeExecution.sol
+++ b/src/contracts/libraries/GPv2TradeExecution.sol
@@ -48,7 +48,7 @@ library GPv2TradeExecution {
     /// receiver from the caller's address.
     function transferBuyAmountToOwner(Data memory trade) internal {
         address receiver = trade.receiver;
-        if (trade.receiver == RECEIVER_SAME_AS_OWNER) {
+        if (receiver == RECEIVER_SAME_AS_OWNER) {
             receiver = trade.owner;
         }
 

--- a/src/contracts/libraries/GPv2TradeExecution.sol
+++ b/src/contracts/libraries/GPv2TradeExecution.sol
@@ -12,6 +12,7 @@ library GPv2TradeExecution {
     /// @dev Executed trade data.
     struct Data {
         address owner;
+        address receiver;
         IERC20 sellToken;
         IERC20 buyToken;
         uint256 sellAmount;
@@ -21,6 +22,10 @@ library GPv2TradeExecution {
     /// @dev Ether marker address used to indicate an order is buying Ether.
     address internal constant BUY_ETH_ADDRESS =
         0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    /// @dev Marker address used to indicate that the receiver of the trade
+    /// proceeds should the owner of the order.
+    address internal constant RECEIVER_SAME_AS_OWNER = address(0);
 
     /// @dev Executes the trade's sell amount, transferring it from the trade's
     /// owner to the specified recipient.
@@ -40,12 +45,17 @@ library GPv2TradeExecution {
     }
 
     /// @dev Executes the trade's buy amount, transferring it to the trade's
-    /// owner from the caller's address.
+    /// receiver from the caller's address.
     function transferBuyAmountToOwner(Data memory trade) internal {
+        address receiver = trade.receiver;
+        if (trade.receiver == RECEIVER_SAME_AS_OWNER) {
+            receiver = trade.owner;
+        }
+
         if (address(trade.buyToken) == BUY_ETH_ADDRESS) {
-            payable(trade.owner).transfer(trade.buyAmount);
+            payable(receiver).transfer(trade.buyAmount);
         } else {
-            trade.buyToken.safeTransfer(trade.owner, trade.buyAmount);
+            trade.buyToken.safeTransfer(receiver, trade.buyAmount);
         }
     }
 }

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -1221,7 +1221,7 @@ describe("GPv2Settlement", () => {
         .withArgs(traders[0].address, amount)
         .returns(true);
       await tokens[1].mock.transfer
-        .withArgs(traders[1].address, amount)
+        .withArgs(traders[2].address, amount)
         .returns(true);
 
       await expect(
@@ -1229,11 +1229,13 @@ describe("GPv2Settlement", () => {
           encodeOutTransfers([
             {
               owner: traders[0].address,
+              receiver: RECEIVER_SAME_AS_OWNER,
               buyToken: tokens[0].address,
               buyAmount: amount,
             },
             {
               owner: traders[1].address,
+              receiver: traders[2].address,
               buyToken: tokens[1].address,
               buyAmount: amount,
             },

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -1229,7 +1229,7 @@ describe("GPv2Settlement", () => {
           encodeOutTransfers([
             {
               owner: traders[0].address,
-              receiver: RECEIVER_SAME_AS_OWNER,
+              receiver: ethers.constants.AddressZero,
               buyToken: tokens[0].address,
               buyAmount: amount,
             },

--- a/test/GPv2TradeExecution.test.ts
+++ b/test/GPv2TradeExecution.test.ts
@@ -3,10 +3,12 @@ import { expect } from "chai";
 import { Contract } from "ethers";
 import { ethers, waffle } from "hardhat";
 
-import { BUY_ETH_ADDRESS, RECEIVER_SAME_AS_OWNER } from "../src/ts";
+import { BUY_ETH_ADDRESS } from "../src/ts";
 
 import { NON_STANDARD_ERC20 } from "./ERC20";
 import { encodeExecutedTrade } from "./encoding";
+
+const RECEIVER_SAME_AS_OWNER = ethers.constants.AddressZero;
 
 describe("GPv2TradeExecution", () => {
   const [deployer, recipient, ...traders] = waffle.provider.getWallets();

--- a/test/GPv2TradeExecution.test.ts
+++ b/test/GPv2TradeExecution.test.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 import { Contract } from "ethers";
 import { ethers, waffle } from "hardhat";
 
-import { BUY_ETH_ADDRESS } from "../src/ts";
+import { BUY_ETH_ADDRESS, RECEIVER_SAME_AS_OWNER } from "../src/ts";
 
 import { NON_STANDARD_ERC20 } from "./ERC20";
 import { encodeExecutedTrade } from "./encoding";
@@ -24,6 +24,7 @@ describe("GPv2TradeExecution", () => {
 
   describe("transferSellAmountToRecipient", () => {
     const withoutBuy = {
+      receiver: ethers.constants.AddressZero,
       buyToken: ethers.constants.AddressZero,
       buyAmount: ethers.constants.Zero,
     };
@@ -152,7 +153,30 @@ describe("GPv2TradeExecution", () => {
       sellAmount: ethers.constants.Zero,
     };
 
-    it("should transfer buy amount to sender", async () => {
+    it("should transfer buy amount to receiver", async () => {
+      const [owner, receiver] = traders;
+
+      const amount = ethers.utils.parseEther("13.37");
+
+      const buyToken = await waffle.deployMockContract(deployer, IERC20.abi);
+      await buyToken.mock.transfer
+        .withArgs(receiver.address, amount)
+        .returns(true);
+
+      await expect(
+        tradeExecution.transferBuyAmountToOwnerTest(
+          encodeExecutedTrade({
+            owner: owner.address,
+            receiver: receiver.address,
+            buyToken: buyToken.address,
+            buyAmount: amount,
+            ...withoutSell,
+          }),
+        ),
+      ).to.not.be.reverted;
+    });
+
+    it("should transfer buy amount to owner when receiver is not set", async () => {
       const amount = ethers.utils.parseEther("13.37");
 
       const buyToken = await waffle.deployMockContract(deployer, IERC20.abi);
@@ -164,6 +188,7 @@ describe("GPv2TradeExecution", () => {
         tradeExecution.transferBuyAmountToOwnerTest(
           encodeExecutedTrade({
             owner: traders[0].address,
+            receiver: RECEIVER_SAME_AS_OWNER,
             buyToken: buyToken.address,
             buyAmount: amount,
             ...withoutSell,
@@ -184,6 +209,7 @@ describe("GPv2TradeExecution", () => {
         tradeExecution.transferBuyAmountToOwnerTest(
           encodeExecutedTrade({
             owner: traders[0].address,
+            receiver: RECEIVER_SAME_AS_OWNER,
             buyToken: buyToken.address,
             buyAmount: amount,
             ...withoutSell,
@@ -192,11 +218,12 @@ describe("GPv2TradeExecution", () => {
       ).to.be.revertedWith("test error");
     });
 
-    it("should revert when transfering from a token with no contract at its address", async () => {
+    it("should not revert when transfering from a token with no contract at its address", async () => {
       await expect(
         tradeExecution.transferBuyAmountToOwnerTest(
           encodeExecutedTrade({
             owner: traders[0].address,
+            receiver: RECEIVER_SAME_AS_OWNER,
             buyToken: traders[1].address,
             buyAmount: ethers.utils.parseEther("1.0"),
             ...withoutSell,
@@ -205,7 +232,33 @@ describe("GPv2TradeExecution", () => {
       ).not.to.be.reverted;
     });
 
-    it("should transfer Ether if the marker address is used", async () => {
+    it("should transfer Ether to receiver if the marker address is used", async () => {
+      const [owner, receiver] = traders;
+
+      const amount = ethers.utils.parseEther("1.0");
+      const initialBalance = await receiver.getBalance();
+
+      await deployer.sendTransaction({
+        to: tradeExecution.address,
+        value: amount,
+      });
+
+      await tradeExecution.transferBuyAmountToOwnerTest(
+        encodeExecutedTrade({
+          owner: owner.address,
+          receiver: receiver.address,
+          buyToken: BUY_ETH_ADDRESS,
+          buyAmount: amount,
+          ...withoutSell,
+        }),
+      );
+
+      expect(await receiver.getBalance()).to.deep.equal(
+        initialBalance.add(amount),
+      );
+    });
+
+    it("should transfer Ether if to owner the marker address is used when receiver is not set", async () => {
       const amount = ethers.utils.parseEther("1.0");
       const initialBalance = await traders[0].getBalance();
 
@@ -217,6 +270,7 @@ describe("GPv2TradeExecution", () => {
       await tradeExecution.transferBuyAmountToOwnerTest(
         encodeExecutedTrade({
           owner: traders[0].address,
+          receiver: RECEIVER_SAME_AS_OWNER,
           buyToken: BUY_ETH_ADDRESS,
           buyAmount: amount,
           ...withoutSell,
@@ -244,6 +298,7 @@ describe("GPv2TradeExecution", () => {
           tradeExecution.transferBuyAmountToOwnerTest(
             encodeExecutedTrade({
               owner: traders[0].address,
+              receiver: RECEIVER_SAME_AS_OWNER,
               buyToken: buyToken.address,
               buyAmount: amount,
               ...withoutSell,
@@ -264,6 +319,7 @@ describe("GPv2TradeExecution", () => {
           tradeExecution.transferBuyAmountToOwnerTest(
             encodeExecutedTrade({
               owner: traders[0].address,
+              receiver: RECEIVER_SAME_AS_OWNER,
               buyToken: buyToken.address,
               buyAmount: amount,
               ...withoutSell,

--- a/test/encoding.ts
+++ b/test/encoding.ts
@@ -1,7 +1,7 @@
 import type { BigNumber } from "ethers";
 import { ethers } from "hardhat";
 
-import { Order, OrderKind, RECEIVER_SAME_AS_OWNER } from "../src/ts";
+import { Order, OrderKind } from "../src/ts";
 
 export type AbiOrder = [
   string,
@@ -119,7 +119,7 @@ export function encodeInTransfers(transfers: InTransfer[]): AbiExecutedTrade[] {
   return transfers.map((transfer) =>
     encodeExecutedTrade({
       ...transfer,
-      receiver: RECEIVER_SAME_AS_OWNER,
+      receiver: ethers.constants.AddressZero,
       buyToken: ethers.constants.AddressZero,
       buyAmount: ethers.constants.Zero,
     }),

--- a/test/encoding.ts
+++ b/test/encoding.ts
@@ -1,7 +1,7 @@
 import type { BigNumber } from "ethers";
 import { ethers } from "hardhat";
 
-import { Order, OrderKind } from "../src/ts";
+import { Order, OrderKind, RECEIVER_SAME_AS_OWNER } from "../src/ts";
 
 export type AbiOrder = [
   string,
@@ -68,10 +68,18 @@ export function decodeTrade(trade: AbiTrade): Trade {
   };
 }
 
-export type AbiExecutedTrade = [string, string, string, BigNumber, BigNumber];
+export type AbiExecutedTrade = [
+  string,
+  string,
+  string,
+  string,
+  BigNumber,
+  BigNumber,
+];
 
 export interface ExecutedTrade {
   owner: string;
+  receiver: string;
   sellToken: string;
   buyToken: string;
   sellAmount: BigNumber;
@@ -81,6 +89,7 @@ export interface ExecutedTrade {
 export function encodeExecutedTrade(trade: ExecutedTrade): AbiExecutedTrade {
   return [
     trade.owner,
+    trade.receiver,
     trade.sellToken,
     trade.buyToken,
     trade.sellAmount,
@@ -93,10 +102,11 @@ export function decodeExecutedTrades(
 ): ExecutedTrade[] {
   return trades.map((trade) => ({
     owner: trade[0],
-    sellToken: trade[1],
-    buyToken: trade[2],
-    sellAmount: trade[3],
-    buyAmount: trade[4],
+    receiver: trade[1],
+    sellToken: trade[2],
+    buyToken: trade[3],
+    sellAmount: trade[4],
+    buyAmount: trade[5],
   }));
 }
 
@@ -109,6 +119,7 @@ export function encodeInTransfers(transfers: InTransfer[]): AbiExecutedTrade[] {
   return transfers.map((transfer) =>
     encodeExecutedTrade({
       ...transfer,
+      receiver: RECEIVER_SAME_AS_OWNER,
       buyToken: ethers.constants.AddressZero,
       buyAmount: ethers.constants.Zero,
     }),
@@ -117,7 +128,7 @@ export function encodeInTransfers(transfers: InTransfer[]): AbiExecutedTrade[] {
 
 export type OutTransfer = Pick<
   ExecutedTrade,
-  "owner" | "buyToken" | "buyAmount"
+  "owner" | "receiver" | "buyToken" | "buyAmount"
 >;
 
 export function encodeOutTransfers(


### PR DESCRIPTION
Closes #376 

This PR modifies the trade execution code to send to the `receiver` specified in the order if it is set (i.e. non-zero), defaulting to the owner of the order otherwise.

### Test Plan

Added unit tests checking this works for both ERC20 and Ether. Overall, this increases the gas cost of trades by around 275 gas each:

<details><summary>Benchmarks</summary>

```
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
            2 |           10 |            0 |            0 |       749793  (change: 275 / trade)
            3 |           10 |            0 |            0 |       750373  (change: 274 / trade)
            4 |           10 |            0 |            0 |       759305  (change: 274 / trade)
            5 |           10 |            0 |            0 |       763989  (change: 271 / trade)
            6 |           10 |            0 |            0 |       760297  (change: 273 / trade)
            7 |           10 |            0 |            0 |       769229  (change: 277 / trade)
            8 |           10 |            0 |            0 |       773901  (change: 272 / trade)
            8 |           20 |            0 |            0 |      1466647  (change: 279 / trade)
            8 |           30 |            0 |            0 |      2112844  (change: 276 / trade)
            8 |           40 |            0 |            0 |      2763741  (change: 280 / trade)
            8 |           50 |            0 |            0 |      3414323  (change: 282 / trade)
            8 |           60 |            0 |            0 |      4061220  (change: 279 / trade)
            8 |           70 |            0 |            0 |      4712692  (change: 281 / trade)
            8 |           80 |            0 |            0 |      5363994  (change: 280 / trade)
            2 |           10 |            1 |            0 |       820269  (change: 264 / trade)
            2 |           10 |            2 |            0 |       866052  (change: 272 / trade)
            2 |           10 |            3 |            0 |       911824  (change: 276 / trade)
            2 |           10 |            4 |            0 |       957408  (change: 270 / trade)
            2 |           10 |            5 |            0 |      1003205  (change: 276 / trade)
            2 |           10 |            6 |            0 |      1048930  (change: 269 / trade)
            2 |           10 |            7 |            0 |      1094705  (change: 268 / trade)
            2 |           10 |            8 |            0 |      1140328  (change: 269 / trade)
            2 |           50 |            0 |           10 |      3139963  (change: 280 / trade)
            2 |           50 |            0 |           15 |      3096563  (change: 278 / trade)
            2 |           50 |            0 |           20 |      3053215  (change: 282 / trade)
            2 |           50 |            0 |           25 |      3009791  (change: 280 / trade)
            2 |           50 |            0 |           30 |      2966523  (change: 282 / trade)
            2 |           50 |            0 |           35 |      2923195  (change: 282 / trade)
            2 |           50 |            0 |           40 |      2879691  (change: 281 / trade)
            2 |           50 |            0 |           45 |      2836375  (change: 281 / trade)
            2 |           50 |            0 |           50 |      2793119  (change: 282 / trade)
            2 |            2 |            0 |            0 |       185939  (change: 325 / trade)
            2 |            1 |            1 |            0 |       185928  (change: 342 / trade)
           10 |          100 |           10 |           20 |      7173412  (change: 279 / trade)
```

</details>