### PR TITLE
[upgradable authenticator] Proxy reader

### DIFF
--- a/src/ts/deploy.ts
+++ b/src/ts/deploy.ts
@@ -34,7 +34,7 @@ export type ContractName = typeof CONTRACT_NAMES[keyof typeof CONTRACT_NAMES];
 export type DeploymentArguments<
   T extends ContractName
 > = T extends typeof CONTRACT_NAMES.authenticator
-  ? [string]
+  ? never
   : T extends typeof CONTRACT_NAMES.settlement
   ? [string]
   : unknown[];

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -25,4 +25,5 @@ export * from "./settlement";
 export * from "./reader";
 export * from "./deploy";
 export * from "./sign";
+export * from "./proxy";
 export * from "./types/ethers";

--- a/src/ts/proxy.ts
+++ b/src/ts/proxy.ts
@@ -1,0 +1,49 @@
+// defined in https://eips.ethereum.org/EIPS/eip-1967
+
+import { BigNumber } from "ethers";
+import { ethers } from "hardhat";
+
+// The proxy contract used by hardhat-deploy implements EIP-1967 (Standard Proxy
+// Storage Slot). See <https://eips.ethereum.org/EIPS/eip-1967>.
+function slot(string: string) {
+  return ethers.utils.defaultAbiCoder.encode(
+    ["bytes32"],
+    [
+      BigNumber.from(
+        ethers.utils.keccak256(ethers.utils.toUtf8Bytes(string)),
+      ).sub(1),
+    ],
+  );
+}
+const IMPLEMENTATION_STORAGE_SLOT = slot("eip1967.proxy.implementation");
+const OWNER_STORAGE_SLOT = slot("eip1967.proxy.admin");
+
+/**
+ * Returns the address of the implementation of an EIP-1967-compatible proxy
+ * from its address.
+ *
+ * @param proxy Address of the proxy contract.
+ * @returns The address of the contract storing the proxy implementation.
+ */
+export async function implementationAddress(proxy: string): Promise<string> {
+  const [implementation] = await ethers.utils.defaultAbiCoder.decode(
+    ["address"],
+    await ethers.provider.getStorageAt(proxy, IMPLEMENTATION_STORAGE_SLOT),
+  );
+  return implementation;
+}
+
+/**
+ * Returns the address of the imple mentation of an EIP-1967-compatible proxy
+ * from its address.
+ *
+ * @param proxy Address of the proxy contract.
+ * @returns The address of the administrator of the proxy.
+ */
+export async function ownerAddress(proxy: string): Promise<string> {
+  const [owner] = await ethers.utils.defaultAbiCoder.decode(
+    ["address"],
+    await ethers.provider.getStorageAt(proxy, OWNER_STORAGE_SLOT),
+  );
+  return owner;
+}

--- a/test/e2e/deployment.test.ts
+++ b/test/e2e/deployment.test.ts
@@ -6,6 +6,7 @@ import {
   ContractName,
   DeploymentArguments,
   deterministicDeploymentAddress,
+  implementationAddress,
 } from "../../src/ts";
 import { builtAndDeployedMetadataCoincide } from "../bytecode";
 
@@ -45,7 +46,7 @@ describe("E2E: Deployment", () => {
     it("authenticator", async () => {
       expect(
         await builtAndDeployedMetadataCoincide(
-          authenticator.address,
+          await implementationAddress(authenticator.address),
           "GPv2AllowListAuthentication",
         ),
       ).to.be.true;

--- a/test/e2e/deployment.test.ts
+++ b/test/e2e/deployment.test.ts
@@ -73,9 +73,9 @@ describe("E2E: Deployment", () => {
 
   describe("deterministic addresses", () => {
     it("authenticator", async () => {
-      expect(
-        await contractAddress("GPv2AllowListAuthentication", owner.address),
-      ).to.equal(authenticator.address);
+      expect(await contractAddress("GPv2AllowListAuthentication")).to.equal(
+        await implementationAddress(authenticator.address),
+      );
     });
 
     it("settlement", async () => {


### PR DESCRIPTION
(PR is part of the work in #167 to make the authenticator upgradable.)

Adds a small library to recover the implementation and the owner of EIP-1967-compatible proxies.

The two failing tests from #167 are fixed by referencing to the proxy implementation.
Next steps, in no particular order:
1. test that the address of the proxy is deterministic
2. test that the owner is the expected address, and 
3. test that the proxy upgrade process works.

### Test Plan

Implementation retrieval is used in the existing unit tests. Owner retrieval is untested.
