### PR TITLE
"Lite" Settlement

### DIFF
--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -328,9 +328,19 @@ export class BenchFixture {
     );
 
     debug(`executing settlement`);
-    const transaction = await settlement
-      .connect(solver)
-      .settle(...encoder.encodedSettlement(prices));
+    const transaction =
+      options.refunds > 0
+        ? await settlement
+            .connect(solver)
+            .settle(...encoder.encodedSettlement(prices))
+        : await settlement
+            .connect(solver)
+            .settleLite(
+              encoder.tokens,
+              encoder.clearingPrices(prices),
+              encoder.trades,
+              encoder.interactions[1],
+            );
 
     return await transaction.wait();
   }

--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -327,20 +327,18 @@ export class BenchFixture {
       {},
     );
 
-    debug(`executing settlement`);
-    const transaction =
-      options.refunds > 0
-        ? await settlement
-            .connect(solver)
-            .settle(...encoder.encodedSettlement(prices))
-        : await settlement
-            .connect(solver)
-            .settleLite(
-              encoder.tokens,
-              encoder.clearingPrices(prices),
-              encoder.trades,
-              encoder.interactions[1],
-            );
+    let transaction;
+    if (encoder.isLite) {
+      debug(`executing lite settlement`);
+      transaction = await settlement
+        .connect(solver)
+        .settleLite(...encoder.encodedSettlementLite(prices));
+    } else {
+      debug(`executing full settlement`);
+      transaction = await settlement
+        .connect(solver)
+        .settle(...encoder.encodedSettlement(prices));
+    }
 
     return await transaction.wait();
   }

--- a/bench/uniswap/fixture.ts
+++ b/bench/uniswap/fixture.ts
@@ -146,8 +146,8 @@ export class UniswapFixture {
       }
     }
 
-    const transaction = await settlement.connect(solver).settle(
-      ...encoder.encodedSettlement({
+    const transaction = await settlement.connect(solver).settleLite(
+      ...encoder.encodedSettlementLite({
         [buyToken.address]: totalSellAmount,
         [sellToken.address]: totalBuyAmount,
       }),
@@ -306,6 +306,8 @@ export class UniswapFixture {
       ]),
     });
 
-    await settlement.connect(solver).settle(...encoder.encodedSettlement({}));
+    await settlement
+      .connect(solver)
+      .settleLite(...encoder.encodedSettlementLite({}));
   }
 }

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -137,6 +137,20 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
         emit Settlement(msg.sender);
     }
 
+    function settleLite(
+        IERC20[] calldata tokens,
+        uint256[] calldata clearingPrices,
+        GPv2Trade.Data[] calldata trades,
+        GPv2Interaction.Data[] calldata intraInteractions
+    ) external nonReentrant onlySolver {
+        GPv2TradeExecution.Data[] memory executedTrades =
+            computeTradeExecutions(tokens, clearingPrices, trades);
+        allowanceManager.transferIn(executedTrades);
+        executeInteractions(intraInteractions);
+        transferOut(executedTrades);
+        emit Settlement(msg.sender);
+    }
+
     /// @dev Invalidate onchain an order that has been signed offline.
     ///
     /// @param orderUid The unique identifier of the order that is to be made

--- a/src/ts/settlement.ts
+++ b/src/ts/settlement.ts
@@ -153,6 +153,8 @@ export type EncodedSettlementLite = [
   Trade[],
   /** Encoded intra-settlement interactions. */
   Interaction[],
+  /** Order UIDs for `filledAmount` storage refunds. */
+  BytesLike[],
 ];
 
 /**
@@ -301,13 +303,10 @@ export class SettlementEncoder {
    */
   public get isLite(): boolean {
     const [preInteractions, , postInteractions] = this.interactions;
-    const { filledAmounts, preSignatures } = this.orderRefunds;
-    return [
-      preInteractions,
-      postInteractions,
-      filledAmounts,
-      preSignatures,
-    ].every(({ length }) => length === 0);
+    const { preSignatures } = this.orderRefunds;
+    return [preInteractions, postInteractions, preSignatures].every(
+      ({ length }) => length === 0,
+    );
   }
 
   /**
@@ -454,6 +453,7 @@ export class SettlementEncoder {
       this.clearingPrices(prices),
       this.trades,
       this.interactions[InteractionStage.INTRA],
+      this.orderRefunds.filledAmounts,
     ];
   }
 

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -283,7 +283,9 @@ describe("GPv2Settlement", () => {
       });
 
       await expect(
-        settlement.connect(solver).settleLite(...encoder.encodedSettlement({})),
+        settlement
+          .connect(solver)
+          .settleLite(...encoder.encodedSettlementLite({})),
       ).to.be.revertedWith("reentrant call");
     });
 
@@ -296,7 +298,9 @@ describe("GPv2Settlement", () => {
       });
 
       await expect(
-        settlement.connect(solver).settleLite(...encoder.encodedSettlement({})),
+        settlement
+          .connect(solver)
+          .settleLite(...encoder.encodedSettlementLite({})),
       ).to.be.revertedWith("reentrant call");
     });
 

--- a/test/e2e/uniswapTrade.test.ts
+++ b/test/e2e/uniswapTrade.test.ts
@@ -167,8 +167,8 @@ describe("E2E: Should Trade Surplus With Uniswap", () => {
       ]),
     });
 
-    await settlement.connect(solver).settle(
-      ...encoder.encodedSettlement({
+    await settlement.connect(solver).settleLite(
+      ...encoder.encodedSettlementLite({
         [weth.address]: uniswapUsdtOutAmount,
         [usdt.address]: uniswapWethInAmount,
       }),


### PR DESCRIPTION
This PR proposes adding a separate function for "lite" settlements that only use intra-interactions and don't have refunds.

The motivation behind this change is to make small batches a little more gas efficient. Specifically this can help make it so only 3 trades are required to be batched in order to be more gas efficient than directly trading with Uniswap (see #410).

### Test Plan

Added some new tests, and converted one of the E2E tests to exercise the `settleLite` path.

<details><summary>Benchmarks</summary>

```
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
            2 |           10 |            0 |            0 |       764087  (change: -271 / trade)
            3 |           10 |            0 |            0 |       764607  (change: -276 / trade)
            4 |           10 |            0 |            0 |       773527  (change: -274 / trade)
            5 |           10 |            0 |            0 |       778235  (change: -274 / trade)
            6 |           10 |            0 |            0 |       774591  (change: -272 / trade)
            7 |           10 |            0 |            0 |       783511  (change: -267 / trade)
            8 |           10 |            0 |            0 |       788219  (change: -268 / trade)
            8 |           20 |            0 |            0 |      1487822  (change: -133 / trade)
            8 |           30 |            0 |            0 |      2149259  (change: -91 / trade)
            8 |           40 |            0 |            0 |      2815020  (change: -67 / trade)
            8 |           50 |            0 |            0 |      3481412  (change: -52 / trade)
            8 |           60 |            0 |            0 |      4143966  (change: -45 / trade)
            8 |           70 |            0 |            0 |      4810699  (change: -41 / trade)
            8 |           80 |            0 |            0 |      5476764  (change: -34 / trade)
            2 |           10 |            1 |            0 |       835681  (change: -272 / trade)
            2 |           10 |            2 |            0 |       882515  (change: -277 / trade)
            2 |           10 |            3 |            0 |       929433  (change: -270 / trade)
            2 |           10 |            4 |            0 |       976279  (change: -268 / trade)
            2 |           10 |            5 |            0 |      1023149  (change: -276 / trade)
            2 |           10 |            6 |            0 |      1070038  (change: -272 / trade)
            2 |           10 |            7 |            0 |      1116856  (change: -276 / trade)
            2 |           10 |            8 |            0 |      1163794  (change: -267 / trade)
            2 |           50 |            0 |           10 |      3181038  (change: 0 / trade)
            2 |           50 |            0 |           15 |      3140106  (change: 0 / trade)
            2 |           50 |            0 |           20 |      3099186  (change: 0 / trade)
            2 |           50 |            0 |           25 |      3058302  (change: 2 / trade)
            2 |           50 |            0 |           30 |      3017298  (change: 1 / trade)
            2 |           50 |            0 |           35 |      2976378  (change: 0 / trade)
            2 |           50 |            0 |           40 |      2935398  (change: -1 / trade)
            2 |           50 |            0 |           45 |      2894514  (change: 0 / trade)
            2 |           50 |            0 |           50 |      2853534  (change: -2 / trade)
            2 |            2 |            0 |            0 |       187992  (change: -1380 / trade)
            2 |            1 |            1 |            0 |       187492  (change: -2724 / trade)
           10 |          100 |           10 |           20 |      6741872  (change: 0 / trade)
```

</details>
