### PR TITLE
Remove assembly for decoding trades.

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -65,6 +65,9 @@ export default {
     ],
   },
   networks: {
+    hardhat: {
+      blockGasLimit: 12e6,
+    },
     mainnet: {
       ...sharedNetworkConfig,
       url: `https://mainnet.infura.io/v3/${INFURA_KEY}`,

--- a/src/contracts/test/GPv2EncodingTestInterface.sol
+++ b/src/contracts/test/GPv2EncodingTestInterface.sol
@@ -19,22 +19,13 @@ contract GPv2EncodingTestInterface {
         return (GPv2Encoding.ORDER_TYPE_HASH);
     }
 
-    function tradeCountTest(bytes calldata encodedTrades)
-        external
-        pure
-        returns (uint256 count, bytes calldata encodedTradesWithoutLength)
-    {
-        (count, encodedTradesWithoutLength) = encodedTrades.decodeTradeCount();
-    }
-
     function decodeTradesTest(
         IERC20[] calldata tokens,
-        bytes calldata encodedTrades
+        GPv2Encoding.TradeData[] calldata encodedTrades
     )
         external
         view
         returns (
-            uint256 tradeCount,
             GPv2Encoding.Trade[] memory trades,
             uint256 mem,
             uint256 gas_
@@ -42,12 +33,9 @@ contract GPv2EncodingTestInterface {
     {
         bytes32 domainSeparator = DOMAIN_SEPARATOR;
 
-        bytes calldata remainingEncodedTrades;
-        (tradeCount, remainingEncodedTrades) = encodedTrades.decodeTradeCount();
-
-        trades = new GPv2Encoding.Trade[](tradeCount);
+        trades = new GPv2Encoding.Trade[](encodedTrades.length);
         uint256 i;
-        for (i = 0; i < tradeCount; i++) {
+        for (i = 0; i < encodedTrades.length; i++) {
             trades[i].orderUid = new bytes(56);
         }
 
@@ -62,14 +50,13 @@ contract GPv2EncodingTestInterface {
         }
         gas_ = gasleft();
 
-        i = 0;
-        while (remainingEncodedTrades.length != 0) {
-            remainingEncodedTrades = remainingEncodedTrades.decodeTrade(
+        for (i = 0; i < encodedTrades.length; i++) {
+            GPv2Encoding.decodeTrade(
+                encodedTrades[i],
                 domainSeparator,
                 tokens,
                 trades[i]
             );
-            i++;
         }
 
         // solhint-disable-next-line no-inline-assembly

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -17,7 +17,7 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
     function computeTradeExecutionsTest(
         IERC20[] calldata tokens,
         uint256[] calldata clearingPrices,
-        bytes calldata encodedTrades
+        GPv2Encoding.TradeData[] calldata encodedTrades
     ) external returns (GPv2TradeExecution.Data[] memory executedTrades) {
         executedTrades = computeTradeExecutions(
             tokens,


### PR DESCRIPTION
This is _draft_ PR to discuss the possibility of replacing our custom encoding with `abicoder v2` calldata structs.

In preparing for SC audits, I decided to do some due diligence and evaluate just how much gas we save from our custom encoding, and whether or not it is worth the extra code complexity and code surface for potential bugs (especially because there are little gotchas around assembly such as masking values that are smaller than 32-bytes).

When we started with the encoding library, `abicoder v2` was still experimental (enabled with `pragma experimental ABIEncoderV2`). This meant that for some calldata to be decoded without experimental features, we would have to use `abi.decode` which was quite problematic for large batches as it would require huge amounts of memory, ~320 bytes per order, and cause very high memory costs because of the quadratic memory costs. The other option was to use `assembly`, and since we were using assembly anyway, it made more sense to use a packed encoding to save on calldata gas.

Now that ABI v2 has stabilized, this means that we can use `Struct[] calldata values` instead, which leaves struct data as calldata and generates appropriate `CALLDATALOAD` calls on access. This is very nice as it allows us to pass complex structs around in our code without every having to load them into memory :tada: and is **very** gas efficient. Additionally, this makes implementing wrapper contracts that inspect and/or modify the settlement input much easier (as they do not need to perform decoding and/or implement complex encoding). The downside being much more bloated calldata :-1:.

On the one hand, this change cuts down an immense amount of complexity, on the other it would be very sad to see our optimized decoding go :cry:. Also worth noting that 1270 gas is non-negligible amount of gas. If we match two orders per minute at the current gas costs, thats:
```js
100e9 /* 100 gwei */
  * 2500 /* extra gas for 2 orders */
  * 60 /* minutes */
  * 24 /* hours */
  * 365 /* days */
  * (1300/1e18) /* $ price of wei */
//  = 170820 $/year
``` 

### Test Plan

Tests were adjusted, additionally benchmarking results are interesting:

<details>

<summary>Tracing from 6 trades shows that the difference in gas costs are almost entirely paid in the calldata</summary>

Current gas costs:
```
GPv2Settlement.settle 567674 +61800
...
├── <calldata> 46652 -25652
...
```

Gas costs after change:
```
GPv2Settlement.settle 575019 +61800
...
├── <calldata> 53132 -32132
...
```

So the difference is `575019 - 567674 = 7345` more gas in total for settling 6 trades, out of which `53132 - 46652 = 6480` gas is just for the additional calldata.

</details>


<details>

<summary>Benchmarking shows that this costs around 1275 gas/order (<2% gas increase)</summary>

```
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
            2 |           10 |            0 |            0 |       762484  (change: 1257 / trade)
            3 |           10 |            0 |            0 |       763028  (change: 1252 / trade)
            4 |           10 |            0 |            0 |       771948  (change: 1250 / trade)
            5 |           10 |            0 |            0 |       776644  (change: 1251 / trade)
            6 |           10 |            0 |            0 |       773000  (change: 1254 / trade)
            7 |           10 |            0 |            0 |       781872  (change: 1248 / trade)
            8 |           10 |            0 |            0 |       786580  (change: 1256 / trade)
            8 |           20 |            0 |            0 |      1492530  (change: 1268 / trade)
            8 |           30 |            0 |            0 |      2151723  (change: 1268 / trade)
            8 |           40 |            0 |            0 |      2815236  (change: 1257 / trade)
            8 |           50 |            0 |            0 |      3479262  (change: 1272 / trade)
            8 |           60 |            0 |            0 |      4139455  (change: 1275 / trade)
            8 |           70 |            0 |            0 |      4803783  (change: 1272 / trade)
            8 |           80 |            0 |            0 |      5467341  (change: 1262 / trade)
            2 |           10 |            1 |            0 |       833008  (change: 1254 / trade)
            2 |           10 |            2 |            0 |       878743  (change: 1254 / trade)
            2 |           10 |            3 |            0 |       924479  (change: 1253 / trade)
            2 |           10 |            4 |            0 |       970099  (change: 1254 / trade)
            2 |           10 |            5 |            0 |      1015812  (change: 1245 / trade)
            2 |           10 |            6 |            0 |      1061633  (change: 1254 / trade)
            2 |           10 |            7 |            0 |      1107384  (change: 1253 / trade)
            2 |           10 |            8 |            0 |      1153019  (change: 1253 / trade)
            2 |           50 |            0 |           10 |      3204902  (change: 1273 / trade)
            2 |           50 |            0 |           15 |      3161610  (change: 1274 / trade)
            2 |           50 |            0 |           20 |      3118130  (change: 1273 / trade)
            2 |           50 |            0 |           25 |      3074850  (change: 1274 / trade)
            2 |           50 |            0 |           30 |      3031438  (change: 1272 / trade)
            2 |           50 |            0 |           35 |      2988194  (change: 1274 / trade)
            2 |           50 |            0 |           40 |      2944666  (change: 1273 / trade)
            2 |           50 |            0 |           45 |      2901398  (change: 1274 / trade)
            2 |           50 |            0 |           50 |      2857962  (change: 1271 / trade)
            2 |            2 |            0 |            0 |       188094  (change: 1134 / trade)
            2 |            1 |            1 |            0 |       186805  (change: 1018 / trade)
           10 |          100 |           10 |           20 |      7303763  (change: 1277 / trade)
```

</details>

One thing to note is that the code is currently structured about the previous decoding assembly. I think it can be refactored a bit and made slightly more efficient (for example, we load the `TradeData calldata` to `Trade memory` but we don't have to, we just need to recover the order and owner) to make up some of the loss if we decide to go with `calldata` structs.