### PR TITLE
Add presign scheme

### DIFF
--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -11,8 +11,8 @@ import {
   SettlementEncoder,
   SigningScheme,
   TypedDataDomain,
-  computeOrderUid,
   domain,
+  packOrderUidParams,
 } from "../src/ts";
 import { deployTestContracts, TestDeployment } from "../test/e2e/fixture";
 
@@ -293,7 +293,7 @@ export class BenchFixture {
     for (let i = 0; i < options.refunds; i++) {
       const trader = traders[i % traders.length];
       const key = (i + 1).toString(16).padStart(2, "0");
-      const orderUid = computeOrderUid({
+      const orderUid = packOrderUidParams({
         orderDigest: `0x${key}${"42".repeat(31)}`,
         owner: trader.address,
         validTo: 0,

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -356,6 +356,7 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
             // solhint-disable-next-line not-rely-on-time
             require(validTo < block.timestamp, "GPv2: order still valid");
             filledAmount[orderUid] = 0;
+            preSignature[orderUid] = false;
         }
     }
 }

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -135,6 +135,7 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
     }
 
     /// @dev Invalidate onchain an order that has been signed offline.
+    ///
     /// @param orderUid The unique identifier of the order that is to be made
     /// invalid after calling this function. The user that created the order
     /// must be the the sender of this message. See [`extractOrderUidParams`]
@@ -151,6 +152,7 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
     ///
     /// This method reverts if processing of any single trade fails. See
     /// [`computeTradeExecution`] for more details.
+    ///
     /// @param tokens An array of ERC20 tokens to be traded in the settlement.
     /// @param clearingPrices An array of token clearing prices.
     /// @param trades Trades for signed orders.

--- a/src/contracts/libraries/GPv2Trade.sol
+++ b/src/contracts/libraries/GPv2Trade.sol
@@ -78,7 +78,7 @@ library GPv2Trade {
     ///                                    00: EIP-712
     ///                                    01: eth_sign
     ///                                    10: EIP-1271
-    ///                                    11: reserved
+    ///                                    11: pre_sign
     /// ```
     function extractFlags(uint256 flags)
         internal
@@ -98,8 +98,7 @@ library GPv2Trade {
 
         // NOTE: Take advantage of the fact that Solidity will revert if the
         // following expression does not produce a valid enum value. This means
-        // we simultaneously check here that the leading reserved bits must be
-        // 0 and that the reserved `0b11` scheme value is not used.
+        // we check here that the leading reserved bits must be 0.
         signingScheme = GPv2Signing.Scheme(flags >> 2);
     }
 }

--- a/src/contracts/mixins/GPv2Signing.sol
+++ b/src/contracts/mixins/GPv2Signing.sol
@@ -42,8 +42,8 @@ abstract contract GPv2Signing {
     /// GPv2 contracts.
     bytes32 public immutable domainSeparator;
 
-    /// @dev Storage indicating whether or not an order has been signed for by
-    /// a particular address.
+    /// @dev Storage indicating whether or not an order has been signed by a
+    /// particular address.
     mapping(bytes => bool) public preSignature;
 
     constructor() {

--- a/src/contracts/mixins/GPv2Signing.sol
+++ b/src/contracts/mixins/GPv2Signing.sol
@@ -20,7 +20,7 @@ abstract contract GPv2Signing {
     }
 
     /// @dev Signing scheme used for recovery.
-    enum Scheme {Eip712, EthSign, Eip1271}
+    enum Scheme {Eip712, EthSign, Eip1271, PreSign}
 
     /// @dev The EIP-712 domain type hash used for computing the domain
     /// separator.
@@ -42,6 +42,10 @@ abstract contract GPv2Signing {
     /// GPv2 contracts.
     bytes32 public immutable domainSeparator;
 
+    /// @dev Storage indicating whether or not an order has been signed for by
+    /// a particular address.
+    mapping(bytes => bool) public preSignature;
+
     constructor() {
         // NOTE: Currently, the only way to get the chain ID in solidity is
         // using assembly.
@@ -60,6 +64,15 @@ abstract contract GPv2Signing {
                 address(this)
             )
         );
+    }
+
+    /// @dev Sets a presignature for the specified order UID.
+    ///
+    /// @param orderUid The unique identifier of the order to pre-sign.
+    function setPreSignature(bytes calldata orderUid, bool signed) external {
+        (, address owner, ) = orderUid.extractOrderUidParams();
+        require(owner == msg.sender, "GPv2: cannot presign order");
+        preSignature[orderUid] = signed;
     }
 
     /// @dev Returns an empty recovered order with a pre-allocated buffer for
@@ -130,6 +143,8 @@ abstract contract GPv2Signing {
             owner = recoverEthsignSigner(orderDigest, signature);
         } else if (signingScheme == Scheme.Eip1271) {
             owner = recoverEip1271Signer(orderDigest, signature);
+        } else if (signingScheme == Scheme.PreSign) {
+            owner = recoverPreSigner(orderDigest, signature, order.validTo);
         }
 
         // Manually set the free memory pointer back to what it was at the start
@@ -274,6 +289,11 @@ abstract contract GPv2Signing {
     ///
     /// This function enforces that the encoded data stores enough bytes to
     /// cover the full length of the decoded signature.
+    ///
+    /// @param encodedSignature The encoded EIP-1271 signature.
+    /// @param orderDigest The EIP-712 signing digest derived from the order
+    /// parameters.
+    /// @return owner The address of the signer.
     function recoverEip1271Signer(
         bytes32 orderDigest,
         bytes calldata encodedSignature
@@ -296,5 +316,33 @@ abstract contract GPv2Signing {
                 GPv2EIP1271.MAGICVALUE,
             "GPv2: invalid eip1271 signature"
         );
+    }
+
+    /// @dev Verifies the order has been pre-signed. The signature is the
+    /// address of the signer of the order.
+    ///
+    /// @param orderDigest The EIP-712 signing digest derived from the order
+    /// parameters.
+    /// @param encodedSignature The pre-sign signature reprenting the order UID.
+    /// @param validTo The order expiry timestamp.
+    /// @return owner The address of the signer.
+    function recoverPreSigner(
+        bytes32 orderDigest,
+        bytes calldata encodedSignature,
+        uint32 validTo
+    ) internal view returns (address owner) {
+        require(encodedSignature.length == 20, "GPv2: malformed presign sig");
+        // NOTE: Use assembly to read the owner address from the encoded
+        // signature bytes.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // owner = address(encodedSignature[0:20])
+            owner := shr(96, calldataload(encodedSignature.offset))
+        }
+
+        bytes memory orderUid = new bytes(GPv2Order.UID_LENGTH);
+        orderUid.packOrderUidParams(orderDigest, owner, validTo);
+
+        require(preSignature[orderUid], "GPv2: invalid presign signature");
     }
 }

--- a/src/contracts/mixins/GPv2Signing.sol
+++ b/src/contracts/mixins/GPv2Signing.sol
@@ -331,7 +331,7 @@ abstract contract GPv2Signing {
         bytes calldata encodedSignature,
         uint32 validTo
     ) internal view returns (address owner) {
-        require(encodedSignature.length == 20, "GPv2: malformed presign sig");
+        require(encodedSignature.length == 20, "GPv2: malformed presignature");
         // NOTE: Use assembly to read the owner address from the encoded
         // signature bytes.
         // solhint-disable-next-line no-inline-assembly
@@ -343,6 +343,6 @@ abstract contract GPv2Signing {
         bytes memory orderUid = new bytes(GPv2Order.UID_LENGTH);
         orderUid.packOrderUidParams(orderDigest, owner, validTo);
 
-        require(preSignature[orderUid], "GPv2: invalid presign signature");
+        require(preSignature[orderUid], "GPv2: order not presigned");
     }
 }

--- a/src/contracts/reader/SettlementStorageReader.sol
+++ b/src/contracts/reader/SettlementStorageReader.sol
@@ -9,6 +9,7 @@ contract SettlementStorageReader {
     // This sneaky storage member is inherited through ReentrancyGuard
     uint256 private _status;
 
+    mapping(bytes => uint256) public preSignature;
     mapping(bytes => uint256) public filledAmount;
 
     function filledAmountsForOrders(bytes[] calldata orderUids)

--- a/src/ts/order.ts
+++ b/src/ts/order.ts
@@ -211,6 +211,21 @@ export interface OrderUidParams {
 }
 
 /**
+ * Computes the order UID for an order and the given owner.
+ */
+export function computeOrderUid(
+  domain: TypedDataDomain,
+  order: Order,
+  owner: string,
+): string {
+  return packOrderUidParams({
+    orderDigest: orderSigningHash(domain, order),
+    owner,
+    validTo: order.validTo,
+  });
+}
+
+/**
  * Compute the unique identifier describing a user order in the settlement
  * contract.
  *
@@ -218,7 +233,7 @@ export interface OrderUidParams {
  * identifier.
  * @returns A string that unequivocally identifies the order of the user.
  */
-export function computeOrderUid({
+export function packOrderUidParams({
   orderDigest,
   owner,
   validTo,

--- a/src/ts/settlement.ts
+++ b/src/ts/settlement.ts
@@ -11,9 +11,7 @@ import {
   Order,
   OrderFlags,
   OrderKind,
-  extractOrderUidParams,
   normalizeOrder,
-  packOrderUidParams,
 } from "./order";
 import {
   EcdsaSigningScheme,
@@ -201,9 +199,7 @@ function encodeSignatureData(sig: Signature): string {
     case SigningScheme.EIP1271:
       return encodeEip1271SignatureData(sig.data);
     case SigningScheme.PRESIGN:
-      return packOrderUidParams(
-        extractOrderUidParams(ethers.utils.hexlify(sig.data)),
-      );
+      return ethers.utils.getAddress(sig.data);
     default:
       throw new Error("unsupported signing scheme");
   }

--- a/src/ts/settlement.ts
+++ b/src/ts/settlement.ts
@@ -11,7 +11,9 @@ import {
   Order,
   OrderFlags,
   OrderKind,
+  extractOrderUidParams,
   normalizeOrder,
+  packOrderUidParams,
 } from "./order";
 import {
   EcdsaSigningScheme,
@@ -151,6 +153,8 @@ export function encodeSigningScheme(scheme: SigningScheme): number {
       return 0b0100;
     case SigningScheme.EIP1271:
       return 0b1000;
+    case SigningScheme.PRESIGN:
+      return 0b1100;
     default:
       throw new Error("Unsupported signing scheme");
   }
@@ -196,8 +200,12 @@ function encodeSignatureData(sig: Signature): string {
       return ethers.utils.joinSignature(sig.data);
     case SigningScheme.EIP1271:
       return encodeEip1271SignatureData(sig.data);
+    case SigningScheme.PRESIGN:
+      return packOrderUidParams(
+        extractOrderUidParams(ethers.utils.hexlify(sig.data)),
+      );
     default:
-      throw new Error("invalid signing scheme");
+      throw new Error("unsupported signing scheme");
   }
 }
 

--- a/src/ts/sign.ts
+++ b/src/ts/sign.ts
@@ -109,9 +109,9 @@ export interface PreSignSignature {
    */
   scheme: SigningScheme.PRESIGN;
   /**
-   * The order UID.
+   * The address of the signer.
    */
-  data: BytesLike;
+  data: string;
 }
 
 function ecdsaSignOrder(

--- a/src/ts/sign.ts
+++ b/src/ts/sign.ts
@@ -45,6 +45,10 @@ export const enum SigningScheme {
    * <https://eips.ethereum.org/EIPS/eip-1271>
    */
   EIP1271,
+  /**
+   * Pre-signed order.
+   */
+  PRESIGN,
 }
 
 export type EcdsaSigningScheme = SigningScheme.EIP712 | SigningScheme.ETHSIGN;
@@ -52,7 +56,7 @@ export type EcdsaSigningScheme = SigningScheme.EIP712 | SigningScheme.ETHSIGN;
 /**
  * The signature of an order.
  */
-export type Signature = EcdsaSignature | Eip1271Signature;
+export type Signature = EcdsaSignature | Eip1271Signature | PreSignSignature;
 
 /**
  * ECDSA signature of an order.
@@ -94,6 +98,20 @@ export interface Eip1271Signature {
    * The signature data.
    */
   data: Eip1271SignatureData;
+}
+
+/**
+ * Signature data for a pre-signed order.
+ */
+export interface PreSignSignature {
+  /**
+   * The signing scheme used in the signature.
+   */
+  scheme: SigningScheme.PRESIGN;
+  /**
+   * The order UID.
+   */
+  data: BytesLike;
 }
 
 function ecdsaSignOrder(

--- a/test/GPv2Order.test.ts
+++ b/test/GPv2Order.test.ts
@@ -7,7 +7,7 @@ import {
   ORDER_TYPE_FIELDS,
   ORDER_UID_LENGTH,
   OrderKind,
-  computeOrderUid,
+  packOrderUidParams,
 } from "../src/ts";
 
 import { encodeOrder } from "./encoding";
@@ -73,7 +73,7 @@ describe("GPv2Order", () => {
           validTo,
         ),
       ).to.equal(
-        computeOrderUid({
+        packOrderUidParams({
           orderDigest,
           owner,
           validTo: validTo.toNumber(),
@@ -100,7 +100,7 @@ describe("GPv2Order", () => {
       const address = ethers.utils.getAddress(fillDistinctBytes(20, 1 + 32));
       const validTo = BigNumber.from(fillDistinctBytes(4, 1 + 32 + 20));
 
-      const orderUid = computeOrderUid({
+      const orderUid = packOrderUidParams({
         orderDigest,
         owner: address,
         validTo: validTo.toNumber(),

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -1083,6 +1083,19 @@ describe("GPv2Settlement", () => {
       }
     });
 
+    it("should clear pre-signatures", async () => {
+      const orderUid = packOrderUidParams({
+        orderDigest: `0x${"11".repeat(32)}`,
+        owner: traders[0].address,
+        validTo: 0,
+      });
+
+      await settlement.connect(traders[0]).setPreSignature(orderUid, true);
+      await settlement.claimOrderRefundsTest([orderUid]);
+
+      expect(await settlement.preSignature(orderUid)).to.be.false;
+    });
+
     it("should revert if the encoded order UIDs are malformed", async () => {
       const orderUid = packOrderUidParams({
         orderDigest: ethers.constants.HashZero,

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -15,7 +15,7 @@ import {
   computeOrderUid,
   domain,
   normalizeInteractions,
-  orderSigningHash,
+  packOrderUidParams,
 } from "../src/ts";
 
 import { builtAndDeployedMetadataCoincide } from "./bytecode";
@@ -114,7 +114,7 @@ describe("GPv2Settlement", () => {
 
       expect(
         await settlement.filledAmount(
-          computeOrderUid({ orderDigest, owner, validTo }),
+          packOrderUidParams({ orderDigest, owner, validTo }),
         ),
       ).to.equal(ethers.constants.Zero);
     });
@@ -258,7 +258,7 @@ describe("GPv2Settlement", () => {
     it("sets filled amount of the caller's order to max uint256", async () => {
       const orderDigest = "0x" + "11".repeat(32);
       const validTo = 2 ** 32 - 1;
-      const orderUid = computeOrderUid({
+      const orderUid = packOrderUidParams({
         orderDigest,
         owner: traders[0].address,
         validTo,
@@ -271,7 +271,7 @@ describe("GPv2Settlement", () => {
     });
 
     it("emits an OrderInvalidated event log", async () => {
-      const orderUid = computeOrderUid({
+      const orderUid = packOrderUidParams({
         orderDigest: ethers.constants.HashZero,
         owner: traders[0].address,
         validTo: 0,
@@ -292,7 +292,7 @@ describe("GPv2Settlement", () => {
     it("fails to invalidate order that is not owned by the caller", async () => {
       const orderDigest = "0x".padEnd(66, "1");
       const validTo = 2 ** 32 - 1;
-      const orderUid = computeOrderUid({
+      const orderUid = packOrderUidParams({
         orderDigest,
         owner: traders[0].address,
         validTo,
@@ -706,11 +706,7 @@ describe("GPv2Settlement", () => {
           encoder.trades,
         );
 
-        const orderUid = computeOrderUid({
-          orderDigest: orderSigningHash(testDomain, order),
-          owner: traders[0].address,
-          validTo: order.validTo,
-        });
+        const orderUid = computeOrderUid(testDomain, order, traders[0].address);
         const filledAmount = await settlement.filledAmount(orderUid);
 
         return filledAmount;
@@ -838,11 +834,7 @@ describe("GPv2Settlement", () => {
           executedSellAmount,
           executedBuyAmount,
           order.feeAmount,
-          computeOrderUid({
-            orderDigest: orderSigningHash(testDomain, order),
-            owner: traders[0].address,
-            validTo: order.validTo,
-          }),
+          computeOrderUid(testDomain, order, traders[0].address),
         );
 
       const { events } = await (await tx).wait();
@@ -1059,17 +1051,17 @@ describe("GPv2Settlement", () => {
   describe("claimOrderRefunds", () => {
     it("should set filled amount to 0 for all orders", async () => {
       const orderUids = [
-        computeOrderUid({
+        packOrderUidParams({
           orderDigest: `0x${"11".repeat(32)}`,
           owner: traders[0].address,
           validTo: 0,
         }),
-        computeOrderUid({
+        packOrderUidParams({
           orderDigest: `0x${"22".repeat(32)}`,
           owner: traders[0].address,
           validTo: 0,
         }),
-        computeOrderUid({
+        packOrderUidParams({
           orderDigest: `0x${"33".repeat(32)}`,
           owner: traders[0].address,
           validTo: 0,
@@ -1092,7 +1084,7 @@ describe("GPv2Settlement", () => {
     });
 
     it("should revert if the encoded order UIDs are malformed", async () => {
-      const orderUid = computeOrderUid({
+      const orderUid = packOrderUidParams({
         orderDigest: ethers.constants.HashZero,
         owner: ethers.constants.AddressZero,
         validTo: 0,
@@ -1109,7 +1101,7 @@ describe("GPv2Settlement", () => {
 
     it("should revert if the order is still valid", async () => {
       const orderDigest = "0x" + "11".repeat(32);
-      const orderUid = computeOrderUid({
+      const orderUid = packOrderUidParams({
         orderDigest,
         owner: traders[0].address,
         validTo: 0xffffffff,

--- a/test/GPv2Signing.test.ts
+++ b/test/GPv2Signing.test.ts
@@ -75,6 +75,32 @@ describe("GPv2Signing", () => {
     });
   });
 
+  describe("setPreSignature", () => {
+    const [owner, nonOwner] = traders;
+    const orderUid = packOrderUidParams({
+      orderDigest: ethers.constants.HashZero,
+      owner: owner.address,
+      validTo: 0xffffffff,
+    });
+
+    it("should set the pre-signature", async () => {
+      await signing.connect(owner).setPreSignature(orderUid, true);
+      expect(await signing.preSignature(orderUid)).to.be.true;
+    });
+
+    it("should unset the pre-signature", async () => {
+      await signing.connect(owner).setPreSignature(orderUid, true);
+      await signing.connect(owner).setPreSignature(orderUid, false);
+      expect(await signing.preSignature(orderUid)).to.be.false;
+    });
+
+    it("should revert if the order owner is not the transaction sender", async () => {
+      await expect(
+        signing.connect(nonOwner).setPreSignature(orderUid, true),
+      ).to.be.revertedWith("cannot presign order");
+    });
+  });
+
   describe("recoverOrderFromTrade", () => {
     it("should round-trip encode order data", async () => {
       // NOTE: Pay extra attention to use all bytes for each field, and that

--- a/test/GPv2Signing.test.ts
+++ b/test/GPv2Signing.test.ts
@@ -202,10 +202,9 @@ describe("GPv2Signing", () => {
       ];
 
       for (const [i, trade] of encoder.trades.entries()) {
-        const { owner } = await signing.recoverOrderFromTradeTest(
-          encoder.tokens,
-          trade,
-        );
+        const {
+          recoveredOrder: { owner },
+        } = await signing.recoverOrderFromTradeTest(encoder.tokens, trade);
         expect(owner).to.equal(owners[i]);
       }
     });

--- a/test/GPv2Trade.test.ts
+++ b/test/GPv2Trade.test.ts
@@ -137,16 +137,13 @@ describe("GPv2Trade", () => {
         SigningScheme.EIP712,
         SigningScheme.ETHSIGN,
         SigningScheme.EIP1271,
+        SigningScheme.PRESIGN,
       ]) {
         const {
           signingScheme: extractedScheme,
         } = await tradeLib.extractFlagsTest(encodeSigningScheme(scheme));
         expect(extractedScheme).to.deep.equal(scheme);
       }
-    });
-
-    it("should revert when encoding an invalid signing scheme", async () => {
-      await expect(tradeLib.extractFlagsTest(0b1100)).to.be.reverted;
     });
 
     it("should revert when encoding invalid flags", async () => {

--- a/test/SettlementStorageReader.test.ts
+++ b/test/SettlementStorageReader.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { Contract } from "ethers";
 import { ethers, waffle } from "hardhat";
 
-import { computeOrderUid, SettlementReader } from "../src/ts";
+import { SettlementReader, packOrderUidParams } from "../src/ts";
 
 describe("SettlementStorageReader", () => {
   const [deployer, owner, ...traders] = waffle.provider.getWallets();
@@ -29,7 +29,7 @@ describe("SettlementStorageReader", () => {
     it("returns expected filledAmounts", async () => {
       // construct 3 unique order Ids and invalidate the first two.
       const orderUids = [0, 1, 2].map((i) =>
-        computeOrderUid({
+        packOrderUidParams({
           orderDigest: "0x" + "11".repeat(32),
           owner: traders[i].address,
           validTo: 2 ** 32 - 1,

--- a/test/e2e/orderRefunds.test.ts
+++ b/test/e2e/orderRefunds.test.ts
@@ -121,7 +121,7 @@ describe("E2E: Expired Order Gas Refunds", () => {
       await settlement.connect(traders[1]).setPreSignature(buyOrderUid, true);
       encoder.encodeTrade(buyOrder, {
         scheme: SigningScheme.PRESIGN,
-        data: buyOrderUid,
+        data: traders[1].address,
       });
 
       return [encoder, [sellOrderUid, buyOrderUid]] as const;

--- a/test/e2e/orderRefunds.test.ts
+++ b/test/e2e/orderRefunds.test.ts
@@ -11,7 +11,6 @@ import {
   TypedDataDomain,
   computeOrderUid,
   domain,
-  orderSigningHash,
 } from "../../src/ts";
 
 import { deployTestContracts } from "./fixture";
@@ -107,19 +106,15 @@ describe("E2E: Expired Order Gas Refunds", () => {
         traders[0],
         SigningScheme.EIP712,
       );
-      await encoder.signEncodeTrade(buyOrder, traders[1], SigningScheme.EIP712);
+      await encoder.signEncodeTrade(
+        buyOrder,
+        traders[1],
+        SigningScheme.ETHSIGN,
+      );
 
       const orderUids = [
-        computeOrderUid({
-          orderDigest: orderSigningHash(domainSeparator, sellOrder),
-          owner: traders[0].address,
-          validTo,
-        }),
-        computeOrderUid({
-          orderDigest: orderSigningHash(domainSeparator, buyOrder),
-          owner: traders[1].address,
-          validTo,
-        }),
+        computeOrderUid(domainSeparator, sellOrder, traders[0].address),
+        computeOrderUid(domainSeparator, buyOrder, traders[1].address),
       ];
 
       return [encoder, orderUids] as const;
@@ -154,6 +149,6 @@ describe("E2E: Expired Order Gas Refunds", () => {
       .div(orderUids.length);
     debug(`Gas savings per order: ${gasSavingsPerOrderRefund}`);
 
-    expect(gasSavingsPerOrderRefund.gt(8000)).to.be.true;
+    expect(gasSavingsPerOrderRefund.gt(0)).to.be.true;
   });
 });


### PR DESCRIPTION
This PR adds a `pre-sign` scheme

One remaining question is how to deal with freeing the "pre-signature" storage once it isn't needed (created #400). I imagine the most straight-forward way would be to extend the order refund to also specify what storage is being refunded, right now blindly clearing the `preSignature` storage for every order refund is costing us about 2000 gas per refund :-1:. 

### Test Plan

Added some new unit tests.
