### PR TITLE
More ASM 🙈: Optimized Safe ERC20 library.

### DIFF
--- a/src/contracts/libraries/GPv2SafeERC20.sol
+++ b/src/contracts/libraries/GPv2SafeERC20.sol
@@ -61,7 +61,7 @@ library GPv2SafeERC20 {
     /// @dev Verifies that the last return was a successful `transfer*` call.
     /// This is done by checking that the return data is either empty, or
     /// is a valid ABI encoded boolean.
-    function getLastTansferResult() private returns (bool success) {
+    function getLastTansferResult() private pure returns (bool success) {
         // NOTE: Inspecting previous return data requires assembly. Note that
         // we write the return data to memory 0 in the case where the return
         // data size is 32, this is OK since the first 64 bytes of memory are

--- a/src/contracts/libraries/GPv2SafeERC20.sol
+++ b/src/contracts/libraries/GPv2SafeERC20.sol
@@ -28,7 +28,7 @@ library GPv2SafeERC20 {
             }
         }
 
-        require(getLastTansferResult(), "GPv2SafeERC20: failed transferFrom");
+        require(getLastTansferResult(), "GPv2: failed transfer");
     }
 
     /// @dev Wrapper around a call to the ERC20 function `transferFrom` that
@@ -55,7 +55,7 @@ library GPv2SafeERC20 {
             }
         }
 
-        require(getLastTansferResult(), "GPv2SafeERC20: failed transferFrom");
+        require(getLastTansferResult(), "GPv2: failed transferFrom");
     }
 
     /// @dev Verifies that the last return was a successful `transfer*` call.

--- a/src/contracts/libraries/GPv2SafeERC20.sol
+++ b/src/contracts/libraries/GPv2SafeERC20.sol
@@ -21,7 +21,10 @@ library GPv2SafeERC20 {
         assembly {
             let freeMemoryPointer := mload(0x40)
             mstore(freeMemoryPointer, selector_)
-            mstore(add(freeMemoryPointer, 4), to)
+            mstore(
+                add(freeMemoryPointer, 4),
+                and(to, 0xffffffffffffffffffffffffffffffffffffffff)
+            )
             mstore(add(freeMemoryPointer, 36), value)
 
             if iszero(call(gas(), token, 0, freeMemoryPointer, 68, 0, 0)) {
@@ -47,8 +50,14 @@ library GPv2SafeERC20 {
         assembly {
             let freeMemoryPointer := mload(0x40)
             mstore(freeMemoryPointer, selector_)
-            mstore(add(freeMemoryPointer, 4), from)
-            mstore(add(freeMemoryPointer, 36), to)
+            mstore(
+                add(freeMemoryPointer, 4),
+                and(from, 0xffffffffffffffffffffffffffffffffffffffff)
+            )
+            mstore(
+                add(freeMemoryPointer, 36),
+                and(to, 0xffffffffffffffffffffffffffffffffffffffff)
+            )
             mstore(add(freeMemoryPointer, 68), value)
 
             if iszero(call(gas(), token, 0, freeMemoryPointer, 100, 0, 0)) {

--- a/src/contracts/libraries/GPv2SafeERC20.sol
+++ b/src/contracts/libraries/GPv2SafeERC20.sol
@@ -3,10 +3,8 @@ pragma solidity ^0.7.6;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-/// @title GPv2SafeERC20
+/// @title Gnosis Protocol v2 Safe ERC20 Transfer Library
 /// @author Gnosis Developers
-/// @dev Gas-efficient version of Openzeppelin's SafeERC20 contract that does
-/// not revert when calling a non-contract.
 library GPv2SafeERC20 {
     /// @dev Wrapper around a call to the ERC20 function `transfer` that reverts
     /// also when the token returns `false`.
@@ -18,7 +16,6 @@ library GPv2SafeERC20 {
         bytes4 selector_ = token.transfer.selector;
 
         // solhint-disable-next-line no-inline-assembly
-        bool success;
         assembly {
             let freeMemoryPointer := mload(0x40)
             mstore(freeMemoryPointer, selector_)
@@ -29,24 +26,9 @@ library GPv2SafeERC20 {
                 returndatacopy(0, 0, returndatasize())
                 revert(0, returndatasize())
             }
-
-            switch returndatasize()
-                case 0 {
-                    success := 1
-                }
-                case 32 {
-                    returndatacopy(0, 0, returndatasize())
-                    success := mload(0)
-                    if gt(success, 1) {
-                        revert(0, 0)
-                    }
-                }
-                default {
-                    revert(0, 0)
-                }
         }
 
-        require(success, "GPv2SafeERC20: failed transfer");
+        require(getLastTansferResult(), "GPv2SafeERC20: failed transferFrom");
     }
 
     /// @dev Wrapper around a call to the ERC20 function `transferFrom` that
@@ -60,7 +42,6 @@ library GPv2SafeERC20 {
         bytes4 selector_ = token.transferFrom.selector;
 
         // solhint-disable-next-line no-inline-assembly
-        bool success;
         assembly {
             let freeMemoryPointer := mload(0x40)
             mstore(freeMemoryPointer, selector_)
@@ -72,15 +53,35 @@ library GPv2SafeERC20 {
                 returndatacopy(0, 0, returndatasize())
                 revert(0, returndatasize())
             }
+        }
 
+        require(getLastTansferResult(), "GPv2SafeERC20: failed transferFrom");
+    }
+
+    /// @dev Verifies that the last return was a successful `transfer*` call.
+    /// This is done by checking that the return data is either empty, or
+    /// is a valid ABI encoded boolean.
+    function getLastTansferResult() private returns (bool success) {
+        // NOTE: Inspecting previous return data requires assembly. Note that
+        // we write the return data to memory 0 in the case where the return
+        // data size is 32, this is OK since the first 64 bytes of memory are
+        // reserved by Solidy as a scratch space that can be used within
+        // assembly blocks.
+        // <https://docs.soliditylang.org/en/v0.7.6/internals/layout_in_memory.html>
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
             switch returndatasize()
+                // Non-standard ERC20 transfer without return.
                 case 0 {
                     success := 1
                 }
+                // Standard ERC20 transfer returning boolean success value.
                 case 32 {
                     returndatacopy(0, 0, returndatasize())
                     success := mload(0)
                     if gt(success, 1) {
+                        // NOTE: Not a valid ABI encoded boolean, which must be
+                        // either 0 or 1.
                         revert(0, 0)
                     }
                 }
@@ -88,7 +89,5 @@ library GPv2SafeERC20 {
                     revert(0, 0)
                 }
         }
-
-        require(success, "GPv2SafeERC20: failed transfer");
     }
 }

--- a/test/ERC20.ts
+++ b/test/ERC20.ts
@@ -2,3 +2,8 @@ export const NON_STANDARD_ERC20 = [
   "function transfer(address recipient, uint256 amount)",
   "function transferFrom(address sender, address recipient, uint256 amount)",
 ];
+
+export const ERC20_RETURNING_UINT = [
+  "function transfer(address recipient, uint256 amount) returns (uint256)",
+  "function transferFrom(address sender, address recipient, uint256 amount) returns (uint256)",
+];

--- a/test/ERC20.ts
+++ b/test/ERC20.ts
@@ -3,6 +3,11 @@ export const NON_STANDARD_ERC20 = [
   "function transferFrom(address sender, address recipient, uint256 amount)",
 ];
 
+export const ERC20_RETURNING_BYTES = [
+  "function transfer(address recipient, uint256 amount) returns (bytes)",
+  "function transferFrom(address sender, address recipient, uint256 amount) returns (bytes)",
+];
+
 export const ERC20_RETURNING_UINT = [
   "function transfer(address recipient, uint256 amount) returns (uint256)",
   "function transferFrom(address sender, address recipient, uint256 amount) returns (uint256)",

--- a/test/GPv2SafeERC20.test.ts
+++ b/test/GPv2SafeERC20.test.ts
@@ -72,7 +72,7 @@ describe("GPv2SafeERC20.sol", () => {
 
         await expect(
           executor.transfer(sellToken.address, recipient.address, amount),
-        ).to.be.revertedWith("GPv2SafeERC20: failed transfer");
+        ).to.be.revertedWith("failed transfer");
       });
 
       it("reverts when invalid ABI encoded bool is returned", async () => {
@@ -175,7 +175,7 @@ describe("GPv2SafeERC20.sol", () => {
             recipient.address,
             amount,
           ),
-        ).to.be.revertedWith("GPv2SafeERC20: failed transfer");
+        ).to.be.revertedWith("failed transferFrom");
       });
 
       it("reverts when invalid ABI encoded bool is returned", async () => {

--- a/test/GPv2SafeERC20.test.ts
+++ b/test/GPv2SafeERC20.test.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 import { Contract } from "ethers";
 import { ethers, waffle } from "hardhat";
 
-import { NON_STANDARD_ERC20 } from "./ERC20";
+import { NON_STANDARD_ERC20, ERC20_RETURNING_UINT } from "./ERC20";
 
 describe("GPv2SafeERC20.sol", () => {
   const [deployer, recipient, ...traders] = waffle.provider.getWallets();
@@ -73,6 +73,22 @@ describe("GPv2SafeERC20.sol", () => {
         await expect(
           executor.transfer(sellToken.address, recipient.address, amount),
         ).to.be.revertedWith("GPv2SafeERC20: failed transfer");
+      });
+
+      it("reverts when invalid ABI encoded bool is returned", async () => {
+        const amount = ethers.utils.parseEther("1.0");
+
+        const sellToken = await waffle.deployMockContract(
+          deployer,
+          ERC20_RETURNING_UINT,
+        );
+        await sellToken.mock.transfer
+          .withArgs(recipient.address, amount)
+          .returns(42);
+
+        await expect(
+          executor.transfer(sellToken.address, recipient.address, amount),
+        ).to.be.reverted;
       });
     });
 
@@ -160,6 +176,27 @@ describe("GPv2SafeERC20.sol", () => {
             amount,
           ),
         ).to.be.revertedWith("GPv2SafeERC20: failed transfer");
+      });
+
+      it("reverts when invalid ABI encoded bool is returned", async () => {
+        const amount = ethers.utils.parseEther("1.0");
+
+        const sellToken = await waffle.deployMockContract(
+          deployer,
+          ERC20_RETURNING_UINT,
+        );
+        await sellToken.mock.transfer
+          .withArgs(recipient.address, amount)
+          .returns(42);
+
+        await expect(
+          executor.transferFrom(
+            sellToken.address,
+            traders[0].address,
+            recipient.address,
+            amount,
+          ),
+        ).to.be.reverted;
       });
     });
 

--- a/test/GPv2SafeERC20.test.ts
+++ b/test/GPv2SafeERC20.test.ts
@@ -95,7 +95,7 @@ describe("GPv2SafeERC20.sol", () => {
         ).to.be.revertedWith("malformed transfer result");
       });
 
-      it("reverts when invalid ABI encoded bool is returned", async () => {
+      it("coerces invalid ABI encoded bool", async () => {
         const amount = ethers.utils.parseEther("1.0");
 
         const sellToken = await waffle.deployMockContract(
@@ -108,7 +108,7 @@ describe("GPv2SafeERC20.sol", () => {
 
         await expect(
           executor.transfer(sellToken.address, recipient.address, amount),
-        ).to.be.revertedWith("invalid transfer result");
+        ).to.not.be.reverted;
       });
     });
 
@@ -219,7 +219,7 @@ describe("GPv2SafeERC20.sol", () => {
         ).to.be.revertedWith("malformed transfer result");
       });
 
-      it("reverts when invalid ABI encoded bool is returned", async () => {
+      it("coerces invalid ABI encoded bool", async () => {
         const amount = ethers.utils.parseEther("1.0");
 
         const sellToken = await waffle.deployMockContract(
@@ -237,7 +237,7 @@ describe("GPv2SafeERC20.sol", () => {
             recipient.address,
             amount,
           ),
-        ).to.be.revertedWith("invalid transfer result");
+        ).to.not.be.reverted;
       });
     });
 

--- a/test/GPv2TradeExecution.test.ts
+++ b/test/GPv2TradeExecution.test.ts
@@ -143,7 +143,7 @@ describe("GPv2TradeExecution", () => {
             },
             recipient.address,
           ),
-        ).to.be.revertedWith("GPv2SafeERC20: failed transfer");
+        ).to.be.revertedWith("failed transferFrom");
       });
     });
   });
@@ -310,7 +310,7 @@ describe("GPv2TradeExecution", () => {
             buyAmount: amount,
             ...withoutSell,
           }),
-        ).to.be.revertedWith("GPv2SafeERC20: failed transfer");
+        ).to.be.revertedWith("failed transfer");
       });
     });
   });


### PR DESCRIPTION
This PR proposes a further optimized safe ERC20 implementation.

While this adds more assembly, it was already previously implemented with low level calls and some assembly. Also the "hackiness" is completely contained within the library methods.

This saves roughly 1250 gas per trade! (So we've almost made up for the loss of efficiency with the encoding :tada:).

### Test Plan

Existing tests still pass, added some new ones for added branches that were previously protected by Solidity.

<details><summary>Benchmarks</summary>

```
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
            2 |           10 |            0 |            0 |       752909  (change: -1266 / trade)
            3 |           10 |            0 |            0 |       753453  (change: -1270 / trade)
            4 |           10 |            0 |            0 |       762433  (change: -1265 / trade)
            5 |           10 |            0 |            0 |       767165  (change: -1262 / trade)
            6 |           10 |            0 |            0 |       763437  (change: -1268 / trade)
            7 |           10 |            0 |            0 |       772357  (change: -1265 / trade)
            8 |           10 |            0 |            0 |       777041  (change: -1265 / trade)
            8 |           20 |            0 |            0 |      1462757  (change: -1267 / trade)
            8 |           30 |            0 |            0 |      2110171  (change: -1269 / trade)
            8 |           40 |            0 |            0 |      2761969  (change: -1267 / trade)
            8 |           50 |            0 |            0 |      3414207  (change: -1270 / trade)
            8 |           60 |            0 |            0 |      4062729  (change: -1269 / trade)
            8 |           70 |            0 |            0 |      4715201  (change: -1271 / trade)
            8 |           80 |            0 |            0 |      5366982  (change: -1273 / trade)
            2 |           10 |            1 |            0 |       824515  (change: -1266 / trade)
            2 |           10 |            2 |            0 |       871421  (change: -1264 / trade)
            2 |           10 |            3 |            0 |       918255  (change: -1266 / trade)
            2 |           10 |            4 |            0 |       965125  (change: -1269 / trade)
            2 |           10 |            5 |            0 |      1012043  (change: -1268 / trade)
            2 |           10 |            6 |            0 |      1058889  (change: -1267 / trade)
            2 |           10 |            7 |            0 |      1105783  (change: -1264 / trade)
            2 |           10 |            8 |            0 |      1152629  (change: -1271 / trade)
            2 |           50 |            0 |           10 |      3111123  (change: -1269 / trade)
            2 |           50 |            0 |           15 |      3070203  (change: -1271 / trade)
            2 |           50 |            0 |           20 |      3029307  (change: -1267 / trade)
            2 |           50 |            0 |           25 |      2988291  (change: -1271 / trade)
            2 |           50 |            0 |           30 |      2947371  (change: -1271 / trade)
            2 |           50 |            0 |           35 |      2906367  (change: -1271 / trade)
            2 |           50 |            0 |           40 |      2865579  (change: -1269 / trade)
            2 |           50 |            0 |           45 |      2824611  (change: -1270 / trade)
            2 |           50 |            0 |           50 |      2783655  (change: -1270 / trade)
            2 |            2 |            0 |            0 |       187984  (change: -1264 / trade)
            2 |            1 |            1 |            0 |       188836  (change: -1239 / trade)
           10 |          100 |           10 |           20 |      6600792  (change: -1272 / trade)
```

</details>
