### PR TITLE
Implement single trade settlement

### DIFF
--- a/bench/single.ts
+++ b/bench/single.ts
@@ -1,0 +1,40 @@
+import chalk from "chalk";
+
+import { BenchFixture } from "./fixture";
+
+async function main() {
+  const fixture = await BenchFixture.create();
+
+  const pad = (x: unknown) => ` ${x} `.padStart(14);
+  console.log(chalk.bold("=== Single Order Gas Benchmarks ==="));
+  console.log(chalk.gray("--------------+--------------"));
+  console.log(
+    ["settlement", "gas"]
+      .map((header) => chalk.cyan(pad(header)))
+      .join(chalk.gray("|")),
+  );
+  console.log(chalk.gray("--------------+--------------"));
+  for (const [kind, { gasUsed }] of [
+    [
+      "standard",
+      await fixture.settle({
+        tokens: 2,
+        trades: 1,
+        interactions: 1,
+        refunds: 0,
+      }),
+    ],
+    ["single", await fixture.settleOrder()],
+  ] as const) {
+    console.log(
+      [pad(kind), chalk.yellow(pad(gasUsed.toString()))].join(chalk.gray("|")),
+    );
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/bench/single.ts
+++ b/bench/single.ts
@@ -7,27 +7,35 @@ async function main() {
 
   const pad = (x: unknown) => ` ${x} `.padStart(14);
   console.log(chalk.bold("=== Single Order Gas Benchmarks ==="));
-  console.log(chalk.gray("--------------+--------------"));
+  console.log(chalk.gray("--------------+--------------+--------------"));
   console.log(
-    ["settlement", "gas"]
+    ["settlement", "include fees", "gas"]
       .map((header) => chalk.cyan(pad(header)))
       .join(chalk.gray("|")),
   );
-  console.log(chalk.gray("--------------+--------------"));
-  for (const [kind, { gasUsed }] of [
-    [
-      "standard",
-      await fixture.settle({
-        tokens: 2,
-        trades: 1,
-        interactions: 1,
-        refunds: 0,
-      }),
-    ],
-    ["single", await fixture.settleOrder()],
+  console.log(chalk.gray("--------------+--------------+--------------"));
+  for (const [kind, includeFees] of [
+    ["standard", undefined],
+    ["single", true],
+    ["single", false],
   ] as const) {
+    const { gasUsed } =
+      kind === "standard"
+        ? await fixture.settle({
+            tokens: 2,
+            trades: 1,
+            interactions: 1,
+            refunds: 0,
+          })
+        : await fixture.settleOrder({
+            includeFees: includeFees === true,
+          });
+
     console.log(
-      [pad(kind), chalk.yellow(pad(gasUsed.toString()))].join(chalk.gray("|")),
+      [
+        ...[kind, includeFees ?? "-"].map(pad),
+        chalk.yellow(pad(gasUsed.toString())),
+      ].join(chalk.gray("|")),
     );
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "hardhat test",
     "bench": "hardhat run bench/index.ts",
     "bench:compare": "bash bench/compare.sh",
+    "bench:single": "hardhat run bench/single.ts",
     "bench:trace": "hardhat run bench/trace/index.ts",
     "bench:uniswap": "hardhat run bench/uniswap/index.ts",
     "lint": "yarn lint:sol && yarn lint:ts",

--- a/src/deploy/002_settlement.ts
+++ b/src/deploy/002_settlement.ts
@@ -15,7 +15,7 @@ const deploySettlement: DeployFunction = async function ({
 
   await deploy(settlement, {
     from: deployer,
-    gasLimit: 3.5e6,
+    gasLimit: 4e6,
     args: [authenticatorAddress],
     deterministicDeployment: SALT,
     log: true,

--- a/test/e2e/singleOrder.test.ts
+++ b/test/e2e/singleOrder.test.ts
@@ -1,0 +1,237 @@
+import ERC20 from "@openzeppelin/contracts/build/contracts/ERC20PresetMinterPauser.json";
+import UniswapV2Factory from "@uniswap/v2-core/build/UniswapV2Factory.json";
+import UniswapV2Pair from "@uniswap/v2-core/build/UniswapV2Pair.json";
+import UniswapV2Router from "@uniswap/v2-periphery/build/UniswapV2Router02.json";
+import { expect } from "chai";
+import { BigNumber, Contract, Wallet } from "ethers";
+import { ethers, waffle } from "hardhat";
+
+import {
+  Order,
+  OrderKind,
+  SettlementEncoder,
+  SigningScheme,
+  TypedDataDomain,
+  domain,
+} from "../../src/ts";
+
+import { deployTestContracts } from "./fixture";
+
+describe("E2E: Should Perform Single Order Settlements With Uniswap", () => {
+  let deployer: Wallet;
+  let solver: Wallet;
+  let pooler: Wallet;
+  let trader: Wallet;
+  let receiver: Wallet;
+
+  let settlement: Contract;
+  let allowanceManager: Contract;
+  let domainSeparator: TypedDataDomain;
+
+  let weth: Contract;
+  let usdt: Contract;
+
+  const uniswapWethReserve = ethers.utils.parseEther("1000.0");
+  const uniswapUsdtReserve = ethers.utils.parseUnits("1700000.0", 6);
+  let uniswapPair: Contract;
+  let uniswapRouter: Contract;
+  let isWethToken0: boolean;
+
+  beforeEach(async () => {
+    const deployment = await deployTestContracts();
+
+    ({
+      deployer,
+      settlement,
+      allowanceManager,
+      wallets: [solver, pooler, trader, receiver],
+    } = deployment);
+
+    const { authenticator, manager } = deployment;
+    await authenticator.connect(manager).addSolver(solver.address);
+
+    const { chainId } = await ethers.provider.getNetwork();
+    domainSeparator = domain(chainId, settlement.address);
+
+    weth = await waffle.deployContract(deployer, ERC20, ["WETH", 18]);
+    usdt = await waffle.deployContract(deployer, ERC20, ["USDT", 6]);
+
+    const uniswapFactory = await waffle.deployContract(
+      deployer,
+      UniswapV2Factory,
+      [deployer.address],
+    );
+
+    await uniswapFactory.createPair(weth.address, usdt.address);
+    uniswapPair = new Contract(
+      await uniswapFactory.getPair(weth.address, usdt.address),
+      UniswapV2Pair.abi,
+      deployer,
+    );
+
+    const uniswapWethReserve = ethers.utils.parseEther("1000.0");
+    const uniswapUsdtReserve = ethers.utils.parseUnits("1700000.0", 6);
+    await weth.mint(uniswapPair.address, uniswapWethReserve);
+    await usdt.mint(uniswapPair.address, uniswapUsdtReserve);
+    await uniswapPair.mint(pooler.address);
+
+    uniswapRouter = await waffle.deployContract(deployer, UniswapV2Router, [
+      uniswapFactory.address,
+      weth.address,
+    ]);
+
+    // NOTE: Which token ends up as token 0 or token 1 depends on the addresses
+    // of the WETH and USDT token which can change depending on which order the
+    // tests are run. Because of this, check the Uniswap pair to see which token
+    // ended up on which index.
+    isWethToken0 = (await uniswapPair.token0()) === weth.address;
+  });
+
+  const computeUniswapSettlement = async (order: Order) => {
+    // Settles a single order against Uniswap using the "fast-path".
+
+    const transfers = [
+      {
+        target: uniswapPair.address,
+        amount: order.sellAmount,
+      },
+    ];
+    if (BigNumber.from(order.feeAmount).gt(0)) {
+      transfers.push({
+        target: settlement.address,
+        amount: order.feeAmount,
+      });
+    }
+
+    // NOTE: Use Uniswap router as a price oracle. In theory, computing this
+    // amount can be implemented on-chain by making a "light-weight" router
+    // that assumes that the "in amounts" have already been transfered to the
+    // pair.
+    const [
+      ,
+      uniswapUsdtOutAmount,
+    ] = await uniswapRouter.getAmountsOut(order.sellAmount, [
+      weth.address,
+      usdt.address,
+    ]);
+
+    const [amount0Out, amount1Out] = isWethToken0
+      ? [0, uniswapUsdtOutAmount]
+      : [uniswapUsdtOutAmount, 0];
+    const interactions = [
+      {
+        target: uniswapPair.address,
+        value: 0,
+        callData: uniswapPair.interface.encodeFunctionData("swap", [
+          amount0Out,
+          amount1Out,
+          order.receiver ?? trader.address,
+          "0x",
+        ]),
+      },
+    ];
+
+    return {
+      uniswapUsdtOutAmount,
+      transfers,
+      interactions,
+    };
+  };
+
+  it("performs 'fast-path' single order swap", async () => {
+    await weth.mint(trader.address, ethers.utils.parseEther("1.01"));
+    await weth
+      .connect(trader)
+      .approve(allowanceManager.address, ethers.constants.MaxUint256);
+
+    const order = {
+      kind: OrderKind.SELL,
+      partiallyFillable: false,
+      sellToken: weth.address,
+      buyToken: usdt.address,
+      sellAmount: ethers.utils.parseEther("1.0"),
+      buyAmount: ethers.utils.parseUnits("1500.0", 6),
+      feeAmount: ethers.utils.parseEther("0.01"),
+      validTo: 0xffffffff,
+      appData: 1,
+    };
+
+    const {
+      uniswapUsdtOutAmount,
+      transfers,
+      interactions,
+    } = await computeUniswapSettlement(order);
+
+    const encoder = new SettlementEncoder(domainSeparator);
+    await encoder.signEncodeTrade(order, trader, SigningScheme.EIP712);
+    for (const interaction of interactions) {
+      encoder.encodeInteraction(interaction);
+    }
+
+    await settlement
+      .connect(solver)
+      .settleSingleTrade(...encoder.encodeSingleTradeSettlement(transfers));
+
+    expect(await weth.balanceOf(settlement.address)).to.equal(order.feeAmount);
+    expect(await usdt.balanceOf(settlement.address)).to.equal(
+      ethers.constants.Zero,
+    );
+
+    expect(await weth.balanceOf(trader.address)).to.equal(
+      ethers.constants.Zero,
+    );
+    expect(await usdt.balanceOf(trader.address)).to.equal(uniswapUsdtOutAmount);
+
+    const [token0Reserve, token1Reserve] = await uniswapPair.getReserves();
+    const [finalWethReserve, finalUsdtReserve] = isWethToken0
+      ? [token0Reserve, token1Reserve]
+      : [token1Reserve, token0Reserve];
+    expect([finalWethReserve, finalUsdtReserve]).to.deep.equal([
+      uniswapWethReserve.add(order.sellAmount),
+      uniswapUsdtReserve.sub(uniswapUsdtOutAmount),
+    ]);
+  });
+
+  it("should transfer to receiver when specified", async () => {
+    await weth.mint(trader.address, ethers.utils.parseEther("1.0"));
+    await weth
+      .connect(trader)
+      .approve(allowanceManager.address, ethers.constants.MaxUint256);
+
+    const order = {
+      kind: OrderKind.SELL,
+      partiallyFillable: false,
+      sellToken: weth.address,
+      buyToken: usdt.address,
+      receiver: receiver.address,
+      sellAmount: ethers.utils.parseEther("1.0"),
+      buyAmount: ethers.utils.parseUnits("1500.0", 6),
+      feeAmount: ethers.constants.Zero,
+      validTo: 0xffffffff,
+      appData: 1,
+    };
+
+    const {
+      uniswapUsdtOutAmount,
+      transfers,
+      interactions,
+    } = await computeUniswapSettlement(order);
+
+    const encoder = new SettlementEncoder(domainSeparator);
+    await encoder.signEncodeTrade(order, trader, SigningScheme.EIP712);
+    for (const interaction of interactions) {
+      encoder.encodeInteraction(interaction);
+    }
+
+    await settlement
+      .connect(solver)
+      .settleSingleTrade(...encoder.encodeSingleTradeSettlement(transfers));
+
+    expect(await usdt.balanceOf(trader.address)).to.deep.equal(
+      ethers.constants.Zero,
+    );
+    expect(await usdt.balanceOf(receiver.address)).to.deep.equal(
+      uniswapUsdtOutAmount,
+    );
+  });
+});


### PR DESCRIPTION
Closes #414, closes #415 and closes #436.

This PR implements a new settlement "fast-path" for settling a single trade against on-chain liquidity. It uses the executing method implemented in #439 and essentially:
1. Ecdsa recover order
2. Record receiver's initial buy token balance
3. Transfer owner's sell amount directly to AMMs (to Uniswap pair for example, can also specify multiple direct transfers).
4. Execute interactions (Call `swap` on the Uniswap pair for example)
5. Use receiver's final buy token balance to compute executed buy amount
6. Verify order invariants
    1. Order is not over-filled
    2. Order limit price is respected
    3. Executed sell amount equals order sell amount for sell orders
    4. Or, Executed buy amount equals order buy amount for buy orders
7. Set order as filled
5. Emit trade and settlement events

### Test Plan

Added new unit and end to end tests, added benchmarks that indicate ~27K gas savings when using the "fast-path":

![image](https://user-images.githubusercontent.com/4210206/107922601-89920300-6f70-11eb-8a5b-e0e4ae842b46.png)

