### PR TITLE
[playground] Upgradeable authenticator: split proxy ownership and authenticator ownership

### DIFF
--- a/src/contracts/GPv2AllowListAuthentication.sol
+++ b/src/contracts/GPv2AllowListAuthentication.sol
@@ -8,20 +8,26 @@ import "./interfaces/GPv2Authentication.sol";
 
 /// @title Gnosis Protocol v2 Access Control Contract
 /// @author Gnosis Developers
-contract GPv2AllowListAuthentication is
-    GPv2Authentication,
-    StorageAccessible,
-    OwnableUpgradeable
-{
+contract GPv2AllowListAuthentication is GPv2Authentication, StorageAccessible {
     using EnumerableSet for EnumerableSet.AddressSet;
+    address public manager;
 
     EnumerableSet.AddressSet private solvers;
 
-    function addSolver(address solver) external onlyOwner {
+    function setManager(address _manager) public {
+        manager = _manager;
+    }
+
+    modifier onlyManager() {
+        require(manager == msg.sender, "caller is not the manager");
+        _;
+    }
+
+    function addSolver(address solver) external onlyManager {
         solvers.add(solver);
     }
 
-    function removeSolver(address solver) external onlyOwner {
+    function removeSolver(address solver) external onlyManager {
         solvers.remove(solver);
     }
 

--- a/src/deploy/001_authenticator.ts
+++ b/src/deploy/001_authenticator.ts
@@ -58,9 +58,8 @@ const deployAuthenticator: DeployFunction = async function ({
     gasLimit: 2000000,
     deterministicDeployment: SALT,
     log: true,
-    // proxy: {
-    //   owner: owner,
-    // },
+    proxy: "setManager",
+    args: [owner],
   });
 };
 

--- a/test/AllowListStorageReader.test.ts
+++ b/test/AllowListStorageReader.test.ts
@@ -21,7 +21,8 @@ describe("GPv2AllowListAuthentication", () => {
     );
 
     reader = await AllowListStorageReader.deploy();
-    authenticator = await GPv2AllowListAuthentication.connect(owner).deploy();
+    authenticator = await GPv2AllowListAuthentication.deploy();
+    await authenticator.setManager(owner.address);
     allowListReader = new AllowListReader(authenticator, reader);
   });
 

--- a/test/GPv2AllowListAuthenticator.test.ts
+++ b/test/GPv2AllowListAuthenticator.test.ts
@@ -13,14 +13,15 @@ describe("GPv2AllowListAuthentication", () => {
     );
 
     authenticator = await GPv2AllowListAuthentication.deploy();
+    await authenticator.setManager(owner.address);
   });
 
   describe("constructor", () => {
     it("should set the owner", async () => {
-      expect(await authenticator.owner()).to.equal(owner.address);
+      expect(await authenticator.manager()).to.equal(owner.address);
     });
     it("deployer is not the owner", async () => {
-      expect(await authenticator.owner()).not.to.be.equal(deployer.address);
+      expect(await authenticator.manager()).not.to.be.equal(deployer.address);
     });
   });
 
@@ -33,7 +34,7 @@ describe("GPv2AllowListAuthentication", () => {
     it("should not allow non-owner to add solver", async () => {
       await expect(
         authenticator.connect(nonOwner).addSolver(solver.address),
-      ).to.be.revertedWith("caller is not the owner");
+      ).to.be.revertedWith("caller is not the manager");
     });
   });
 
@@ -46,7 +47,7 @@ describe("GPv2AllowListAuthentication", () => {
     it("should not allow non-owner to remove solver", async () => {
       await expect(
         authenticator.connect(nonOwner).removeSolver(solver.address),
-      ).to.be.revertedWith("caller is not the owner");
+      ).to.be.revertedWith("caller is not the manager");
     });
   });
 


### PR DESCRIPTION
Findings of a discussion with @bh2smith. This PR is not supposed to be merged nor reviewed.

The base PR #351 makes the authenticator contract upgradeable with a proxy.
This PR removes `OwnableUpgradeable` from the contract and separates the ownership of the proxy (owned by `owned`) from the ownership of the authenticator (previously called `owner`, which conflicted, now called `manager`). The "managership" of the authenticator is set as part of the proxy deployment. This makes the "proxiness" of the authenticator implicit and not explicit, since it's only evident from the deployment scripts.

The next task would be to write the authenticator contract so that it "inherits" the owner of the proxy. The function setting the manager should be restricted (maybe only called once?). Then I'd test that the upgrading changes the manager and has the right owner.
I didn't investigate on who owns the proxy, however. I suppose the deployer?

### Test Plan

Note that the _end to end_ tests are passing, showing that the proxy contract is deployed correctly and the owner-manager is being set correctly in the deployment.
