### PR TITLE
Differentiate between classes of order refunds

### DIFF
--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -298,8 +298,14 @@ export class BenchFixture {
         owner: trader.address,
         validTo: 0,
       });
-      await settlement.connect(trader).invalidateOrder(orderUid);
-      encoder.encodeOrderRefunds(orderUid);
+
+      if (i % 5 !== 0) {
+        await settlement.connect(trader).invalidateOrder(orderUid);
+        encoder.encodeOrderRefunds({ filledAmounts: [orderUid] });
+      } else {
+        await settlement.connect(trader).setPreSignature(orderUid, true);
+        encoder.encodeOrderRefunds({ preSignatures: [orderUid] });
+      }
     }
 
     const prices = tokens.instances.slice(0, options.tokens).reduce(

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -55,7 +55,9 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
         executeInteractions(interactions);
     }
 
-    function claimOrderRefundsTest(bytes[] calldata orderRefunds) external {
+    function claimOrderRefundsTest(OrderRefunds calldata orderRefunds)
+        external
+    {
         claimOrderRefunds(orderRefunds);
     }
 }

--- a/src/ts/sign.ts
+++ b/src/ts/sign.ts
@@ -24,6 +24,11 @@ export const EIP1271_MAGICVALUE = ethers.utils.hexDataSlice(
 );
 
 /**
+ * Marker value indicating a presignature is set.
+ */
+export const PRE_SIGNED = ethers.utils.id("GPv2Signing.Scheme.PreSign");
+
+/**
  * The signing scheme used to sign the order.
  */
 export const enum SigningScheme {

--- a/test/GPv2Signing.test.ts
+++ b/test/GPv2Signing.test.ts
@@ -4,6 +4,7 @@ import { artifacts, ethers, waffle } from "hardhat";
 
 import {
   EIP1271_MAGICVALUE,
+  PRE_SIGNED,
   OrderKind,
   SettlementEncoder,
   SigningScheme,
@@ -85,13 +86,15 @@ describe("GPv2Signing", () => {
 
     it("should set the pre-signature", async () => {
       await signing.connect(owner).setPreSignature(orderUid, true);
-      expect(await signing.preSignature(orderUid)).to.be.true;
+      expect(await signing.preSignature(orderUid)).to.equal(PRE_SIGNED);
     });
 
     it("should unset the pre-signature", async () => {
       await signing.connect(owner).setPreSignature(orderUid, true);
       await signing.connect(owner).setPreSignature(orderUid, false);
-      expect(await signing.preSignature(orderUid)).to.be.false;
+      expect(await signing.preSignature(orderUid)).to.equal(
+        ethers.constants.Zero,
+      );
     });
 
     it("should revert if the order owner is not the transaction sender", async () => {

--- a/test/encoding.ts
+++ b/test/encoding.ts
@@ -1,7 +1,7 @@
-import { BigNumber } from "ethers";
+import { BigNumber, BytesLike } from "ethers";
 import { ethers } from "hardhat";
 
-import { Order, OrderKind, normalizeOrder } from "../src/ts";
+import { Order, OrderKind, OrderRefunds, normalizeOrder } from "../src/ts";
 
 export type AbiOrder = [
   string,
@@ -90,4 +90,16 @@ export function encodeOutTransfers(transfers: OutTransfer[]): ExecutedTrade[] {
     sellToken: ethers.constants.AddressZero,
     sellAmount: ethers.constants.Zero,
   }));
+}
+
+export function encodeFilledAmountRefunds(
+  ...filledAmounts: BytesLike[]
+): OrderRefunds {
+  return { filledAmounts, preSignatures: [] };
+}
+
+export function encodePreSignatureRefunds(
+  ...preSignatures: BytesLike[]
+): OrderRefunds {
+  return { filledAmounts: [], preSignatures };
 }


### PR DESCRIPTION
Closes #400 

This PR modifies order refunds to work by having separate collections for filled amount refunds and pre signature refunds.

### Test Plan

Added new unit tests.
