### PR TITLE
Move order struct to library

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -237,7 +237,7 @@ contract GPv2Settlement is ReentrancyGuard, StorageAccessible {
         uint256 buyPrice,
         GPv2TradeExecution.Data memory executedTrade
     ) internal {
-        GPv2Encoding.Order memory order = trade.order;
+        GPv2Order.Data memory order = trade.order;
 
         // solhint-disable-next-line not-rely-on-time
         require(order.validTo >= block.timestamp, "GPv2: order expired");
@@ -280,7 +280,7 @@ contract GPv2Settlement is ReentrancyGuard, StorageAccessible {
         // instead of consuming all of the remaining transaction gas when
         // dividing by zero, so no extra checks are needed for those operations.
 
-        if (order.kind == GPv2Encoding.ORDER_KIND_SELL) {
+        if (order.kind == GPv2Order.SELL) {
             if (order.partiallyFillable) {
                 executedSellAmount = trade.executedAmount;
                 executedFeeAmount =

--- a/src/contracts/libraries/GPv2Order.sol
+++ b/src/contracts/libraries/GPv2Order.sol
@@ -6,6 +6,133 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 /// @title Gnosis Protocol v2 Order Library
 /// @author Gnosis Developers
 library GPv2Order {
+    /// @dev The complete data for a Gnosis Protocol order. This struct contains
+    /// all order parameters that are signed for submitting to GP.
+    struct Data {
+        IERC20 sellToken;
+        IERC20 buyToken;
+        address receiver;
+        uint256 sellAmount;
+        uint256 buyAmount;
+        uint32 validTo;
+        bytes32 appData;
+        uint256 feeAmount;
+        bytes32 kind;
+        bool partiallyFillable;
+    }
+
+    /// @dev The order EIP-712 type hash for the [`GPv2Order.Data`] struct.
+    ///
+    /// This value is pre-computed from the following expression:
+    /// ```
+    /// keccak256(
+    ///     "Order(" +
+    ///         "address sellToken," +
+    ///         "address buyToken," +
+    ///         "address receiver," +
+    ///         "uint256 sellAmount," +
+    ///         "uint256 buyAmount," +
+    ///         "uint32 validTo," +
+    ///         "bytes32 appData," +
+    ///         "uint256 feeAmount," +
+    ///         "string kind," +
+    ///         "bool partiallyFillable" +
+    ///     ")"
+    /// )
+    /// ```
+    bytes32 internal constant TYPE_HASH =
+        hex"d604be04a8c6d2df582ec82eba9b65ce714008acbf9122dd95e499569c8f1a80";
+
+    /// @dev The marker value for a sell order for computing the order struct
+    /// hash. This allows the EIP-712 compatible wallets to display a
+    /// descriptive string for the order kind (instead of 0 or 1).
+    ///
+    /// This value is pre-computed from the following expression:
+    /// ```
+    /// keccak256("sell")
+    /// ```
+    bytes32 internal constant SELL =
+        hex"f3b277728b3fee749481eb3e0b3b48980dbbab78658fc419025cb16eee346775";
+
+    /// @dev The OrderKind marker value for a buy order for computing the order
+    /// struct hash.
+    ///
+    /// This value is pre-computed from the following expression:
+    /// ```
+    /// keccak256("buy")
+    /// ```
+    bytes32 internal constant BUY =
+        hex"6ed88e868af0a1983e3886d5f3e95a2fafbd6c3450bc229e27342283dc429ccc";
+
+    /// @dev The byte length of an order unique identifier.
+    uint256 internal constant UID_LENGTH = 56;
+
+    /// @dev Return the EIP-712 struct hash for the specified order.
+    ///
+    /// @param order The order to compute the EIP-712 struct hash for.
+    /// @return orderDigest The 32 byte EIP-712 struct hash.
+    function hash(Data memory order)
+        internal
+        pure
+        returns (bytes32 orderDigest)
+    {
+        // NOTE: Compute the EIP-712 order struct hash in place. The hash is
+        // computed from the order type hash concatenated with the ABI
+        // encoded order fields for a total of `11 * sizeof(uint) = 352`
+        // bytes. Fortunately, since Solidity memory structs **are not**
+        // packed, they are already laid out in memory exactly as is needed
+        // to compute the struct hash, just requiring the order type hash to
+        // be temporarily written to the memory slot coming right before the
+        // order data.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            let dataStart := sub(order, 32)
+            let temp := mload(dataStart)
+            mstore(dataStart, TYPE_HASH)
+            orderDigest := keccak256(dataStart, 352)
+            mstore(dataStart, temp)
+        }
+    }
+
+    /// @dev Packs order UID parameters into the specified memory location. The
+    /// result is equivalent to `abi.encodePacked(...)` with the difference that
+    /// it allows re-using the memory for packing the order UID.
+    function packOrderUidParams(
+        bytes memory orderUid,
+        bytes32 orderDigest,
+        address owner,
+        uint32 validTo
+    ) internal pure {
+        require(orderUid.length == UID_LENGTH, "GPv2: uid buffer overflow");
+
+        // NOTE: Write the order UID to the allocated memory buffer. The order
+        // parameters are written to memory in **reverse order** as memory
+        // operations write 32-bytes at a time and we want to use a packed
+        // encoding. This means, for example, that after writing the value of
+        // `owner` to bytes `20:52`, writing the `orderDigest` to bytes `0:32`
+        // will **overwrite** bytes `20:32`. This is desirable as addresses are
+        // only 20 bytes and `20:32` should be `0`s:
+        //
+        //        |           1111111111222222222233333333334444444444555555
+        //   byte | 01234567890123456789012345678901234567890123456789012345
+        // -------+---------------------------------------------------------
+        //  field | [.........orderDigest..........][......owner.......][vT]
+        // -------+---------------------------------------------------------
+        // mstore |                         [000000000000000000000000000.vT]
+        //        |                     [00000000000.......owner.......]
+        //        | [.........orderDigest..........]
+        //
+        // Additionally, since Solidity `bytes memory` are length prefixed,
+        // 32 needs to be added to all the offsets.
+        //
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            mstore(add(orderUid, 56), validTo)
+            mstore(add(orderUid, 52), owner)
+            mstore(add(orderUid, 32), orderDigest)
+        }
+    }
+
     /// @dev Extracts specific order information from the standardized unique
     /// order id of the protocol.
     ///
@@ -27,7 +154,8 @@ library GPv2Order {
             uint32 validTo
         )
     {
-        require(orderUid.length == 32 + 20 + 4, "GPv2: invalid uid");
+        require(orderUid.length == UID_LENGTH, "GPv2: invalid uid");
+
         // Use assembly to efficiently decode packed calldata.
         // solhint-disable-next-line no-inline-assembly
         assembly {

--- a/src/contracts/libraries/GPv2Order.sol
+++ b/src/contracts/libraries/GPv2Order.sol
@@ -97,6 +97,14 @@ library GPv2Order {
     /// @dev Packs order UID parameters into the specified memory location. The
     /// result is equivalent to `abi.encodePacked(...)` with the difference that
     /// it allows re-using the memory for packing the order UID.
+    ///
+    /// This function reverts if the order UID buffer is not the correct size.
+    ///
+    /// @param orderUid The buffer pack the order UID parameters into.
+    /// @param orderDigest The EIP-712 struct digest derived from the order
+    /// parameters.
+    /// @param owner The address of the user who owns this order.
+    /// @param validTo The epoch time at which the order will stop being valid.
     function packOrderUidParams(
         bytes memory orderUid,
         bytes32 orderDigest,

--- a/src/contracts/test/GPv2EncodingTestInterface.sol
+++ b/src/contracts/test/GPv2EncodingTestInterface.sol
@@ -15,10 +15,6 @@ contract GPv2EncodingTestInterface {
             )
         );
 
-    function orderTypeHashTest() external pure returns (bytes32) {
-        return (GPv2Encoding.ORDER_TYPE_HASH);
-    }
-
     function tradeCountTest(bytes calldata encodedTrades)
         external
         pure

--- a/src/contracts/test/GPv2OrderTestInterface.sol
+++ b/src/contracts/test/GPv2OrderTestInterface.sol
@@ -5,7 +5,29 @@ pragma abicoder v2;
 import "../libraries/GPv2Order.sol";
 
 contract GPv2OrderTestInterface {
-    using GPv2Order for bytes;
+    using GPv2Order for *;
+
+    function typeHashTest() external pure returns (bytes32) {
+        return GPv2Order.TYPE_HASH;
+    }
+
+    function hashTest(GPv2Order.Data memory order)
+        external
+        pure
+        returns (bytes32 orderDigest)
+    {
+        orderDigest = order.hash();
+    }
+
+    function packOrderUidParamsTest(
+        uint256 bufferLength,
+        bytes32 orderDigest,
+        address owner,
+        uint32 validTo
+    ) external pure returns (bytes memory orderUid) {
+        orderUid = new bytes(bufferLength);
+        orderUid.packOrderUidParams(orderDigest, owner, validTo);
+    }
 
     function extractOrderUidParamsTest(bytes calldata orderUid)
         external

--- a/src/ts/order.ts
+++ b/src/ts/order.ts
@@ -143,17 +143,27 @@ export function hashify(h: HashLike): string {
 }
 
 /**
+ * Normalized representation of an [`Order`] for EIP-712 operations.
+ */
+export type NormalizedOrder = Omit<Order, "validTo" | "appData" | "kind"> & {
+  receiver: string;
+  validTo: number;
+  appData: string;
+  kind: string;
+};
+
+/**
  * Normalizes an order for hashing and signing, so that it can be used with
  * Ethers.js for EIP-712 operations.
  * @param hashLike A hash-like value to normalize.
  * @returns A 32-byte hash encoded as a hex-string.
  */
-export function normalizeOrder(order: Order): Record<string, unknown> {
+export function normalizeOrder(order: Order): NormalizedOrder {
   return {
+    receiver: ethers.constants.AddressZero,
     ...order,
-    receiver: order.receiver ?? ethers.constants.AddressZero,
-    appData: hashify(order.appData),
     validTo: timestamp(order.validTo),
+    appData: hashify(order.appData),
   };
 }
 

--- a/test/GPv2Encoding.test.ts
+++ b/test/GPv2Encoding.test.ts
@@ -4,12 +4,10 @@ import { artifacts, ethers, waffle } from "hardhat";
 
 import {
   EIP1271_MAGICVALUE,
-  ORDER_TYPE_HASH,
   OrderKind,
   SettlementEncoder,
   SigningScheme,
   computeOrderUid,
-  extractOrderUidParams,
   hashOrder,
   eip1271Message,
 } from "../src/ts";
@@ -56,12 +54,6 @@ describe("GPv2Encoding", () => {
       expect(await encoding.DOMAIN_SEPARATOR()).to.equal(
         ethers.utils._TypedDataEncoder.hashDomain(testDomain),
       );
-    });
-  });
-
-  describe("ORDER_TYPE_HASH", () => {
-    it("should be match the EIP-712 order type hash", async () => {
-      expect(await encoding.orderTypeHashTest()).to.equal(ORDER_TYPE_HASH);
     });
   });
 
@@ -176,25 +168,6 @@ describe("GPv2Encoding", () => {
       expect(buyTokenIndex).to.equal(
         encoder.tokens.indexOf(sampleOrder.buyToken),
       );
-    });
-
-    it("should compute EIP-712 order struct hash", async () => {
-      const encoder = new SettlementEncoder(testDomain);
-      await encoder.signEncodeTrade(
-        sampleOrder,
-        traders[0],
-        SigningScheme.EIP712,
-      );
-
-      const { trades } = await encoding.decodeTradesTest(
-        encoder.tokens,
-        encoder.encodedTrades,
-      );
-
-      const { orderDigest } = extractOrderUidParams(
-        decodeTrade(trades[0]).orderUid,
-      );
-      expect(orderDigest).to.equal(hashOrder(sampleOrder));
     });
 
     it("should compute order unique identifier", async () => {

--- a/test/encoding.ts
+++ b/test/encoding.ts
@@ -1,7 +1,7 @@
-import type { BigNumber } from "ethers";
+import { BigNumber } from "ethers";
 import { ethers } from "hardhat";
 
-import { Order, OrderKind } from "../src/ts";
+import { Order, OrderKind, normalizeOrder } from "../src/ts";
 
 export type AbiOrder = [
   string,
@@ -10,11 +10,27 @@ export type AbiOrder = [
   BigNumber,
   BigNumber,
   number,
-  number,
+  string,
   BigNumber,
   string,
   boolean,
 ];
+
+export function encodeOrder(order: Order): AbiOrder {
+  const o = normalizeOrder(order);
+  return [
+    o.sellToken,
+    o.buyToken,
+    o.receiver,
+    BigNumber.from(o.sellAmount),
+    BigNumber.from(o.buyAmount),
+    o.validTo,
+    o.appData,
+    BigNumber.from(o.feeAmount),
+    ethers.utils.id(o.kind),
+    o.partiallyFillable,
+  ];
+}
 
 export type AbiTrade = [
   AbiOrder,
@@ -38,7 +54,7 @@ export interface Trade {
 
 export function decodeOrderKind(kindHash: string): OrderKind {
   for (const kind of [OrderKind.SELL, OrderKind.BUY]) {
-    if (kindHash == ethers.utils.keccak256(ethers.utils.toUtf8Bytes(kind))) {
+    if (kindHash == ethers.utils.id(kind)) {
       return kind;
     }
   }


### PR DESCRIPTION
This PR just moves the `Order` struct into the `GPv2Order` library in preparation for removing assembly trade decoding.

### Test Plan

CI, moved unit tests around and added new ones around order UID packing.
