### PR TITLE
Assembly for calling interaction

### DIFF
--- a/src/contracts/libraries/GPv2Interaction.sol
+++ b/src/contracts/libraries/GPv2Interaction.sol
@@ -20,6 +20,13 @@ library GPv2Interaction {
         uint256 value = interaction.value;
         bytes calldata callData = interaction.callData;
 
+        // NOTE: Use assembly to call the interaction instead of a low level
+        // call for two reasons:
+        // - We don't want to copy the return data, since we discard it for
+        // interactions.
+        // - Solidity will under certain conditions generate code to copy input
+        // calldata twice to memory (the second being a "memcopy loop").
+        // <https://github.com/gnosis/gp-v2-contracts/pull/417#issuecomment-775091258>
         // solhint-disable-next-line no-inline-assembly
         assembly {
             let freeMemoryPointer := mload(0x40)

--- a/src/contracts/libraries/GPv2Interaction.sol
+++ b/src/contracts/libraries/GPv2Interaction.sol
@@ -16,18 +16,27 @@ library GPv2Interaction {
     ///
     /// @param interaction Interaction data.
     function execute(Data calldata interaction) internal {
-        // solhint-disable avoid-low-level-calls
-        (bool success, bytes memory response) =
-            (interaction.target).call{value: interaction.value}(
-                interaction.callData
-            );
-        // solhint-enable avoid-low-level-calls
+        address target = interaction.target;
+        uint256 value = interaction.value;
+        bytes calldata callData = interaction.callData;
 
-        if (!success) {
-            // Assembly used to revert with correctly encoded error message.
-            // solhint-disable-next-line no-inline-assembly
-            assembly {
-                revert(add(response, 0x20), mload(response))
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            let freeMemoryPointer := mload(0x40)
+            calldatacopy(freeMemoryPointer, callData.offset, callData.length)
+            if iszero(
+                call(
+                    gas(),
+                    target,
+                    value,
+                    freeMemoryPointer,
+                    callData.length,
+                    0,
+                    0
+                )
+            ) {
+                returndatacopy(0, 0, returndatasize())
+                revert(0, returndatasize())
             }
         }
     }


### PR DESCRIPTION
This is a follow up to #417 applied to interactions.

Use assembly to avoid memory copy loop that the compiler generates for `CALL` and don't read return data unless call fails (since interactions ignore return data). This reduces interaction costs ~250 gas per Uniswap. For interactions with more call data, this will have a more pronounced effect.

I don't know if this is worth merging either, just tried it out following the discussion in #417 and created this PR to discuss what we should do with this information.

### Test Plan

Unit tests still pass.

<details><summary>Benchmarks</summary>

```
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
            2 |           10 |            0 |            0 |       765590  (change: 2 / trade)
            3 |           10 |            0 |            0 |       766170  (change: 6 / trade)
            4 |           10 |            0 |            0 |       775066  (change: 0 / trade)
            5 |           10 |            0 |            0 |       779786  (change: -2 / trade)
            6 |           10 |            0 |            0 |       776106  (change: -2 / trade)
            7 |           10 |            0 |            0 |       785026  (change: 2 / trade)
            8 |           10 |            0 |            0 |       789710  (change: 0 / trade)
            8 |           20 |            0 |            0 |      1488052  (change: -1 / trade)
            8 |           30 |            0 |            0 |      2148251  (change: 0 / trade)
            8 |           40 |            0 |            0 |      2812705  (change: 2 / trade)
            8 |           50 |            0 |            0 |      3477761  (change: 0 / trade)
            8 |           60 |            0 |            0 |      4138932  (change: 0 / trade)
            8 |           70 |            0 |            0 |      4804223  (change: -1 / trade)
            8 |           80 |            0 |            0 |      5468910  (change: 1 / trade)
            2 |           10 |            1 |            0 |       836946  (change: -25 / trade)
            2 |           10 |            2 |            0 |       883566  (change: -50 / trade)
            2 |           10 |            3 |            0 |       930222  (change: -69 / trade)
            2 |           10 |            4 |            0 |       976830  (change: -97 / trade)
            2 |           10 |            5 |            0 |      1023474  (change: -125 / trade)
            2 |           10 |            6 |            0 |      1070046  (change: -150 / trade)
            2 |           10 |            7 |            0 |      1116642  (change: -175 / trade)
            2 |           10 |            8 |            0 |      1163298  (change: -203 / trade)
            2 |           50 |            0 |           10 |      3174569  (change: -1 / trade)
            2 |           50 |            0 |           15 |      3133709  (change: 0 / trade)
            2 |           50 |            0 |           20 |      3092753  (change: 0 / trade)
            2 |           50 |            0 |           25 |      3051893  (change: 1 / trade)
            2 |           50 |            0 |           30 |      3010901  (change: 0 / trade)
            2 |           50 |            0 |           35 |      2969981  (change: 0 / trade)
            2 |           50 |            0 |           40 |      2929061  (change: 0 / trade)
            2 |           50 |            0 |           45 |      2888213  (change: 0 / trade)
            2 |           50 |            0 |           50 |      2847185  (change: -1 / trade)
            2 |            2 |            0 |            0 |       190513  (change: 6 / trade)
            2 |            1 |            1 |            0 |       189849  (change: -250 / trade)
           10 |          100 |           10 |           20 |      6725673  (change: -24 / trade)
```

</details>
