### PR TITLE
Bump @gnosis.pm/util-contracts from 3.0.1-solc-7 to 3.1.0-solc-7

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@0x/contract-artifacts": "=2.2.2",
     "@gnosis.pm/safe-contracts": "=1.2.0",
-    "@gnosis.pm/util-contracts": "=3.0.1-solc-7",
+    "@gnosis.pm/util-contracts": "=3.1.0-solc-7",
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -525,10 +525,10 @@
     solc "0.5.17"
     truffle "^5.1.21"
 
-"@gnosis.pm/util-contracts@=3.0.1-solc-7":
-  version "3.0.1-solc-7"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/util-contracts/-/util-contracts-3.0.1-solc-7.tgz#453dd78e038bbb4b2db43672a8f1283969ac2ee2"
-  integrity sha512-8/dlsGoxxaq9dn+7uBJupZECQJKVuW3H/eGumWuq31FOhWh3J0nTMQjFKxbpkM6CakOZd7VlQKfO4hHhWmtPxQ==
+"@gnosis.pm/util-contracts@=3.1.0-solc-7":
+  version "3.1.0-solc-7"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/util-contracts/-/util-contracts-3.1.0-solc-7.tgz#3c5e116052ea0b24fde2abd05676d3c6276173fe"
+  integrity sha512-I8mQuCoh8B92tKMdaUvXtiZRoK1kClG1vYMl5/a0kat+8an/ch2olxbVB4jeDwwmkRCHIHI/WiSqNQbPHn9ihQ==
   dependencies:
     "@truffle/hdwallet-provider" "^1.0.42"
 


### PR DESCRIPTION
This PR bumps to the latest @gnosis.pm/util-contracts release on the `solc-7` branch. The reason this wasn't picked up by dependabot is because the package's `latest` dist-tag is the older `3.0.1` for the `solc-6` branch.

The [release is quite small](https://github.com/gnosis/util-contracts/releases/tag/v3.1.0-solc-7) and only changes the visibility modifiers of the `StorageAccessible` contract.

### Test Plan

CI still passes, no code changes.
