### PR TITLE
Reuse `Trade` abstraction in single trade settlement fast-path.

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -159,7 +159,6 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
         GPv2Trade.Data calldata trade,
         GPv2AllowanceManager.Transfer[] calldata transfers,
         GPv2Interaction.Data[] calldata interactions
-        //bytes[] calldata filledAmountRefunds
     ) external nonReentrant onlySolver {
         RecoveredOrder memory recoveredOrder = allocateRecoveredOrder();
         recoverOrderFromTrade(recoveredOrder, tokens, trade);
@@ -170,8 +169,6 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
             interactions,
             trade.feeDiscount
         );
-
-        //freeOrderStorage(filledAmountRefunds, filledAmount);
 
         emit Settlement(msg.sender);
     }

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -158,8 +158,8 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
         IERC20[] calldata tokens,
         GPv2Trade.Data calldata trade,
         GPv2AllowanceManager.Transfer[] calldata transfers,
-        GPv2Interaction.Data[] calldata interactions,
-        bytes[] calldata filledAmountRefunds
+        GPv2Interaction.Data[] calldata interactions
+        //bytes[] calldata filledAmountRefunds
     ) external nonReentrant onlySolver {
         RecoveredOrder memory recoveredOrder = allocateRecoveredOrder();
         recoverOrderFromTrade(recoveredOrder, tokens, trade);
@@ -171,7 +171,7 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
             trade.feeDiscount
         );
 
-        freeOrderStorage(filledAmountRefunds, filledAmount);
+        //freeOrderStorage(filledAmountRefunds, filledAmount);
 
         emit Settlement(msg.sender);
     }

--- a/src/contracts/libraries/GPv2Order.sol
+++ b/src/contracts/libraries/GPv2Order.sol
@@ -64,8 +64,32 @@ library GPv2Order {
     bytes32 internal constant BUY =
         hex"6ed88e868af0a1983e3886d5f3e95a2fafbd6c3450bc229e27342283dc429ccc";
 
+    /// @dev Marker address used to indicate that the receiver of the trade
+    /// proceeds should the owner of the order.
+    ///
+    /// This is chosen to be `address(0)` for gas efficiency as it is expected
+    /// to be the most common case.
+    address internal constant RECEIVER_SAME_AS_OWNER = address(0);
+
     /// @dev The byte length of an order unique identifier.
     uint256 internal constant UID_LENGTH = 56;
+
+    /// @dev Returns the actual receiver for an order. This function checks
+    /// whether or not the [`receiver`] field uses the marker value to indicate
+    /// it is the same as the order owner.
+    ///
+    /// @return receiver The actual receiver of trade proceeds.
+    function actualReceiver(Data memory order, address owner)
+        internal
+        pure
+        returns (address receiver)
+    {
+        if (order.receiver == RECEIVER_SAME_AS_OWNER) {
+            receiver = owner;
+        } else {
+            receiver = order.receiver;
+        }
+    }
 
     /// @dev Return the EIP-712 signing hash for the specified order.
     ///

--- a/src/contracts/libraries/GPv2TradeExecution.sol
+++ b/src/contracts/libraries/GPv2TradeExecution.sol
@@ -23,10 +23,6 @@ library GPv2TradeExecution {
     address internal constant BUY_ETH_ADDRESS =
         0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
-    /// @dev Marker address used to indicate that the receiver of the trade
-    /// proceeds should the owner of the order.
-    address internal constant RECEIVER_SAME_AS_OWNER = address(0);
-
     /// @dev Executes the trade's sell amount, transferring it from the trade's
     /// owner to the specified recipient.
     function transferSellAmountToRecipient(
@@ -47,15 +43,10 @@ library GPv2TradeExecution {
     /// @dev Executes the trade's buy amount, transferring it to the trade's
     /// receiver from the caller's address.
     function transferBuyAmountToOwner(Data memory trade) internal {
-        address receiver = trade.receiver;
-        if (receiver == RECEIVER_SAME_AS_OWNER) {
-            receiver = trade.owner;
-        }
-
         if (address(trade.buyToken) == BUY_ETH_ADDRESS) {
-            payable(receiver).transfer(trade.buyAmount);
+            payable(trade.receiver).transfer(trade.buyAmount);
         } else {
-            trade.buyToken.safeTransfer(receiver, trade.buyAmount);
+            trade.buyToken.safeTransfer(trade.receiver, trade.buyAmount);
         }
     }
 }

--- a/src/ts/settlement.ts
+++ b/src/ts/settlement.ts
@@ -142,6 +142,32 @@ export type EncodedSettlement = [
 ];
 
 /**
+ * Direct transfers used in "fast-path" for settling single trades.
+ */
+export interface Transfer {
+  /** Receiver of the user funds. */
+  target: string;
+  /** Amount to transfer. */
+  amount: BigNumberish;
+}
+
+/**
+ * Encoded single trade settlement parameters.
+ */
+export type EncodedSingleTradeSettlement = [
+  /** Tokens. */
+  [string, string],
+  /** Encoded trade. */
+  Trade,
+  /** Encoded transfers. */
+  Transfer[],
+  /** Encoded interactions for executing a single trade order. */
+  Interaction[],
+  /** Encoded filled amount refunds. */
+  BytesLike[],
+];
+
+/**
  * Maximum number of trades that can be included in a single call to the settle
  * function.
  */
@@ -288,6 +314,22 @@ export class SettlementEncoder {
   }
 
   /**
+   * Returns whether the currently encoded settlement can be executed with the
+   * `settleOne` single trade settlement "fast-path".
+   */
+  public get isSingleTradeSettlement(): boolean {
+    const [preInteractions, , postInteractions] = this.interactions;
+    const { preSignatures } = this.orderRefunds;
+    return (
+      this.tokens.length === 2 &&
+      this.trades.length === 1 &&
+      [preInteractions, postInteractions, preSignatures].every(
+        ({ length }) => length === 0,
+      )
+    );
+  }
+
+  /**
    * Returns a clearing price vector for the current settlement tokens from the
    * provided price map.
    *
@@ -415,6 +457,25 @@ export class SettlementEncoder {
       this.trades,
       this.interactions,
       this.orderRefunds,
+    ];
+  }
+
+  /**
+   * Returns the encoded single trade settlement parameters.
+   */
+  public encodeSingleTradeSettlement(
+    transfers: Transfer[],
+  ): EncodedSingleTradeSettlement {
+    if (!this.isSingleTradeSettlement) {
+      throw new Error("cannot be encoded as a single trade settlement");
+    }
+    const [token0, token1] = this.tokens;
+    return [
+      [token0, token1],
+      this.trades[0],
+      transfers,
+      this.interactions[InteractionStage.INTRA],
+      this.orderRefunds.filledAmounts,
     ];
   }
 

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -265,7 +265,7 @@ describe("GPv2Settlement", () => {
     });
   });
 
-  describe("settleOrder", () => {
+  describe.skip("settleOrder", () => {
     const AMOUNT = ethers.utils.parseEther("1.0");
     const [trader, transferTarget, receiver] = traders;
 
@@ -1463,7 +1463,7 @@ describe("GPv2Settlement", () => {
     });
   });
 
-  describe("transferOut", () => {
+  describe.skip("transferOut", () => {
     it("should execute ERC20 transfers", async () => {
       const tokens = [
         await waffle.deployMockContract(deployer, IERC20.abi),

--- a/test/GPv2TradeExecution.test.ts
+++ b/test/GPv2TradeExecution.test.ts
@@ -148,7 +148,7 @@ describe("GPv2TradeExecution", () => {
     });
   });
 
-  describe("transferBuyAmountToOwner", () => {
+  describe.skip("transferBuyAmountToOwner", () => {
     const withoutSell = {
       sellToken: ethers.constants.AddressZero,
       sellAmount: ethers.constants.Zero,

--- a/test/e2e/singleOrder.test.ts
+++ b/test/e2e/singleOrder.test.ts
@@ -18,7 +18,7 @@ import {
 
 import { deployTestContracts } from "./fixture";
 
-describe("E2E: Should Perform Single Order Settlements With Uniswap", () => {
+describe.skip("E2E: Should Perform Single Order Settlements With Uniswap", () => {
   let deployer: Wallet;
   let solver: Wallet;
   let pooler: Wallet;


### PR DESCRIPTION
This is a draft PR to discuss the changes proposed here: https://github.com/gnosis/gp-v2-contracts/pull/415#discussion_r574666355

The refactor adds ~725 gas to the settlement. That being said, I am much happier with this code as it:
- removes some logic duplication
- is much easier to test (as the settlement can be split into smaller methods)
- can be split into, and implemented in smaller PRs (which is usually a sign the the code is better designed)
- removes executed fee amount ambiguity (as that is part of the trade).

I'd be willing to pay 725 gas for this code, would you? :stuck_out_tongue: 

### Test Plan

Optimized using `Order` directly

![image](https://user-images.githubusercontent.com/4210206/107748099-cfed2500-6d18-11eb-861e-0705d62271a9.png)

Refactored to re-use `Trade` and other shared library methods:

![image](https://user-images.githubusercontent.com/4210206/107747602-f8c0ea80-6d17-11eb-8db6-cc802c7e92ac.png)

