### PR TITLE
Combine order hashing methods into one.

### DIFF
--- a/src/contracts/mixins/GPv2Signing.sol
+++ b/src/contracts/mixins/GPv2Signing.sol
@@ -136,7 +136,7 @@ abstract contract GPv2Signing {
         Scheme signingScheme,
         bytes calldata signature
     ) internal view returns (bytes32 orderDigest, address owner) {
-        orderDigest = orderSigningHash(order);
+        orderDigest = order.hash(domainSeparator);
         if (signingScheme == Scheme.Eip712) {
             owner = recoverEip712Signer(orderDigest, signature);
         } else if (signingScheme == Scheme.EthSign) {
@@ -146,20 +146,6 @@ abstract contract GPv2Signing {
         } else if (signingScheme == Scheme.PreSign) {
             owner = recoverPreSigner(orderDigest, signature, order.validTo);
         }
-    }
-
-    /// @dev Returns the EIP-712 signing hash for the specified order.
-    ///
-    /// @param order The order to hash.
-    /// @return orderDigest The EIP-712 signing hash for the order.
-    function orderSigningHash(GPv2Order.Data memory order)
-        internal
-        view
-        returns (bytes32 orderDigest)
-    {
-        orderDigest = keccak256(
-            abi.encodePacked("\x19\x01", domainSeparator, order.hash())
-        );
     }
 
     /// @dev Perform an ECDSA recover for the specified message and calldata

--- a/src/contracts/test/GPv2OrderTestInterface.sol
+++ b/src/contracts/test/GPv2OrderTestInterface.sol
@@ -12,12 +12,12 @@ contract GPv2OrderTestInterface {
         return GPv2Order.TYPE_HASH;
     }
 
-    function hashTest(GPv2Order.Data memory order)
+    function hashTest(GPv2Order.Data memory order, bytes32 domainSeparator)
         external
         pure
         returns (bytes32 orderDigest)
     {
-        orderDigest = order.hash();
+        orderDigest = order.hash(domainSeparator);
     }
 
     function packOrderUidParamsTest(

--- a/src/contracts/test/GPv2SigningTestInterface.sol
+++ b/src/contracts/test/GPv2SigningTestInterface.sol
@@ -22,12 +22,4 @@ contract GPv2SigningTestInterface is GPv2Signing {
     ) external view returns (address owner) {
         (, owner) = recoverOrderSigner(order, signingScheme, signature);
     }
-
-    function orderSigningHashTest(GPv2Order.Data memory order)
-        external
-        view
-        returns (bytes32 orderDigest)
-    {
-        orderDigest = orderSigningHash(order);
-    }
 }

--- a/src/ts/order.ts
+++ b/src/ts/order.ts
@@ -176,10 +176,7 @@ export function normalizeOrder(order: Order): NormalizedOrder {
  * @param order The order to compute the digest for.
  * @return Hex-encoded 32-byte order digest.
  */
-export function orderSigningHash(
-  domain: TypedDataDomain,
-  order: Order,
-): string {
+export function hashOrder(domain: TypedDataDomain, order: Order): string {
   return ethers.utils._TypedDataEncoder.hash(
     domain,
     { Order: ORDER_TYPE_FIELDS },
@@ -219,7 +216,7 @@ export function computeOrderUid(
   owner: string,
 ): string {
   return packOrderUidParams({
-    orderDigest: orderSigningHash(domain, order),
+    orderDigest: hashOrder(domain, order),
     owner,
     validTo: order.validTo,
   });

--- a/src/ts/sign.ts
+++ b/src/ts/sign.ts
@@ -1,11 +1,6 @@
 import { BytesLike, ethers, Signer } from "ethers";
 
-import {
-  ORDER_TYPE_FIELDS,
-  Order,
-  normalizeOrder,
-  orderSigningHash,
-} from "./order";
+import { ORDER_TYPE_FIELDS, Order, normalizeOrder, hashOrder } from "./order";
 import {
   SignatureLike,
   isTypedDataSigner,
@@ -137,9 +132,7 @@ function ecdsaSignOrder(
       );
 
     case SigningScheme.ETHSIGN:
-      return owner.signMessage(
-        ethers.utils.arrayify(orderSigningHash(domain, order)),
-      );
+      return owner.signMessage(ethers.utils.arrayify(hashOrder(domain, order)));
 
     default:
       throw new Error("invalid signing scheme");

--- a/test/GPv2Order.test.ts
+++ b/test/GPv2Order.test.ts
@@ -4,9 +4,9 @@ import { ethers } from "hardhat";
 
 import {
   ORDER_TYPE_HASH,
-  ORDER_TYPE_FIELDS,
   ORDER_UID_LENGTH,
   OrderKind,
+  hashOrder,
   packOrderUidParams,
 } from "../src/ts";
 
@@ -37,7 +37,10 @@ describe("GPv2Order", () => {
   });
 
   describe("hash", () => {
-    it("computes EIP-712 order struct hash", async () => {
+    it("computes EIP-712 order signing hash", async () => {
+      const domain = { name: "test" };
+      const domainSeparator = ethers.utils._TypedDataEncoder.hashDomain(domain);
+
       const order = {
         sellToken: fillBytes(20, 0x01),
         buyToken: fillBytes(20, 0x02),
@@ -50,13 +53,10 @@ describe("GPv2Order", () => {
         kind: OrderKind.SELL,
         partiallyFillable: false,
       };
-      expect(await orders.hashTest(encodeOrder(order))).to.equal(
-        ethers.utils._TypedDataEncoder.hashStruct(
-          "Order",
-          { Order: ORDER_TYPE_FIELDS },
-          order,
-        ),
-      );
+
+      expect(
+        await orders.hashTest(encodeOrder(order), domainSeparator),
+      ).to.equal(hashOrder(domain, order));
     });
   });
 

--- a/test/GPv2Signing.test.ts
+++ b/test/GPv2Signing.test.ts
@@ -12,7 +12,7 @@ import {
   computeOrderUid,
   domain,
   encodeEip1271SignatureData,
-  orderSigningHash,
+  hashOrder,
   packOrderUidParams,
   signOrder,
 } from "../src/ts";
@@ -369,7 +369,7 @@ describe("GPv2Signing", () => {
       const artifact = await artifacts.readArtifact("EIP1271Verifier");
       const verifier = await waffle.deployMockContract(deployer, artifact.abi);
 
-      const message = orderSigningHash(testDomain, sampleOrder);
+      const message = hashOrder(testDomain, sampleOrder);
       const eip1271Signature = "0x031337";
       await verifier.mock.isValidSignature
         .withArgs(message, eip1271Signature)
@@ -388,7 +388,7 @@ describe("GPv2Signing", () => {
     });
 
     it("should revert on an invalid EIP-1271 signature", async () => {
-      const message = orderSigningHash(testDomain, sampleOrder);
+      const message = hashOrder(testDomain, sampleOrder);
       const eip1271Signature = "0x031337";
 
       const artifact = await artifacts.readArtifact("EIP1271Verifier");
@@ -410,7 +410,7 @@ describe("GPv2Signing", () => {
     });
 
     it("should revert with non-standard EIP-1271 verifiers", async () => {
-      const message = orderSigningHash(testDomain, sampleOrder);
+      const message = hashOrder(testDomain, sampleOrder);
       const eip1271Signature = "0x031337";
 
       const NON_STANDARD_EIP1271_VERIFIER = [
@@ -456,7 +456,7 @@ describe("GPv2Signing", () => {
       );
 
       const evilVerifier = await StateChangingEIP1271.deploy();
-      const message = orderSigningHash(testDomain, sampleOrder);
+      const message = hashOrder(testDomain, sampleOrder);
       const eip1271Signature = "0x";
 
       expect(await evilVerifier.state()).to.equal(ethers.constants.Zero);
@@ -538,14 +538,6 @@ describe("GPv2Signing", () => {
           "0x",
         ),
       ).to.be.revertedWith("malformed presignature");
-    });
-  });
-
-  describe("orderSigningHash", () => {
-    it("computes EIP-712 order signing hash", async () => {
-      expect(
-        await signing.orderSigningHashTest(encodeOrder(sampleOrder)),
-      ).to.equal(orderSigningHash(testDomain, sampleOrder));
     });
   });
 });

--- a/test/e2e/contractOrdersWithGnosisSafe.test.ts
+++ b/test/e2e/contractOrdersWithGnosisSafe.test.ts
@@ -12,7 +12,7 @@ import {
   SigningScheme,
   TypedDataDomain,
   domain,
-  orderSigningHash,
+  hashOrder,
 } from "../../src/ts";
 
 import { deployTestContracts } from "./fixture";
@@ -245,7 +245,7 @@ describe("E2E: Order From A Gnosis Safe", () => {
       validTo: UNLIMITED_VALID_TO,
       feeAmount: SAFE_FEE,
     };
-    const gpv2Message = orderSigningHash(domainSeparator, order);
+    const gpv2Message = hashOrder(domainSeparator, order);
     // Note: threshold is 2, any two owners should suffice.
     const signature = await fallbackSign(safe, gpv2Message, [
       safeOwners[4],


### PR DESCRIPTION
This PR just combines the hashing methods into one. For me having two separate order hashing methods was a bit weird when I was going over the code (especially since the `GPv2Order.hash` was only ever used for computing the signing hash). So this PR combines them into one.

A tiny bit of assembly was used as:
- it is small and very contained, without leaking out of the library method
- Saves a cool 120-140 gas per order :dollar: 

<details><summary>Benchmarks</summary>

```
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
            2 |           10 |            0 |            0 |       765578  (change: -122 / trade)
            3 |           10 |            0 |            0 |       766158  (change: -120 / trade)
            4 |           10 |            0 |            0 |       775090  (change: -118 / trade)
            5 |           10 |            0 |            0 |       779786  (change: -119 / trade)
            6 |           10 |            0 |            0 |       776118  (change: -119 / trade)
            7 |           10 |            0 |            0 |       785014  (change: -117 / trade)
            8 |           10 |            0 |            0 |       789698  (change: -120 / trade)
            8 |           20 |            0 |            0 |      1488112  (change: -118 / trade)
            8 |           30 |            0 |            0 |      2148251  (change: -125 / trade)
            8 |           40 |            0 |            0 |      2812657  (change: -126 / trade)
            8 |           50 |            0 |            0 |      3477713  (change: -126 / trade)
            8 |           60 |            0 |            0 |      4138920  (change: -129 / trade)
            8 |           70 |            0 |            0 |      4804235  (change: -133 / trade)
            8 |           80 |            0 |            0 |      5468850  (change: -133 / trade)
            2 |           10 |            1 |            0 |       837184  (change: -122 / trade)
            2 |           10 |            2 |            0 |       884066  (change: -122 / trade)
            2 |           10 |            3 |            0 |       930924  (change: -120 / trade)
            2 |           10 |            4 |            0 |       977818  (change: -114 / trade)
            2 |           10 |            5 |            0 |      1024724  (change: -118 / trade)
            2 |           10 |            6 |            0 |      1071565  (change: -119 / trade)
            2 |           10 |            7 |            0 |      1118431  (change: -118 / trade)
            2 |           10 |            8 |            0 |      1165344  (change: -112 / trade)
            2 |           50 |            0 |           10 |      3174581  (change: -128 / trade)
            2 |           50 |            0 |           15 |      3133757  (change: -127 / trade)
            2 |           50 |            0 |           20 |      3092705  (change: -129 / trade)
            2 |           50 |            0 |           25 |      3051845  (change: -126 / trade)
            2 |           50 |            0 |           30 |      3010961  (change: -125 / trade)
            2 |           50 |            0 |           35 |      2969945  (change: -127 / trade)
            2 |           50 |            0 |           40 |      2929037  (change: -128 / trade)
            2 |           50 |            0 |           45 |      2888117  (change: -127 / trade)
            2 |           50 |            0 |           50 |      2847197  (change: -128 / trade)
            2 |            2 |            0 |            0 |       190513  (change: -119 / trade)
            2 |            1 |            1 |            0 |       190075  (change: -141 / trade)
           10 |          100 |           10 |           20 |      6728029  (change: -138 / trade)
```

</details>

We can easily remove the assembly and replace it with `keccak256(abi.encodePacked(...))` if we don't want it, and keep the change to combine the order hashing methods.

### Test Plan

CI still passes.
