### PR TITLE
full size app data and fee discount

### DIFF
--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -6,7 +6,6 @@ import { Contract, ContractReceipt, Wallet } from "ethers";
 import { ethers, waffle } from "hardhat";
 
 import {
-  FULL_FEE_DISCOUNT,
   Order,
   OrderKind,
   SettlementEncoder,
@@ -218,7 +217,9 @@ export class BenchFixture {
         (i + Math.floor(i / 4)) % 2 == 0
           ? SigningScheme.EIP712
           : SigningScheme.ETHSIGN;
-      const feeDiscount = (i % 3) * (FULL_FEE_DISCOUNT / 2); // 0% | 50% | 100%
+
+      const feeAmount = ethers.utils.parseEther("1.0");
+      const feeDiscount = feeAmount.mul(i % 3).div(2); // 0% | 50% | 100%
 
       const dbg = {
         fill: orderSpice.partiallyFillable
@@ -226,7 +227,7 @@ export class BenchFixture {
           : "fill-or-kill",
         kind: orderSpice.kind == OrderKind.SELL ? "sell" : "buy",
         sign: signingScheme == SigningScheme.EIP712 ? "eip-712" : "eth_sign",
-        fee: 100 * (1 - feeDiscount / FULL_FEE_DISCOUNT),
+        fee: feeAmount.sub(feeDiscount).mul(100).div(feeAmount).toNumber(),
       };
       debug(
         `encoding ${dbg.fill} ${dbg.kind} order with ${dbg.sign} signature and ${dbg.fee}% fees`,
@@ -236,17 +237,21 @@ export class BenchFixture {
         {
           sellToken: tokens.id(i % options.tokens).address,
           buyToken: tokens.id((i + 1) % options.tokens).address,
-          feeAmount: ethers.utils.parseEther("1"),
+          feeAmount,
           validTo: 0xffffffff,
           appData: this.nonce++,
           ...orderSpice,
         },
         traders[i % traders.length],
         signingScheme,
-        {
-          executedAmount: ethers.utils.parseEther("100.0"),
-          feeDiscount,
-        },
+        orderSpice.partiallyFillable
+          ? {
+              executedAmount: ethers.utils.parseEther("100.0"),
+              feeDiscount: feeDiscount.div(2),
+            }
+          : {
+              feeDiscount,
+            },
       );
     }
 

--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -247,6 +247,8 @@ export class BenchFixture {
         orderSpice.partiallyFillable
           ? {
               executedAmount: ethers.utils.parseEther("100.0"),
+              // NOTE: Order is exactly half executed, so adjust fee discount as
+              // well so that it doesn't execeed the executed fee amount.
               feeDiscount: feeDiscount.div(2),
             }
           : {

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -31,9 +31,6 @@ contract GPv2Settlement is ReentrancyGuard {
     /// @dev The EIP-712 domain version used for computing the domain separator.
     bytes32 private constant DOMAIN_VERSION = keccak256("v2");
 
-    /// @dev The number of basis points to make up 100%.
-    uint256 private constant BPS_BASE = 10000;
-
     /// @dev The domain separator used for signing orders that gets mixed in
     /// making signatures for different domains incompatible. This domain
     /// separator is computed following the EIP-712 standard and has replay
@@ -321,10 +318,11 @@ contract GPv2Settlement is ReentrancyGuard {
             );
         }
 
-        require(trade.feeDiscount <= BPS_BASE, "GPv2: fee discount too large");
-        executedFeeAmount =
-            executedFeeAmount.mul(BPS_BASE - trade.feeDiscount) /
-            BPS_BASE;
+        require(
+            trade.feeDiscount <= executedFeeAmount,
+            "GPv2: fee discount too large"
+        );
+        executedFeeAmount = executedFeeAmount - trade.feeDiscount;
 
         executedTrade.sellAmount = executedSellAmount.add(executedFeeAmount);
         executedTrade.buyAmount = executedBuyAmount;

--- a/src/ts/sign.ts
+++ b/src/ts/sign.ts
@@ -1,6 +1,6 @@
 import { BytesLike, ethers, Signer } from "ethers";
 
-import { hashOrder, Order, ORDER_TYPE_FIELDS, timestamp } from "./order";
+import { ORDER_TYPE_FIELDS, Order, hashOrder, normalizeOrder } from "./order";
 import { isTypedDataSigner, TypedDataDomain } from "./types/ethers";
 
 /**
@@ -67,11 +67,7 @@ function ecdsaSignOrder(
       return owner._signTypedData(
         domain,
         { Order: ORDER_TYPE_FIELDS },
-        {
-          ...order,
-          receiver: order.receiver ?? ethers.constants.AddressZero,
-          validTo: timestamp(order.validTo),
-        },
+        normalizeOrder(order),
       );
 
     case SigningScheme.ETHSIGN:

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -42,7 +42,7 @@ describe("GPv2Encoding", () => {
     sellAmount: ethers.utils.parseEther("42"),
     buyAmount: ethers.utils.parseEther("13.37"),
     validTo: 0xffffffff,
-    appData: 0,
+    appData: ethers.constants.HashZero,
     feeAmount: ethers.utils.parseEther("1.0"),
     kind: OrderKind.SELL,
     partiallyFillable: false,
@@ -130,14 +130,14 @@ describe("GPv2Encoding", () => {
         sellAmount: fillUint(256, 0x04),
         buyAmount: fillUint(256, 0x05),
         validTo: fillUint(32, 0x06).toNumber(),
-        appData: fillUint(32, 0x07).toNumber(),
+        appData: fillBytes(32, 0x07),
         feeAmount: fillUint(256, 0x08),
         kind: OrderKind.BUY,
         partiallyFillable: true,
       };
       const tradeExecution = {
         executedAmount: fillUint(256, 0x09),
-        feeDiscount: fillUint(16, 0x0a).toNumber(),
+        feeDiscount: fillUint(256, 0x0a),
       };
 
       const encoder = new SettlementEncoder(testDomain);
@@ -256,7 +256,7 @@ describe("GPv2Encoding", () => {
       // NOTE: `v` must be either `27` or `28`, so just set it to something else
       // to generate an invalid signature.
       const encodedTradeBytes = ethers.utils.arrayify(encoder.encodedTrades);
-      encodedTradeBytes[227] = 42;
+      encodedTradeBytes[285] = 42;
 
       await expect(
         encoding.decodeTradesTest(encoder.tokens, encodedTradeBytes),
@@ -274,7 +274,7 @@ describe("GPv2Encoding", () => {
       // NOTE: `v` must be either `27` or `28`, so just set it to something else
       // to generate an invalid signature.
       const encodedTradeBytes = ethers.utils.arrayify(encoder.encodedTrades);
-      encodedTradeBytes[227] = 42;
+      encodedTradeBytes[285] = 42;
 
       await expect(
         encoding.decodeTradesTest(encoder.tokens, encodedTradeBytes),
@@ -455,7 +455,7 @@ describe("GPv2Encoding", () => {
 
       const encodedTrades = ethers.utils.arrayify(encoder.encodedTrades);
 
-      encodedTrades[2 + 126] |= 0b11000000;
+      encodedTrades[2 + 154] |= 0b11000000;
       await expect(
         encoding.decodeTradesTest(encoder.tokens, encodedTrades),
       ).to.be.revertedWith("GPv2: invalid signature scheme");
@@ -464,7 +464,7 @@ describe("GPv2Encoding", () => {
     describe("invalid encoded trade", () => {
       const sampleTradeExecution = {
         executedAmount: fillUint(256, 0x09),
-        feeDiscount: fillUint(16, 0x0a).toNumber(),
+        feeDiscount: fillUint(256, 0x0a),
       };
 
       it("calldata shorter than single trade length", async () => {

--- a/test/e2e/uniswapTrade.test.ts
+++ b/test/e2e/uniswapTrade.test.ts
@@ -123,7 +123,7 @@ describe("E2E: Should Trade Surplus With Uniswap", () => {
       SigningScheme.EIP712,
       // NOTE: Only take 50% of fees as the user traded half of their order
       // against Uniswap.
-      { feeDiscount: 5000 },
+      { feeDiscount: ethers.utils.parseEther("0.0005") },
     );
 
     await usdt.mint(traders[1].address, ethers.utils.parseUnits("300.3", 6));

--- a/test/encoding.ts
+++ b/test/encoding.ts
@@ -21,7 +21,7 @@ export type AbiTrade = [
   number,
   number,
   BigNumber,
-  number,
+  BigNumber,
   string,
   string,
 ];
@@ -31,7 +31,7 @@ export interface Trade {
   sellTokenIndex: number;
   buyTokenIndex: number;
   executedAmount: BigNumber;
-  feeDiscount: number;
+  feeDiscount: BigNumber;
   owner: string;
   orderUid: string;
 }


### PR DESCRIPTION
This PR introduces full-sized (i.e. 32 bytes) `appData` and `feeDiscount` properties. Specifically, compressing `feeDiscount` into a percentage was not very gas effecient (because of `uint16` safe math, which generates code with a lot of jumps and masking) and added unnecessary complexity.

The full-sized `appData` is useful for encoding more things (specifically it has more than enough space to encode a "referrer address").

### Test Plan

Adjusted unit tests still pass. It turns out this negligibly increases gas costs (~20-30 per order) because of the inefficient fee discount calculation code:

<details><summary>Benchmarks</summary>

```
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
            2 |           10 |            0 |            0 |       749911  (change: 13 / trade)
            3 |           10 |            0 |            0 |       750503  (change: 15 / trade)
            4 |           10 |            0 |            0 |       759447  (change: 15 / trade)
            5 |           10 |            0 |            0 |       764131  (change: 11 / trade)
            6 |           10 |            0 |            0 |       760451  (change: 14 / trade)
            7 |           10 |            0 |            0 |       769383  (change: 17 / trade)
            8 |           10 |            0 |            0 |       774019  (change: 13 / trade)
            8 |           20 |            0 |            0 |      1467163  (change: 24 / trade)
            8 |           30 |            0 |            0 |      2113658  (change: 26 / trade)
            8 |           40 |            0 |            0 |      2764929  (change: 31 / trade)
            8 |           50 |            0 |            0 |      3415637  (change: 25 / trade)
            8 |           60 |            0 |            0 |      4062952  (change: 28 / trade)
            8 |           70 |            0 |            0 |      4714690  (change: 30 / trade)
            8 |           80 |            0 |            0 |      5366306  (change: 29 / trade)
            2 |           10 |            1 |            0 |       820459  (change: 14 / trade)
            2 |           10 |            2 |            0 |       866194  (change: 11 / trade)
            2 |           10 |            3 |            0 |       911942  (change: 13 / trade)
            2 |           10 |            4 |            0 |       957550  (change: 10 / trade)
            2 |           10 |            5 |            0 |      1003359  (change: 19 / trade)
            2 |           10 |            6 |            0 |      1049084  (change: 14 / trade)
            2 |           10 |            7 |            0 |      1094847  (change: 17 / trade)
            2 |           10 |            8 |            0 |      1140482  (change: 14 / trade)
            2 |           50 |            0 |           10 |      3141229  (change: 24 / trade)
            2 |           50 |            0 |           15 |      3097865  (change: 23 / trade)
            2 |           50 |            0 |           20 |      3054445  (change: 24 / trade)
            2 |           50 |            0 |           25 |      3011141  (change: 26 / trade)
            2 |           50 |            0 |           30 |      2967825  (change: 26 / trade)
            2 |           50 |            0 |           35 |      2924461  (change: 27 / trade)
            2 |           50 |            0 |           40 |      2880981  (change: 24 / trade)
            2 |           50 |            0 |           45 |      2837665  (change: 25 / trade)
            2 |           50 |            0 |           50 |      2794397  (change: 28 / trade)
            2 |            2 |            0 |            0 |       185825  (change: -63 / trade)
            2 |            1 |            1 |            0 |       185787  (change: -141 / trade)
           10 |          100 |           10 |           20 |      7175968  (change: 27 / trade)
```

</details>