### PR TITLE
RLE-encode some trade parameters

### DIFF
--- a/src/contracts/libraries/GPv2Encoding.sol
+++ b/src/contracts/libraries/GPv2Encoding.sol
@@ -87,9 +87,6 @@ library GPv2Encoding {
     bytes32 internal constant ORDER_TYPE_HASH =
         hex"d604be04a8c6d2df582ec82eba9b65ce714008acbf9122dd95e499569c8f1a80";
 
-    /// @dev The length of the fixed-length components in an encoded trade.
-    uint256 private constant CONSTANT_SIZE_TRADE_LENGTH = 219;
-
     /// @dev The byte length of an order unique identifier.
     uint256 private constant ORDER_UID_LENGTH = 56;
 
@@ -140,16 +137,21 @@ library GPv2Encoding {
     /// struct EncodedTrade {
     ///     uint8 sellTokenIndex;
     ///     uint8 buyTokenIndex;
-    ///     address receiver;
-    ///     uint256 sellAmount;
+    ///     address receiver?;             // only present if the receiver bit
+    ///                                    // is 1 (see below)
+    ///     bytes sellAmount;
     ///     uint256 buyAmount;
     ///     uint32 validTo;
-    ///     bytes32 appData;
+    ///     uint8 appDataStride;
+    ///     bytes appData;                 // size determined by previous byte
     ///     uint256 feeAmount;
     ///     uint8 flags;
-    ///     uint256 executedAmount;
-    ///     uint256 feeDiscount;
-    ///     bytes signature;
+    ///     uint256 executedAmount;        // only present if partially fillable
+    ///                                    // flag is 1 (see below)
+    ///     uint8 feeDiscountStride;
+    ///     bytes feeDiscount;             // size determined by previous byte
+    ///     bytes signature;               // size determined by the signature
+    ///                                    // type (see below)
     /// }
     /// ```
     ///
@@ -169,14 +171,19 @@ library GPv2Encoding {
     /// ```
     /// bit | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
     /// ----+-----------------------+---+---+
-    ///     | * | * |    unused     | * | * |
-    ///       |   |                   |   |
-    ///       |   |                   |   +---- order kind bit, 0 for a sell
-    ///       |   |                   |         order and 1 for a buy order
-    ///       |   |                   |
-    ///       |   |                   +-------- order fill bit, 0 for fill-or-
-    ///       |   |                             kill and 1 for a partially
-    ///       |   |                             fillable order
+    ///     | * | * |  unused   | * | * | * |
+    ///       |   |               |   |   |
+    ///       |   |               |   |   +---- order kind bit, 0 for a sell
+    ///       |   |               |   |         order and 1 for a buy order
+    ///       |   |               |   |
+    ///       |   |               |   +-------- order fill bit, 0 for fill-or-
+    ///       |   |               |             kill and 1 for a partially
+    ///       |   |               |             fillable order
+    ///       |   |               |
+    ///       |   |               +------------ receiver bit, 0 if the funds
+    ///       |   |                             bought with this order should
+    ///       |   |                             be sent to the signer, 1 if
+    ///       |   |                             a different receiver is encoded.
     ///       |   |
     ///       +---+---------------------------- signature-type bits:
     ///                                         00: EIP-712
@@ -198,14 +205,10 @@ library GPv2Encoding {
         IERC20[] calldata tokens,
         Trade memory trade
     ) internal view returns (bytes calldata remainingCalldata) {
-        require(
-            encodedTrade.length >= CONSTANT_SIZE_TRADE_LENGTH,
-            "GPv2: invalid trade"
-        );
-
         uint32 validTo;
         bytes32 orderDigest;
         uint256 flags;
+        uint256 unprocessedCalldataPointer;
 
         // This scope is needed to clear variables from the stack after use and
         // avoids stack too deep errors.
@@ -218,53 +221,130 @@ library GPv2Encoding {
             // NOTE: Use assembly to efficiently decode packed data. Memory
             // structs in Solidity aren't packed, so the `Order` fields are in
             // order at 32 byte increments.
+
             // solhint-disable-next-line no-inline-assembly
             assembly {
-                // sellTokenIndex = uint8(encodedTrade[0])
-                sellTokenIndex := shr(248, calldataload(encodedTrade.offset))
-                // buyTokenIndex = uint8(encodedTrade[1])
+                unprocessedCalldataPointer := encodedTrade.offset
+
+                // uint8 flags;
+                flags := shr(248, calldataload(unprocessedCalldataPointer))
+                unprocessedCalldataPointer := add(unprocessedCalldataPointer, 1)
+
+                // uint8 sellTokenIndex;
+                sellTokenIndex := shr(
+                    248,
+                    calldataload(unprocessedCalldataPointer)
+                )
+                unprocessedCalldataPointer := add(unprocessedCalldataPointer, 1)
+
+                // uint8 buyTokenIndex;
                 buyTokenIndex := shr(
                     248,
-                    calldataload(add(encodedTrade.offset, 1))
+                    calldataload(unprocessedCalldataPointer)
                 )
-                // order.receiver = uint256(encodedTrade[2:22])
-                mstore(
-                    add(order, 64),
-                    shr(96, calldataload(add(encodedTrade.offset, 2)))
+                unprocessedCalldataPointer := add(unprocessedCalldataPointer, 1)
+
+                // if third flag bit from the right is set (receiver flag)
+                if gt(and(flags, 4), 0) {
+                    // address order.receiver;
+                    mstore(
+                        add(order, 64),
+                        shr(96, calldataload(unprocessedCalldataPointer))
+                    )
+                    unprocessedCalldataPointer := add(
+                        unprocessedCalldataPointer,
+                        20
+                    )
+                }
+
+                // uint256 order.sellAmount
+                mstore(add(order, 96), calldataload(unprocessedCalldataPointer))
+                unprocessedCalldataPointer := add(
+                    unprocessedCalldataPointer,
+                    32
                 )
-                // order.sellAmount = uint256(encodedTrade[22:54])
-                mstore(
-                    add(order, 96),
-                    calldataload(add(encodedTrade.offset, 22))
-                )
-                // order.buyAmount = uint256(encodedTrade[54:86])
+
+                // uint256 order.buyAmount;
                 mstore(
                     add(order, 128),
-                    calldataload(add(encodedTrade.offset, 54))
+                    calldataload(unprocessedCalldataPointer)
                 )
-                // validTo = uint32(encodedTrade[86:90])
-                validTo := shr(224, calldataload(add(encodedTrade.offset, 86)))
-                // order.appData = uint32(encodedTrade[90:122])
+                unprocessedCalldataPointer := add(
+                    unprocessedCalldataPointer,
+                    32
+                )
+
+                // uint32 validTo;
+                validTo := shr(224, calldataload(unprocessedCalldataPointer))
+                unprocessedCalldataPointer := add(unprocessedCalldataPointer, 4)
+
+                // uint8 appDataLength; // 0 <= appDataLength <= 32
+                let appDataLength := shr(
+                    248,
+                    calldataload(unprocessedCalldataPointer)
+                )
+                if gt(appDataLength, 32) {
+                    // "GPv2: appData too long"
+                    revert(0, 0)
+                }
+                unprocessedCalldataPointer := add(unprocessedCalldataPointer, 1)
+                // bytes32 order.appData;
                 mstore(
                     add(order, 192),
-                    calldataload(add(encodedTrade.offset, 90))
+                    shr(
+                        sub(256, mul(8, appDataLength)),
+                        calldataload(unprocessedCalldataPointer)
+                    )
                 )
-                // order.feeAmount = uint256(encodedTrade[122:154])
+                unprocessedCalldataPointer := add(
+                    unprocessedCalldataPointer,
+                    appDataLength
+                )
+
+                // uint256 order.feeAmount;
                 mstore(
                     add(order, 224),
-                    calldataload(add(encodedTrade.offset, 122))
+                    calldataload(unprocessedCalldataPointer)
                 )
-                // flags = uint8(encodedTrade[154])
-                flags := shr(248, calldataload(add(encodedTrade.offset, 154)))
-                // trade.executedAmount = uint256(encodedTrade[155:187])
-                mstore(
-                    add(trade, 96),
-                    calldataload(add(encodedTrade.offset, 155))
+                unprocessedCalldataPointer := add(
+                    unprocessedCalldataPointer,
+                    32
                 )
-                // trade.feeDiscount = uint256(encodedTrade[187:219])
+
+                // if second flag bit from the right is set (partialy fillable)
+                if gt(and(flags, 2), 0) {
+                    // uint256 trade.executedAmount;
+                    mstore(
+                        add(trade, 96),
+                        calldataload(unprocessedCalldataPointer)
+                    )
+                    unprocessedCalldataPointer := add(
+                        unprocessedCalldataPointer,
+                        32
+                    )
+                }
+
+                // uint8 feeDiscountStride; // 0 <= feeDiscountStride <= 32
+                let feeDiscountStride := shr(
+                    248,
+                    calldataload(unprocessedCalldataPointer)
+                )
+                if gt(feeDiscountStride, 32) {
+                    // "GPv2: feeAmount too long"
+                    revert(0, 0)
+                }
+                unprocessedCalldataPointer := add(unprocessedCalldataPointer, 1)
+                // uint256 order.feeAmount;
                 mstore(
                     add(trade, 128),
-                    calldataload(add(encodedTrade.offset, 187))
+                    shr(
+                        sub(256, mul(8, feeDiscountStride)),
+                        calldataload(unprocessedCalldataPointer)
+                    )
+                )
+                unprocessedCalldataPointer := add(
+                    unprocessedCalldataPointer,
+                    feeDiscountStride
                 )
             }
 
@@ -300,18 +380,24 @@ library GPv2Encoding {
         }
 
         bytes calldata signature;
+
         // NOTE: Use assembly to slice the calldata bytes without generating
-        // code for bounds checking.
+        // code for bounds checking and accessing the calldata offset and length
+        // parameters.
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            signature.offset := add(
-                encodedTrade.offset,
-                CONSTANT_SIZE_TRADE_LENGTH
+            let usedCalldataLength := sub(
+                unprocessedCalldataPointer,
+                encodedTrade.offset
             )
-            signature.length := sub(
-                encodedTrade.length,
-                CONSTANT_SIZE_TRADE_LENGTH
-            )
+
+            if gt(usedCalldataLength, encodedTrade.length) {
+                // "GPv2: trade data too short"
+                revert(0, 0)
+            }
+
+            signature.offset := unprocessedCalldataPointer
+            signature.length := sub(encodedTrade.length, usedCalldataLength)
         }
 
         address owner;

--- a/src/ts/settlement.ts
+++ b/src/ts/settlement.ts
@@ -308,6 +308,7 @@ export class SettlementEncoder {
       signingScheme: signature.scheme,
       hasReceiver,
     };
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { receiver, validTo, appData } = normalizeOrder(order);
 
     const shortenedAppData = ethers.utils.stripZeros(

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -256,7 +256,7 @@ describe("GPv2Encoding", () => {
       // NOTE: `v` must be either `27` or `28`, so just set it to something else
       // to generate an invalid signature.
       const encodedTradeBytes = ethers.utils.arrayify(encoder.encodedTrades);
-      encodedTradeBytes[285] = 42;
+      encodedTradeBytes[191] = 42;
 
       await expect(
         encoding.decodeTradesTest(encoder.tokens, encodedTradeBytes),
@@ -274,7 +274,7 @@ describe("GPv2Encoding", () => {
       // NOTE: `v` must be either `27` or `28`, so just set it to something else
       // to generate an invalid signature.
       const encodedTradeBytes = ethers.utils.arrayify(encoder.encodedTrades);
-      encodedTradeBytes[285] = 42;
+      encodedTradeBytes[191] = 42;
 
       await expect(
         encoding.decodeTradesTest(encoder.tokens, encodedTradeBytes),
@@ -329,6 +329,25 @@ describe("GPv2Encoding", () => {
       expect(tokens.pop()).to.equal(lastToken);
       await expect(encoding.decodeTradesTest(tokens, encoder.encodedTrades)).to
         .be.reverted;
+    });
+
+    it("should revert if appData does not fit a bytes32", async () => {
+      const encoder = new SettlementEncoder(testDomain);
+
+      await encoder.signEncodeTrade(
+        {
+          ...sampleOrder,
+          appData: 2 ** 25 - 1,
+        },
+        traders[0],
+        SigningScheme.ETHSIGN,
+      );
+
+      const encodedTradeBytes = ethers.utils.arrayify(encoder.encodedTrades);
+      encodedTradeBytes[2 + 91] = 42;
+
+      await expect(encoding.decodeTradesTest(encoder.tokens, encodedTradeBytes))
+        .to.be.reverted;
     });
 
     it("should verify EIP-1271 contract signatures by returning owner", async () => {
@@ -455,7 +474,7 @@ describe("GPv2Encoding", () => {
 
       const encodedTrades = ethers.utils.arrayify(encoder.encodedTrades);
 
-      encodedTrades[2 + 154] |= 0b11000000;
+      encodedTrades[2 + 0] |= 0b11000000;
       await expect(
         encoding.decodeTradesTest(encoder.tokens, encodedTrades),
       ).to.be.revertedWith("GPv2: invalid signature scheme");


### PR DESCRIPTION
Draft PR to estimate the gas savings and extra complexity from implementing #378. It saves about 140 gas/trade.

```
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
            2 |           10 |            0 |            0 |       748467  (change: -144 / trade)
            3 |           10 |            0 |            0 |       749023  (change: -148 / trade)
            4 |           10 |            0 |            0 |       757955  (change: -149 / trade)
            5 |           10 |            0 |            0 |       762687  (change: -144 / trade)
            6 |           10 |            0 |            0 |       758959  (change: -149 / trade)
            7 |           10 |            0 |            0 |       767903  (change: -148 / trade)
            8 |           10 |            0 |            0 |       772623  (change: -139 / trade)
            8 |           20 |            0 |            0 |      1464723  (change: -122 / trade)
            8 |           30 |            0 |            0 |      2109726  (change: -131 / trade)
            8 |           40 |            0 |            0 |      2759741  (change: -129 / trade)
            8 |           50 |            0 |            0 |      3409097  (change: -130 / trade)
            8 |           60 |            0 |            0 |      4055464  (change: -124 / trade)
            8 |           70 |            0 |            0 |      4705826  (change: -126 / trade)
            8 |           80 |            0 |            0 |      5356482  (change: -122 / trade)
            2 |           10 |            1 |            0 |       819119  (change: -134 / trade)
            2 |           10 |            2 |            0 |       864842  (change: -135 / trade)
            2 |           10 |            3 |            0 |       910602  (change: -134 / trade)
            2 |           10 |            4 |            0 |       956186  (change: -136 / trade)
            2 |           10 |            5 |            0 |      1001959  (change: -140 / trade)
            2 |           10 |            6 |            0 |      1047768  (change: -131 / trade)
            2 |           10 |            7 |            0 |      1093507  (change: -134 / trade)
            2 |           10 |            8 |            0 |      1139130  (change: -135 / trade)
            2 |           50 |            0 |           10 |      3135065  (change: -123 / trade)
            2 |           50 |            0 |           15 |      3091629  (change: -124 / trade)
            2 |           50 |            0 |           20 |      3048173  (change: -125 / trade)
            2 |           50 |            0 |           25 |      3004869  (change: -125 / trade)
            2 |           50 |            0 |           30 |      2961565  (change: -125 / trade)
            2 |           50 |            0 |           35 |      2918189  (change: -125 / trade)
            2 |           50 |            0 |           40 |      2874805  (change: -123 / trade)
            2 |           50 |            0 |           45 |      2831501  (change: -123 / trade)
            2 |           50 |            0 |           50 |      2788149  (change: -124 / trade)
            2 |            2 |            0 |            0 |       185477  (change: -174 / trade)
            2 |            1 |            1 |            0 |       185607  (change: -180 / trade)
           10 |          100 |           10 |           20 |      7163892  (change: -120 / trade)
```

### Test Plan

Not ready.