### PR TITLE
Add order filled amount refunds to lite settlement

### DIFF
--- a/src/ts/settlement.ts
+++ b/src/ts/settlement.ts
@@ -153,6 +153,8 @@ export type EncodedSettlementLite = [
   Trade[],
   /** Encoded intra-settlement interactions. */
   Interaction[],
+  /** Order UIDs for `filledAmount` storage refunds. */
+  BytesLike[],
 ];
 
 /**
@@ -301,13 +303,10 @@ export class SettlementEncoder {
    */
   public get isLite(): boolean {
     const [preInteractions, , postInteractions] = this.interactions;
-    const { filledAmounts, preSignatures } = this.orderRefunds;
-    return [
-      preInteractions,
-      postInteractions,
-      filledAmounts,
-      preSignatures,
-    ].every(({ length }) => length === 0);
+    const { preSignatures } = this.orderRefunds;
+    return [preInteractions, postInteractions, preSignatures].every(
+      ({ length }) => length === 0,
+    );
   }
 
   /**
@@ -454,6 +453,7 @@ export class SettlementEncoder {
       this.clearingPrices(prices),
       this.trades,
       this.interactions[InteractionStage.INTRA],
+      this.orderRefunds.filledAmounts,
     ];
   }
 


### PR DESCRIPTION
This PR adds order filled amount refunds to the lite settlement.

The rational behind this change is that this "lite" settlement is likely to be used instead of the proposed `settleSingleOrder` settlement when there is more than one trade to settle at once. In that case, it is very likely that there are order filled amount refunds to use from previous `settleSingleOrder`s, which is likely to be the most common case.

The added cost in that case (for 2 orders) is roughly 293 gas/per order:
```
$ yarn bench:compare settle-lite
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
...
            2 |            2 |            0 |            0 |       185876  (change: 293 / trade)
...
```

This is still a nice improvement over the full settlement for these small batches:
```
$ yarn bench:compare settle-lite
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
...
            2 |            2 |            0 |            0 |       185876  (change: -1075 / trade)
...
```

### Test Plan

Tests still pass, added unit test for verifying filled amount order refunds are getting processed.

Also, despite this change, batching Uniswaps (even if they are in the same direction) is more gas efficient if we have 3 or more orders in the single hop case, regardless of whether or not we use the router.

<details><summary>Uniswap Gas Benchmarks</summary>

```
--------------+--------------+--------------+--------------+--------------
         hops |   use router |   batch size |  direct swap |   batch swap 
--------------+--------------+--------------+--------------+--------------
            1 |         true |            1 |       112166 |       194461 
            1 |         true |            2 |       112166 |       134552 
            1 |         true |            3 |       112166 |       111775 
            1 |         true |            4 |       112166 |       102490 
            1 |         true |            5 |       112166 |        96077 
            1 |        false |            1 |       112166 |       178285 
            1 |        false |            2 |       112166 |       126464 
            1 |        false |            3 |       112166 |       107787 
            1 |        false |            4 |       112166 |        98428 
            1 |        false |            5 |       112166 |        92844 
            2 |         true |            1 |       173691 |       256001 
            2 |         true |            2 |       173691 |       165316 
            2 |         true |            3 |       173691 |       132285 
            2 |         true |            4 |       173691 |       117857 
            2 |         true |            5 |       173691 |       108388 
            2 |        false |            1 |       173691 |       236574 
            2 |        false |            2 |       173691 |       155602 
            2 |        false |            3 |       173691 |       127217 
            2 |        false |            4 |       173691 |       113016 
            2 |        false |            5 |       173691 |       104500 
            3 |         true |            1 |       235618 |       317922 
            3 |         true |            2 |       235618 |       194181 
            3 |         true |            3 |       235618 |       152904 
            3 |         true |            4 |       235618 |       133349 
            3 |         true |            5 |       235618 |       120774 
            3 |        false |            1 |       235618 |       295284 
            3 |        false |            2 |       235618 |       184957 
            3 |        false |            3 |       235618 |       145387 
            3 |        false |            4 |       235618 |       127693 
            3 |        false |            5 |       235618 |       116244
```

</details>