### PR TITLE
Remove free memory pointer manipulation as has little to no effect.

### DIFF
--- a/src/contracts/mixins/GPv2Signing.sol
+++ b/src/contracts/mixins/GPv2Signing.sol
@@ -115,14 +115,6 @@ abstract contract GPv2Signing {
         Scheme signingScheme,
         bytes calldata signature
     ) internal view returns (bytes32 orderDigest, address owner) {
-        // Read the free memory pointer so that we can de-allocate after
-        // recovering the order signer. See below for more details.
-        uint256 freeMemoryPointer;
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            freeMemoryPointer := mload(0x40)
-        }
-
         orderDigest = orderSigningHash(order);
         if (signingScheme == Scheme.Eip712) {
             owner = recoverEip712Signer(orderDigest, signature);
@@ -130,21 +122,6 @@ abstract contract GPv2Signing {
             owner = recoverEthsignSigner(orderDigest, signature);
         } else if (signingScheme == Scheme.Eip1271) {
             owner = recoverEip1271Signer(orderDigest, signature);
-        }
-
-        // Manually set the free memory pointer back to what it was at the start
-        // of the function, effectively freeing allocated memory. This is done
-        // because Solidity allocates temporary memory for certain operations
-        // that can safely be discarded after use. Examples are:
-        // - calling the ABI encoding methods
-        // - calling the `ecrecover` precompile.
-        //
-        // Note that memory pointed to by the free memory pointer **does not
-        // have to point to zero-ed out**.
-        // <https://docs.soliditylang.org/en/v0.7.6/internals/layout_in_memory.html>
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            mstore(0x40, freeMemoryPointer)
         }
     }
 

--- a/src/contracts/test/GPv2SigningTestInterface.sol
+++ b/src/contracts/test/GPv2SigningTestInterface.sol
@@ -10,27 +10,9 @@ contract GPv2SigningTestInterface is GPv2Signing {
     function recoverOrderFromTradeTest(
         IERC20[] calldata tokens,
         GPv2Trade.Data calldata trade
-    )
-        external
-        view
-        returns (RecoveredOrder memory recoveredOrder, uint256 mem)
-    {
+    ) external view returns (RecoveredOrder memory recoveredOrder) {
         recoveredOrder = allocateRecoveredOrder();
-
-        // NOTE: Solidity stores the free memory pointer at address 0x40. Read
-        // it before and after calling `processOrder` to ensure that there are
-        // no memory allocations.
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            mem := mload(0x40)
-        }
-
         recoverOrderFromTrade(recoveredOrder, tokens, trade);
-
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            mem := sub(mload(0x40), mem)
-        }
     }
 
     function recoverOrderSignerTest(

--- a/test/GPv2Signing.test.ts
+++ b/test/GPv2Signing.test.ts
@@ -104,9 +104,7 @@ describe("GPv2Signing", () => {
         tradeExecution,
       );
 
-      const {
-        recoveredOrder: { data: encodedOrder },
-      } = await signing.recoverOrderFromTradeTest(
+      const { data: encodedOrder } = await signing.recoverOrderFromTradeTest(
         encoder.tokens,
         encoder.trades[0],
       );
@@ -121,9 +119,7 @@ describe("GPv2Signing", () => {
         SigningScheme.EIP712,
       );
 
-      const {
-        recoveredOrder: { uid: orderUid },
-      } = await signing.recoverOrderFromTradeTest(
+      const { uid: orderUid } = await signing.recoverOrderFromTradeTest(
         encoder.tokens,
         encoder.trades[0],
       );
@@ -163,26 +159,12 @@ describe("GPv2Signing", () => {
       const owners = [traders[0].address, traders[1].address, verifier.address];
 
       for (const [i, trade] of encoder.trades.entries()) {
-        const {
-          recoveredOrder: { owner },
-        } = await signing.recoverOrderFromTradeTest(encoder.tokens, trade);
+        const { owner } = await signing.recoverOrderFromTradeTest(
+          encoder.tokens,
+          trade,
+        );
         expect(owner).to.equal(owners[i]);
       }
-    });
-
-    it("should not allocated additional memory", async () => {
-      const encoder = new SettlementEncoder(testDomain);
-      await encoder.signEncodeTrade(
-        sampleOrder,
-        traders[0],
-        SigningScheme.EIP712,
-      );
-
-      const { mem } = await signing.recoverOrderFromTradeTest(
-        encoder.tokens,
-        encoder.trades[0],
-      );
-      expect(mem).to.equal(0);
     });
 
     describe("uid uniqueness", () => {
@@ -208,9 +190,7 @@ describe("GPv2Signing", () => {
           SigningScheme.EIP712,
         );
 
-        const {
-          recoveredOrder: { uid: orderUid },
-        } = await signing.recoverOrderFromTradeTest(
+        const { uid: orderUid } = await signing.recoverOrderFromTradeTest(
           encoder.tokens,
           encoder.trades[0],
         );


### PR DESCRIPTION
This PR just removes some assembly that was orginally there based on the assumption that unbounded memory allocations were expensive. While this is true for large allocations, for smaller things such as abi encoding data for hashing and `ecrecover`, it isn't worth it:

<details><summary>Benchmarks</summary>

```
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
            2 |           10 |            0 |            0 |       766307  (change: -8 / trade)
            3 |           10 |            0 |            0 |       766923  (change: -3 / trade)
            4 |           10 |            0 |            0 |       775879  (change: 0 / trade)
            5 |           10 |            0 |            0 |       780587  (change: -3 / trade)
            6 |           10 |            0 |            0 |       776895  (change: -3 / trade)
            7 |           10 |            0 |            0 |       785815  (change: -3 / trade)
            8 |           10 |            0 |            0 |       790523  (change: 0 / trade)
            8 |           20 |            0 |            0 |      1498892  (change: 1 / trade)
            8 |           30 |            0 |            0 |      2160743  (change: 3 / trade)
            8 |           40 |            0 |            0 |      2826882  (change: 8 / trade)
            8 |           50 |            0 |            0 |      3493628  (change: 10 / trade)
            8 |           60 |            0 |            0 |      4156680  (change: 14 / trade)
            8 |           70 |            0 |            0 |      4823959  (change: 20 / trade)
            8 |           80 |            0 |            0 |      5490294  (change: 21 / trade)
            2 |           10 |            1 |            0 |       838047  (change: -1 / trade)
            2 |           10 |            2 |            0 |       884967  (change: -3 / trade)
            2 |           10 |            3 |            0 |       931887  (change: -2 / trade)
            2 |           10 |            4 |            0 |       978783  (change: 3 / trade)
            2 |           10 |            5 |            0 |      1025715  (change: -6 / trade)
            2 |           10 |            6 |            0 |      1072630  (change: -1 / trade)
            2 |           10 |            7 |            0 |      1119558  (change: -1 / trade)
            2 |           10 |            8 |            0 |      1166486  (change: 1 / trade)
            2 |           50 |            0 |           10 |      3224132  (change: 11 / trade)
            2 |           50 |            0 |           15 |      3183212  (change: 9 / trade)
            2 |           50 |            0 |           20 |      3142268  (change: 9 / trade)
            2 |           50 |            0 |           25 |      3101384  (change: 12 / trade)
            2 |           50 |            0 |           30 |      3060452  (change: 13 / trade)
            2 |           50 |            0 |           35 |      3019544  (change: 11 / trade)
            2 |           50 |            0 |           40 |      2978612  (change: 10 / trade)
            2 |           50 |            0 |           45 |      2937620  (change: 9 / trade)
            2 |           50 |            0 |           50 |      2896736  (change: 12 / trade)
            2 |            2 |            0 |            0 |       190032  (change: -5 / trade)
            2 |            1 |            1 |            0 |       189507  (change: -10 / trade)
           10 |          100 |           10 |           20 |      7354464  (change: 28 / trade)
```

</details>

For larger memory allocations such as the order, this is still beneficial:

<details><summary>Benchmarks for returning new order for each trade instead of reusing it</summary>

```
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
            2 |           10 |            0 |            0 |       770715  (change: 473 / trade)
            3 |           10 |            0 |            0 |       771283  (change: 476 / trade)
            4 |           10 |            0 |            0 |       780227  (change: 478 / trade)
            5 |           10 |            0 |            0 |       784947  (change: 476 / trade)
            6 |           10 |            0 |            0 |       781207  (change: 472 / trade)
            7 |           10 |            0 |            0 |       790139  (change: 476 / trade)
            8 |           10 |            0 |            0 |       794847  (change: 471 / trade)
            8 |           20 |            0 |            0 |      1507935  (change: 494 / trade)
            8 |           30 |            0 |            0 |      2174716  (change: 511 / trade)
            8 |           40 |            0 |            0 |      2846046  (change: 528 / trade)
            8 |           50 |            0 |            0 |      3518362  (change: 547 / trade)
            8 |           60 |            0 |            0 |      4187092  (change: 564 / trade)
            8 |           70 |            0 |            0 |      4860611  (change: 585 / trade)
            8 |           80 |            0 |            0 |      5533495  (change: 603 / trade)
            2 |           10 |            1 |            0 |       842383  (change: 477 / trade)
            2 |           10 |            2 |            0 |       889303  (change: 476 / trade)
            2 |           10 |            3 |            0 |       936199  (change: 472 / trade)
            2 |           10 |            4 |            0 |       983131  (change: 478 / trade)
            2 |           10 |            5 |            0 |      1030075  (change: 477 / trade)
            2 |           10 |            6 |            0 |      1076968  (change: 474 / trade)
            2 |           10 |            7 |            0 |      1123909  (change: 473 / trade)
            2 |           10 |            8 |            0 |      1170802  (change: 471 / trade)
            2 |           50 |            0 |           10 |      3248734  (change: 544 / trade)
            2 |           50 |            0 |           15 |      3207958  (change: 548 / trade)
            2 |           50 |            0 |           20 |      3167050  (change: 550 / trade)
            2 |           50 |            0 |           25 |      3126022  (change: 545 / trade)
            2 |           50 |            0 |           30 |      3085174  (change: 549 / trade)
            2 |           50 |            0 |           35 |      3044182  (change: 547 / trade)
            2 |           50 |            0 |           40 |      3003286  (change: 548 / trade)
            2 |           50 |            0 |           45 |      2962330  (change: 546 / trade)
            2 |           50 |            0 |           50 |      2921494  (change: 549 / trade)
            2 |            2 |            0 |            0 |       190877  (change: 459 / trade)
            2 |            1 |            1 |            0 |       190014  (change: 458 / trade)
           10 |          100 |           10 |           20 |      7411147  (change: 637 / trade)
```

</details>

### Test Plan

Unit tests still pass, memory test was removed.
