### PR TITLE
Convert signing library to a mixin

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -65,6 +65,9 @@ export default {
     ],
   },
   networks: {
+    hardhat: {
+      blockGasLimit: 12.5e6,
+    },
     mainnet: {
       ...sharedNetworkConfig,
       url: `https://mainnet.infura.io/v3/${INFURA_KEY}`,

--- a/src/contracts/libraries/GPv2Trade.sol
+++ b/src/contracts/libraries/GPv2Trade.sol
@@ -2,15 +2,14 @@
 pragma solidity ^0.7.6;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "../mixins/GPv2Signing.sol";
 import "./GPv2Order.sol";
-import "./GPv2Signing.sol";
 
 /// @title Gnosis Protocol v2 Trade Library.
 /// @author Gnosis Developers
 library GPv2Trade {
     using GPv2Order for GPv2Order.Data;
     using GPv2Order for bytes;
-    using GPv2Signing for GPv2Order.Data;
 
     /// @dev A struct representing a trade to be executed as part a batch
     /// settlement.

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -4,7 +4,6 @@ pragma abicoder v2;
 
 import "../GPv2Settlement.sol";
 import "../libraries/GPv2Interaction.sol";
-import "../libraries/GPv2Signing.sol";
 import "../libraries/GPv2Trade.sol";
 import "../libraries/GPv2TradeExecution.sol";
 
@@ -25,7 +24,7 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
     }
 
     function computeTradeExecutionMemoryTest() external returns (uint256 mem) {
-        GPv2Signing.RecoveredOrder memory recoveredOrder;
+        RecoveredOrder memory recoveredOrder;
         GPv2TradeExecution.Data memory executedTrade;
 
         // NOTE: Solidity stores the free memory pointer at address 0x40. Read

--- a/src/contracts/test/GPv2SigningTestInterface.sol
+++ b/src/contracts/test/GPv2SigningTestInterface.sol
@@ -3,31 +3,19 @@ pragma solidity ^0.7.6;
 pragma abicoder v2;
 
 import "../libraries/GPv2Order.sol";
-import "../libraries/GPv2Signing.sol";
 import "../libraries/GPv2Trade.sol";
+import "../mixins/GPv2Signing.sol";
 
-contract GPv2SigningTestInterface {
-    using GPv2Signing for GPv2Order.Data;
-    using GPv2Signing for GPv2Signing.RecoveredOrder;
-
-    bytes32 public constant DOMAIN_SEPARATOR =
-        keccak256(
-            abi.encode(
-                keccak256("EIP712Domain(string name)"),
-                keccak256("test")
-            )
-        );
-
+contract GPv2SigningTestInterface is GPv2Signing {
     function recoverOrderFromTradeTest(
         IERC20[] calldata tokens,
         GPv2Trade.Data calldata trade
     )
         external
         view
-        returns (GPv2Signing.RecoveredOrder memory recoveredOrder, uint256 mem)
+        returns (RecoveredOrder memory recoveredOrder, uint256 mem)
     {
-        bytes32 domainSeparator = DOMAIN_SEPARATOR;
-        recoveredOrder = GPv2Signing.allocateRecoveredOrder();
+        recoveredOrder = allocateRecoveredOrder();
 
         // NOTE: Solidity stores the free memory pointer at address 0x40. Read
         // it before and after calling `processOrder` to ensure that there are
@@ -37,7 +25,7 @@ contract GPv2SigningTestInterface {
             mem := mload(0x40)
         }
 
-        recoveredOrder.recoverOrderFromTrade(domainSeparator, tokens, trade);
+        recoverOrderFromTrade(recoveredOrder, tokens, trade);
 
         // solhint-disable-next-line no-inline-assembly
         assembly {
@@ -50,10 +38,6 @@ contract GPv2SigningTestInterface {
         GPv2Signing.Scheme signingScheme,
         bytes calldata signature
     ) external view returns (address owner) {
-        (, owner) = order.recoverOrderSigner(
-            DOMAIN_SEPARATOR,
-            signingScheme,
-            signature
-        );
+        (, owner) = recoverOrderSigner(order, signingScheme, signature);
     }
 }

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -52,26 +52,6 @@ describe("GPv2Settlement", () => {
     testDomain = domain(chainId, settlement.address);
   });
 
-  describe("domainSeparator", () => {
-    it("should have an EIP-712 domain separator", async () => {
-      expect(await settlement.domainSeparator()).to.equal(
-        ethers.utils._TypedDataEncoder.hashDomain(testDomain),
-      );
-    });
-
-    it("should have a different replay protection for each deployment", async () => {
-      const GPv2Settlement = await ethers.getContractFactory(
-        "GPv2SettlementTestInterface",
-        deployer,
-      );
-      const settlement2 = await GPv2Settlement.deploy(authenticator.address);
-
-      expect(await settlement.domainSeparator()).to.not.equal(
-        await settlement2.domainSeparator(),
-      );
-    });
-  });
-
   describe("authenticator", () => {
     it("should be set to the authenticator the contract was initialized with", async () => {
       expect(await settlement.authenticator()).to.equal(authenticator.address);


### PR DESCRIPTION
This PR converts the `GPv2Siging` library to a mixin (i.e. abstract contract). This allows a couple things:
- The domain separator does not need to be passed around everywhere
- It can have storage for `presign` scheme

### Test Plan

Adjusted tests still pass.
