### PR TITLE
Allow changing manager

### DIFF
--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -90,14 +90,14 @@ export class BenchFixture {
       authenticator,
       settlement,
       deployer,
-      owner,
-      wallets: [solver, ...traders],
+      manager,
+      wallets: [solver, pooler, ...traders],
     } = deployment;
 
     const { chainId } = await ethers.provider.getNetwork();
     const domainSeparator = domain(chainId, settlement.address);
 
-    await authenticator.connect(owner).addSolver(solver.address);
+    await authenticator.connect(manager).addSolver(solver.address);
 
     const tokens = new TokenManager(deployment, traders);
 
@@ -122,7 +122,7 @@ export class BenchFixture {
     ].map((tokenAddress) => new Contract(tokenAddress, ERC20.abi, deployer));
     await uniswapTokens[0].mint(uniswapPair.address, LOTS);
     await uniswapTokens[1].mint(uniswapPair.address, LOTS);
-    await uniswapPair.mint(owner.address);
+    await uniswapPair.mint(pooler.address);
 
     debug("performing Uniswap initial swap to write initial storage values");
     await uniswapTokens[1].mint(
@@ -132,7 +132,7 @@ export class BenchFixture {
     await uniswapPair.swap(
       ethers.utils.parseEther("0.99"),
       ethers.constants.Zero,
-      owner.address,
+      pooler.address,
       "0x",
     );
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -91,6 +91,10 @@ export default {
       default: "0x6Fb5916c0f57f88004d5b5EB25f6f4D77353a1eD",
       hardhat: 1,
     },
+    manager: {
+      default: "0x6Fb5916c0f57f88004d5b5EB25f6f4D77353a1eD",
+      hardhat: 2,
+    },
   },
   gasReporter: {
     enabled: REPORT_GAS ? true : false,

--- a/src/contracts/GPv2AllowListAuthentication.sol
+++ b/src/contracts/GPv2AllowListAuthentication.sol
@@ -2,26 +2,34 @@
 pragma solidity ^0.7.6;
 
 import "@gnosis.pm/util-contracts/contracts/StorageAccessible.sol";
+import "@openzeppelin/contracts/proxy/Initializable.sol";
 import "@openzeppelin/contracts/utils/EnumerableSet.sol";
 import "./interfaces/GPv2Authentication.sol";
 
 /// @title Gnosis Protocol v2 Access Control Contract
 /// @author Gnosis Developers
-contract GPv2AllowListAuthentication is GPv2Authentication, StorageAccessible {
+contract GPv2AllowListAuthentication is
+    GPv2Authentication,
+    Initializable,
+    StorageAccessible
+{
     using EnumerableSet for EnumerableSet.AddressSet;
 
     address public manager;
 
     EnumerableSet.AddressSet private solvers;
 
-    function initializeManager(address manager_) external {
-        require(manager == address(0), "GPv2: already initialized");
+    function initializeManager(address manager_) external initializer {
         manager = manager_;
     }
 
     modifier onlyManager() {
         require(manager == msg.sender, "GPv2: caller not manager");
         _;
+    }
+
+    function setManager(address manager_) external onlyManager {
+        manager = manager_;
     }
 
     function addSolver(address solver) external onlyManager {

--- a/src/contracts/GPv2AllowListAuthentication.sol
+++ b/src/contracts/GPv2AllowListAuthentication.sol
@@ -5,6 +5,7 @@ import "@gnosis.pm/util-contracts/contracts/StorageAccessible.sol";
 import "@openzeppelin/contracts/proxy/Initializable.sol";
 import "@openzeppelin/contracts/utils/EnumerableSet.sol";
 import "./interfaces/GPv2Authentication.sol";
+import "./libraries/GPv2EIP1967.sol";
 
 /// @title Gnosis Protocol v2 Access Control Contract
 /// @author Gnosis Developers
@@ -28,7 +29,15 @@ contract GPv2AllowListAuthentication is
         _;
     }
 
-    function setManager(address manager_) external onlyManager {
+    modifier onlyManagerOrOwner() {
+        require(
+            manager == msg.sender || GPv2EIP1967.getAdmin() == msg.sender,
+            "GPv2: not authorized"
+        );
+        _;
+    }
+
+    function setManager(address manager_) external onlyManagerOrOwner {
         manager = manager_;
     }
 

--- a/src/contracts/libraries/GPv2EIP1967.sol
+++ b/src/contracts/libraries/GPv2EIP1967.sol
@@ -2,48 +2,15 @@
 pragma solidity ^0.7.6;
 
 library GPv2EIP1967 {
-    /// @dev The storage slot where the proxy implementation is stored, defined
-    /// as `keccak256('eip1967.proxy.implementation') - 1`.
-    bytes32 internal constant IMPLEMENTATION_SLOT =
-        hex"360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
-
     /// @dev The storage slot where the proxy administrator is stored, defined
     /// as `keccak256('eip1967.proxy.admin') - 1`.
     bytes32 internal constant ADMIN_SLOT =
         hex"b53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103";
 
-    /// @dev Returns the address stored in the EIP-1967 implementation storage
-    /// slot for the current contract. If this method is not called from an
-    /// EIP-1967 contract, then it will likely return `address(0)`, as the
-    /// implementation slot is likely to be unset.
-    ///
-    /// @return implementation The implementation address.
-    function getImplementation()
-        internal
-        view
-        returns (address implementation)
-    {
-        // NOTE: Assembly is required for reading and writing storage at
-        // arbirary slots.
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            implementation := sload(IMPLEMENTATION_SLOT)
-        }
-    }
-
-    /// @dev Sets the storage at the EIP-1967 implementation slot to be the
-    /// specified address.
-    ///
-    /// @param implementation The implementation address to set.
-    function setImplementation(address implementation) internal {
-        // solhint-disable-next-line no-inline-assembly
-        assembly {
-            sstore(IMPLEMENTATION_SLOT, implementation)
-        }
-    }
-
     /// @dev Returns the address stored in the EIP-1967 administrator storage
-    /// slot for the current contract.
+    /// slot for the current contract. If this method is not called from an
+    /// contract behind an EIP-1967 proxy, then it will most likely return
+    /// `address(0)`, as the implementation slot is likely to be unset.
     ///
     /// @return admin The administrator address.
     function getAdmin() internal view returns (address admin) {

--- a/src/contracts/libraries/GPv2EIP1967.sol
+++ b/src/contracts/libraries/GPv2EIP1967.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.7.6;
+
+library GPv2EIP1967 {
+    /// @dev The storage slot where the proxy implementation is stored, defined
+    /// as `keccak256('eip1967.proxy.implementation') - 1`.
+    bytes32 internal constant IMPLEMENTATION_SLOT =
+        hex"360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+
+    /// @dev The storage slot where the proxy administrator is stored, defined
+    /// as `keccak256('eip1967.proxy.admin') - 1`.
+    bytes32 internal constant ADMIN_SLOT =
+        hex"b53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103";
+
+    /// @dev Returns the address stored in the EIP-1967 implementation storage
+    /// slot for the current contract. If this method is not called from an
+    /// EIP-1967 contract, then it will likely return `address(0)`.
+    /// as `keccak256('eip1967.proxy.implementation') - 1`.
+    ///
+    /// @return implementation The implementation address.
+    function getImplementation()
+        internal
+        view
+        returns (address implementation)
+    {
+        // NOTE: Assembly is required for reading and writing storage at
+        // arbirary slots.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            implementation := sload(IMPLEMENTATION_SLOT)
+        }
+    }
+
+    /// @dev Sets the storage at the EIP-1967 implementation slot to be the
+    /// specified address.
+    ///
+    /// @param implementation The implementation address to set.
+    function setImplementation(address implementation) internal {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            sstore(IMPLEMENTATION_SLOT, implementation)
+        }
+    }
+
+    /// @dev Returns the address stored in the EIP-1967 administrator storage
+    /// slot for the current contract.
+    ///
+    /// @return admin The administrator address.
+    function getAdmin() internal view returns (address admin) {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            admin := sload(ADMIN_SLOT)
+        }
+    }
+
+    /// @dev Sets the storage at the EIP-1967 administrator slot to be the
+    /// specified address.
+    ///
+    /// @param admin The administrator address to set.
+    function setAdmin(address admin) internal {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            sstore(ADMIN_SLOT, admin)
+        }
+    }
+}

--- a/src/contracts/libraries/GPv2EIP1967.sol
+++ b/src/contracts/libraries/GPv2EIP1967.sol
@@ -14,8 +14,8 @@ library GPv2EIP1967 {
 
     /// @dev Returns the address stored in the EIP-1967 implementation storage
     /// slot for the current contract. If this method is not called from an
-    /// EIP-1967 contract, then it will likely return `address(0)`.
-    /// as `keccak256('eip1967.proxy.implementation') - 1`.
+    /// EIP-1967 contract, then it will likely return `address(0)`, as the
+    /// implementation slot is likely to be unset.
     ///
     /// @return implementation The implementation address.
     function getImplementation()

--- a/src/contracts/test/GPv2AllowListAuthenticationTestInterface.sol
+++ b/src/contracts/test/GPv2AllowListAuthenticationTestInterface.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.7.6;
+
+import "../GPv2AllowListAuthentication.sol";
+import "../libraries/GPv2EIP1967.sol";
+
+contract GPv2AllowListAuthenticationTestInterface is
+    GPv2AllowListAuthentication
+{
+    constructor(address owner) {
+        GPv2EIP1967.setAdmin(owner);
+    }
+}

--- a/src/deploy/001_authenticator.ts
+++ b/src/deploy/001_authenticator.ts
@@ -7,7 +7,7 @@ const deployAuthenticator: DeployFunction = async function ({
   deployments,
   getNamedAccounts,
 }: HardhatRuntimeEnvironment) {
-  const { deployer, owner } = await getNamedAccounts();
+  const { deployer, owner, manager } = await getNamedAccounts();
   const { deploy } = deployments;
 
   const { authenticator } = CONTRACT_NAMES;
@@ -20,7 +20,7 @@ const deployAuthenticator: DeployFunction = async function ({
       owner,
       methodName: "initializeManager",
     },
-    args: [owner],
+    args: [manager],
   });
 };
 

--- a/src/tasks/solvers.ts
+++ b/src/tasks/solvers.ts
@@ -12,9 +12,9 @@ async function getOwnerSigner({
   ethers,
   getNamedAccounts,
 }: HardhatRuntimeEnvironment): Promise<Signer> {
-  const { owner } = await getNamedAccounts();
+  const { manager } = await getNamedAccounts();
   const signer = (await ethers.getSigners()).find(
-    (signer) => signer.address == owner,
+    (signer) => signer.address == manager,
   );
   if (signer == undefined) {
     throw new Error(

--- a/src/ts/proxy.ts
+++ b/src/ts/proxy.ts
@@ -1,7 +1,8 @@
 // defined in https://eips.ethereum.org/EIPS/eip-1967
 
-import { BigNumber } from "ethers";
+import { BigNumber, Contract } from "ethers";
 import { ethers } from "hardhat";
+import Proxy from "hardhat-deploy/extendedArtifacts/EIP173Proxy.json";
 
 // The proxy contract used by hardhat-deploy implements EIP-1967 (Standard Proxy
 // Storage Slot). See <https://eips.ethereum.org/EIPS/eip-1967>.
@@ -22,7 +23,7 @@ const OWNER_STORAGE_SLOT = slot("eip1967.proxy.admin");
  * @returns The address of the contract storing the proxy implementation.
  */
 export async function implementationAddress(proxy: string): Promise<string> {
-  const [implementation] = await ethers.utils.defaultAbiCoder.decode(
+  const [implementation] = ethers.utils.defaultAbiCoder.decode(
     ["address"],
     await ethers.provider.getStorageAt(proxy, IMPLEMENTATION_STORAGE_SLOT),
   );
@@ -37,9 +38,24 @@ export async function implementationAddress(proxy: string): Promise<string> {
  * @returns The address of the administrator of the proxy.
  */
 export async function ownerAddress(proxy: string): Promise<string> {
-  const [owner] = await ethers.utils.defaultAbiCoder.decode(
+  const [owner] = ethers.utils.defaultAbiCoder.decode(
     ["address"],
     await ethers.provider.getStorageAt(proxy, OWNER_STORAGE_SLOT),
   );
   return owner;
+}
+
+/**
+ * Returns the proxy interface for the specified address.
+ *
+ * @param contract The proxy contract to return a proxy interface for.
+ * @returns A Ethers.js contract instance for interacting with the proxy.
+ */
+export function proxyInterface(contract: Contract): Contract {
+  const { abi } = Proxy;
+  return new Contract(
+    contract.address,
+    abi,
+    contract.signer ?? contract.provider,
+  );
 }

--- a/test/GPv2AllowListAuthenticator.test.ts
+++ b/test/GPv2AllowListAuthenticator.test.ts
@@ -16,24 +16,37 @@ describe("GPv2AllowListAuthentication", () => {
     await authenticator.initializeManager(owner.address);
   });
 
-  describe("constructor", () => {
+  describe("initializeManager", () => {
     it("should initialize the manager", async () => {
       expect(await authenticator.manager()).to.equal(owner.address);
     });
 
-    it("ensures initializeManager is idempotent", async () => {
+    it("should be idempotent", async () => {
       await expect(
         authenticator.initializeManager(nonOwner.address),
-      ).to.revertedWith("GPv2: already initialized");
+      ).to.revertedWith("contract is already initialized");
 
       // Also reverts when called by owner.
       await expect(
         authenticator.connect(owner).initializeManager(nonOwner.address),
-      ).to.revertedWith("GPv2: already initialized");
+      ).to.revertedWith("contract is already initialized");
     });
 
     it("deployer is not the manager", async () => {
       expect(await authenticator.manager()).not.to.be.equal(deployer.address);
+    });
+  });
+
+  describe("setManager", () => {
+    it("should be able to change manager", async () => {
+      await authenticator.connect(owner).setManager(nonOwner.address);
+      expect(await authenticator.manager()).to.equal(nonOwner.address);
+    });
+
+    it("should revert when non-manager attempts to set a new manager", async () => {
+      await expect(
+        authenticator.connect(nonOwner).setManager(nonOwner.address),
+      ).to.be.revertedWith("GPv2: caller not manager");
     });
   });
 

--- a/test/GPv2AllowListAuthenticator.test.ts
+++ b/test/GPv2AllowListAuthenticator.test.ts
@@ -19,6 +19,8 @@ describe("GPv2AllowListAuthentication", () => {
       deployer,
     );
 
+    // NOTE: This deploys the test interface contract which emulates being
+    // proxied by an EIP-1967 compatible proxy for unit testing purposes.
     authenticator = await GPv2AllowListAuthentication.deploy(owner.address);
     await authenticator.initializeManager(manager.address);
   });

--- a/test/GPv2AllowListAuthenticator.test.ts
+++ b/test/GPv2AllowListAuthenticator.test.ts
@@ -3,82 +3,110 @@ import { Contract } from "ethers";
 import { ethers, waffle } from "hardhat";
 
 describe("GPv2AllowListAuthentication", () => {
-  const [deployer, owner, nonOwner, solver] = waffle.provider.getWallets();
+  const [
+    deployer,
+    owner,
+    manager,
+    newManager,
+    nobody,
+    solver,
+  ] = waffle.provider.getWallets();
   let authenticator: Contract;
 
   beforeEach(async () => {
     const GPv2AllowListAuthentication = await ethers.getContractFactory(
-      "GPv2AllowListAuthentication",
+      "GPv2AllowListAuthenticationTestInterface",
       deployer,
     );
 
-    authenticator = await GPv2AllowListAuthentication.deploy();
-    await authenticator.initializeManager(owner.address);
+    authenticator = await GPv2AllowListAuthentication.deploy(owner.address);
+    await authenticator.initializeManager(manager.address);
   });
 
   describe("initializeManager", () => {
     it("should initialize the manager", async () => {
-      expect(await authenticator.manager()).to.equal(owner.address);
-    });
-
-    it("should be idempotent", async () => {
-      await expect(
-        authenticator.initializeManager(nonOwner.address),
-      ).to.revertedWith("contract is already initialized");
-
-      // Also reverts when called by owner.
-      await expect(
-        authenticator.connect(owner).initializeManager(nonOwner.address),
-      ).to.revertedWith("contract is already initialized");
+      expect(await authenticator.manager()).to.equal(manager.address);
     });
 
     it("deployer is not the manager", async () => {
       expect(await authenticator.manager()).not.to.be.equal(deployer.address);
     });
+
+    it("owner is not the manager", async () => {
+      expect(await authenticator.manager()).not.to.be.equal(owner.address);
+    });
+
+    it("should be idempotent", async () => {
+      await expect(
+        authenticator.initializeManager(nobody.address),
+      ).to.revertedWith("contract is already initialized");
+
+      // Also reverts when called by owner.
+      await expect(
+        authenticator.connect(owner).initializeManager(nobody.address),
+      ).to.revertedWith("contract is already initialized");
+    });
   });
 
   describe("setManager", () => {
-    it("should be able to change manager", async () => {
-      await authenticator.connect(owner).setManager(nonOwner.address);
-      expect(await authenticator.manager()).to.equal(nonOwner.address);
+    it("should be settable by current owner", async () => {
+      await authenticator.connect(owner).setManager(newManager.address);
+      expect(await authenticator.manager()).to.equal(newManager.address);
     });
 
-    it("should revert when non-manager attempts to set a new manager", async () => {
+    it("should be settable by current manager", async () => {
+      await authenticator.connect(manager).setManager(newManager.address);
+      expect(await authenticator.manager()).to.equal(newManager.address);
+    });
+
+    it("should revert when being set by unauthorized address", async () => {
       await expect(
-        authenticator.connect(nonOwner).setManager(nonOwner.address),
-      ).to.be.revertedWith("GPv2: caller not manager");
+        authenticator.connect(nobody).setManager(ethers.constants.AddressZero),
+      ).to.be.revertedWith("not authorized");
     });
   });
 
   describe("addSolver(address)", () => {
     it("should add a solver", async () => {
-      await expect(authenticator.connect(owner).addSolver(solver.address)).to
+      await expect(authenticator.connect(manager).addSolver(solver.address)).to
         .not.be.reverted;
     });
 
-    it("should not allow non-owner to add solver", async () => {
+    it("should not allow owner to add solver", async () => {
       await expect(
-        authenticator.connect(nonOwner).addSolver(solver.address),
+        authenticator.connect(owner).addSolver(solver.address),
+      ).to.be.revertedWith("GPv2: caller not manager");
+    });
+
+    it("should not allow unauthorized address to add solver", async () => {
+      await expect(
+        authenticator.connect(nobody).addSolver(solver.address),
       ).to.be.revertedWith("GPv2: caller not manager");
     });
   });
 
   describe("removeSolver(address)", () => {
     it("should allow owner to remove solver", async () => {
-      await expect(authenticator.connect(owner).removeSolver(solver.address)).to
-        .not.be.reverted;
+      await expect(authenticator.connect(manager).removeSolver(solver.address))
+        .to.not.be.reverted;
     });
 
-    it("should not allow non-owner to remove solver", async () => {
+    it("should not allow owner to add solver", async () => {
       await expect(
-        authenticator.connect(nonOwner).removeSolver(solver.address),
+        authenticator.connect(owner).removeSolver(solver.address),
+      ).to.be.revertedWith("GPv2: caller not manager");
+    });
+
+    it("should not allow unauthorized address to add solver", async () => {
+      await expect(
+        authenticator.connect(nobody).removeSolver(solver.address),
       ).to.be.revertedWith("GPv2: caller not manager");
     });
   });
 
   describe("isSolver(address)", () => {
     it("returns true when given address is a recognized solver", async () => {
-      await authenticator.connect(owner).addSolver(solver.address);
+      await authenticator.connect(manager).addSolver(solver.address);
       expect(await authenticator.isSolver(solver.address)).to.equal(true);
     });
 

--- a/test/e2e/0xTrade.test.ts
+++ b/test/e2e/0xTrade.test.ts
@@ -43,8 +43,8 @@ describe("E2E: Can settle a 0x trade", () => {
       wallets: [solver, trader, marketMaker],
     } = deployment);
 
-    const { authenticator, owner } = deployment;
-    await authenticator.connect(owner).addSolver(solver.address);
+    const { authenticator, manager } = deployment;
+    await authenticator.connect(manager).addSolver(solver.address);
 
     const { chainId } = await ethers.provider.getNetwork();
     domainSeparator = domain(chainId, settlement.address);

--- a/test/e2e/burnFees.test.ts
+++ b/test/e2e/burnFees.test.ts
@@ -36,8 +36,8 @@ describe("E2E: Burn fees", () => {
       wallets: [solver, ...traders],
     } = deployment);
 
-    const { authenticator, owner } = deployment;
-    await authenticator.connect(owner).addSolver(solver.address);
+    const { authenticator, manager } = deployment;
+    await authenticator.connect(manager).addSolver(solver.address);
 
     const { chainId } = await ethers.provider.getNetwork();
     domainSeparator = domain(chainId, settlement.address);

--- a/test/e2e/buyEth.test.ts
+++ b/test/e2e/buyEth.test.ts
@@ -37,8 +37,8 @@ describe("E2E: Buy Ether", () => {
       wallets: [solver, ...traders],
     } = deployment);
 
-    const { authenticator, owner } = deployment;
-    await authenticator.connect(owner).addSolver(solver.address);
+    const { authenticator, manager } = deployment;
+    await authenticator.connect(manager).addSolver(solver.address);
 
     const { chainId } = await ethers.provider.getNetwork();
     domainSeparator = domain(chainId, settlement.address);

--- a/test/e2e/contractOrdersWithGnosisSafe.test.ts
+++ b/test/e2e/contractOrdersWithGnosisSafe.test.ts
@@ -159,8 +159,8 @@ describe("E2E: Order From A Gnosis Safe", () => {
       wallets: [solver, trader, ...safeOwners],
     } = deployment);
 
-    const { authenticator, owner } = deployment;
-    await authenticator.connect(owner).addSolver(solver.address);
+    const { authenticator, manager } = deployment;
+    await authenticator.connect(manager).addSolver(solver.address);
 
     const { chainId } = await ethers.provider.getNetwork();
     domainSeparator = domain(chainId, settlement.address);

--- a/test/e2e/deployment.test.ts
+++ b/test/e2e/deployment.test.ts
@@ -8,6 +8,7 @@ import {
   DeploymentArguments,
   deterministicDeploymentAddress,
   implementationAddress,
+  proxyInterface,
 } from "../../src/ts";
 import { builtAndDeployedMetadataCoincide } from "../bytecode";
 
@@ -104,7 +105,8 @@ describe("E2E: Deployment", () => {
 
   describe("authorization", () => {
     it("authenticator has dedicated owner", async () => {
-      expect(await authenticator.owner()).to.equal(owner.address);
+      const proxy = proxyInterface(authenticator);
+      expect(await proxy.owner()).to.equal(owner.address);
     });
 
     it("authenticator has dedicated manager", async () => {

--- a/test/e2e/deployment.test.ts
+++ b/test/e2e/deployment.test.ts
@@ -23,6 +23,7 @@ async function contractAddress<C extends ContractName>(
 
 describe("E2E: Deployment", () => {
   let owner: Wallet;
+  let manager: Wallet;
   let user: Wallet;
 
   let authenticator: Contract;
@@ -32,6 +33,7 @@ describe("E2E: Deployment", () => {
   beforeEach(async () => {
     ({
       owner,
+      manager,
       wallets: [user],
       authenticator,
       settlement,
@@ -79,7 +81,7 @@ describe("E2E: Deployment", () => {
           deterministicDeploymentAddress(Proxy, [
             await implementationAddress(authenticator.address),
             authenticator.interface.encodeFunctionData("initializeManager", [
-              owner.address,
+              manager.address,
             ]),
             owner.address,
           ]),
@@ -100,9 +102,13 @@ describe("E2E: Deployment", () => {
     });
   });
 
-  describe("ownership", () => {
+  describe("authorization", () => {
     it("authenticator has dedicated owner", async () => {
-      expect(await authenticator.manager()).to.equal(owner.address);
+      expect(await authenticator.owner()).to.equal(owner.address);
+    });
+
+    it("authenticator has dedicated manager", async () => {
+      expect(await authenticator.manager()).to.equal(manager.address);
     });
   });
 });

--- a/test/e2e/ercPermit.test.ts
+++ b/test/e2e/ercPermit.test.ts
@@ -32,8 +32,8 @@ describe("E2E: EIP-2612 Permit", () => {
       wallets: [solver, ...traders],
     } = deployment);
 
-    const { authenticator, owner } = deployment;
-    await authenticator.connect(owner).addSolver(solver.address);
+    const { authenticator, manager } = deployment;
+    await authenticator.connect(manager).addSolver(solver.address);
 
     const { chainId } = await ethers.provider.getNetwork();
     domainSeparator = domain(chainId, settlement.address);

--- a/test/e2e/fixture.ts
+++ b/test/e2e/fixture.ts
@@ -4,6 +4,7 @@ import { deployments } from "hardhat";
 export interface TestDeployment {
   deployer: Wallet;
   owner: Wallet;
+  manager: Wallet;
   wallets: Wallet[];
   authenticator: Contract;
   settlement: Contract;
@@ -24,7 +25,7 @@ export const deployTestContracts: () => Promise<TestDeployment> = deployments.cr
     } = await deployments.fixture();
 
     const allWallets = waffle.provider.getWallets();
-    const { deployer, owner } = await getNamedAccounts();
+    const { deployer, owner, manager } = await getNamedAccounts();
     const unnamedAccounts = await getUnnamedAccounts();
 
     const authenticator = await ethers.getContractAt(
@@ -43,6 +44,7 @@ export const deployTestContracts: () => Promise<TestDeployment> = deployments.cr
     return {
       deployer: findAccountWallet(allWallets, deployer),
       owner: findAccountWallet(allWallets, owner),
+      manager: findAccountWallet(allWallets, manager),
       wallets: unnamedAccounts.map((account) =>
         findAccountWallet(allWallets, account),
       ),

--- a/test/e2e/orderRefunds.test.ts
+++ b/test/e2e/orderRefunds.test.ts
@@ -40,8 +40,8 @@ describe("E2E: Expired Order Gas Refunds", () => {
       wallets: [solver, ...traders],
     } = deployment);
 
-    const { authenticator, owner } = deployment;
-    await authenticator.connect(owner).addSolver(solver.address);
+    const { authenticator, manager } = deployment;
+    await authenticator.connect(manager).addSolver(solver.address);
 
     const { chainId } = await ethers.provider.getNetwork();
     domainSeparator = domain(chainId, settlement.address);

--- a/test/e2e/uniswapTrade.test.ts
+++ b/test/e2e/uniswapTrade.test.ts
@@ -40,8 +40,8 @@ describe("E2E: Should Trade Surplus With Uniswap", () => {
       wallets: [solver, pooler, ...traders],
     } = deployment);
 
-    const { authenticator, owner } = deployment;
-    await authenticator.connect(owner).addSolver(solver.address);
+    const { authenticator, manager } = deployment;
+    await authenticator.connect(manager).addSolver(solver.address);
 
     const { chainId } = await ethers.provider.getNetwork();
     domainSeparator = domain(chainId, settlement.address);

--- a/test/e2e/upgradeAuthenticator.test.ts
+++ b/test/e2e/upgradeAuthenticator.test.ts
@@ -1,7 +1,8 @@
 import { expect } from "chai";
 import { Contract, Wallet } from "ethers";
 import { deployments, ethers } from "hardhat";
-import Proxy from "hardhat-deploy/extendedArtifacts/EIP173Proxy.json";
+
+import { proxyInterface } from "../../src/ts";
 
 import { deployTestContracts } from "./fixture";
 
@@ -96,7 +97,7 @@ describe("Upgrade Authenticator", () => {
   });
 
   it("should be able to transfer proxy ownership", async () => {
-    const proxy = new Contract(authenticator.address, Proxy.abi, deployer);
+    const proxy = proxyInterface(authenticator);
     await proxy.connect(owner).transferOwnership(newOwner.address);
     expect(await proxy.owner()).to.equal(newOwner.address);
 

--- a/test/e2e/upgradeAuthenticator.test.ts
+++ b/test/e2e/upgradeAuthenticator.test.ts
@@ -96,6 +96,11 @@ describe("Upgrade Authenticator", () => {
     expect(await authenticatorV2.manager()).to.equal(newManager.address);
   });
 
+  it("should allow the proxy owner to change the manager", async () => {
+    await authenticator.connect(owner).setManager(newManager.address);
+    expect(await authenticator.manager()).to.equal(newManager.address);
+  });
+
   it("should be able to transfer proxy ownership", async () => {
     const proxy = proxyInterface(authenticator);
     await proxy.connect(owner).transferOwnership(newOwner.address);

--- a/test/e2e/upgradeAuthenticator.test.ts
+++ b/test/e2e/upgradeAuthenticator.test.ts
@@ -4,10 +4,37 @@ import { deployments, ethers } from "hardhat";
 
 import { deployTestContracts } from "./fixture";
 
+async function rejectError(
+  promise: Promise<unknown>,
+): Promise<Error | undefined> {
+  try {
+    await promise;
+    return undefined;
+  } catch (err) {
+    return err;
+  }
+}
+
+async function upgrade(
+  proxyOwner: Wallet,
+  contractName: string,
+  newContractName: string,
+) {
+  // Note that deterministic deployment and gasLimit are not needed/used here as deployment args.
+  await deployments.deploy(contractName, {
+    contract: newContractName,
+    // From differs from initial deployment here since the proxy owner is the Authenticator manager.
+    from: proxyOwner.address,
+    proxy: true,
+  });
+}
+
 describe("Upgrade Authenticator", () => {
   let authenticator: Contract;
   let deployer: Wallet;
   let owner: Wallet;
+  let nonOwner: Wallet;
+  let newManager: Wallet;
   let solver: Wallet;
 
   beforeEach(async () => {
@@ -15,7 +42,7 @@ describe("Upgrade Authenticator", () => {
       authenticator,
       deployer,
       owner,
-      wallets: [solver],
+      wallets: [nonOwner, newManager, solver],
     } = await deployTestContracts());
   });
 
@@ -32,6 +59,7 @@ describe("Upgrade Authenticator", () => {
     await expect(authenticatorV2.newMethod()).to.be.reverted;
 
     await upgrade(
+      owner,
       "GPv2AllowListAuthentication",
       "GPv2AllowListAuthenticationV2",
     );
@@ -40,10 +68,12 @@ describe("Upgrade Authenticator", () => {
   });
 
   it("should preserve storage", async () => {
-    await authenticator.connect(owner).addSolver(solver.address);
+    await authenticator.connect(owner).setManager(newManager.address);
+    await authenticator.connect(newManager).addSolver(solver.address);
 
-    // Upgrade after storage is set.
+    // Upgrade after storage is set with **proxy owner**;
     await upgrade(
+      owner,
       "GPv2AllowListAuthentication",
       "GPv2AllowListAuthenticationV2",
     );
@@ -55,18 +85,34 @@ describe("Upgrade Authenticator", () => {
     const authenticatorV2 = GPv2AllowListAuthenticationV2.attach(
       authenticator.address,
     );
-    // Both, the listed solvers and original manager are still set
+
+    // Both, the listed solvers and updated manager are still set
     expect(await authenticatorV2.isSolver(solver.address)).to.equal(true);
-    expect(await authenticatorV2.manager()).to.equal(owner.address);
+    expect(await authenticatorV2.manager()).to.equal(newManager.address);
   });
 
-  async function upgrade(contractName: string, newContractName: string) {
-    // Note that deterministic deployment and gasLimit are not needed/used here as deployment args.
-    await deployments.deploy(contractName, {
-      contract: newContractName,
-      // From differs from initial deployment here since the proxy owner is the Authenticator manager.
-      from: owner.address,
-      proxy: true,
-    });
-  }
+  it("should revert when not upgrading with the authentication manager", async () => {
+    await authenticator.connect(owner).setManager(newManager.address);
+    expect(
+      await rejectError(
+        upgrade(
+          newManager,
+          "GPv2AllowListAuthentication",
+          "GPv2AllowListAuthenticationV2",
+        ),
+      ),
+    ).to.not.be.undefined;
+  });
+
+  it("should revert when not upgrading with the proxy owner", async () => {
+    expect(
+      await rejectError(
+        upgrade(
+          nonOwner,
+          "GPv2AllowListAuthentication",
+          "GPv2AllowListAuthenticationV2",
+        ),
+      ),
+    ).to.not.be.undefined;
+  });
 });

--- a/test/e2e/wineOilMarket.test.ts
+++ b/test/e2e/wineOilMarket.test.ts
@@ -33,8 +33,8 @@ describe("E2E: RetrETH Red Wine and Olive Oil Market", () => {
       wallets: [solver, ...traders],
     } = deployment);
 
-    const { authenticator, owner } = deployment;
-    await authenticator.connect(owner).addSolver(solver.address);
+    const { authenticator, manager } = deployment;
+    await authenticator.connect(manager).addSolver(solver.address);
 
     const { chainId } = await ethers.provider.getNetwork();
     domainSeparator = domain(chainId, settlement.address);


### PR DESCRIPTION
This PR adds a `setManager` method to the allow list authenticator.

I had originally wanted to just use the `Ownable` contract from OpenZeppelin, but this causes ABI conflicts with the proxy contract from the `hardhat-deploy` plugin:
```
Error: function "owner" will shadow "owner". Please update code to avoid conflict.
```

### Test Plan

Added some new tests.
