### PR TITLE
Add order refunds to fast path

### DIFF
--- a/bench/single.ts
+++ b/bench/single.ts
@@ -7,17 +7,27 @@ async function main() {
 
   const pad = (x: unknown) => ` ${x} `.padStart(14);
   console.log(chalk.bold("=== Single Order Gas Benchmarks ==="));
-  console.log(chalk.gray("--------------+--------------+--------------"));
   console.log(
-    ["settlement", "include fees", "gas"]
+    chalk.gray("--------------+--------------+--------------+--------------"),
+  );
+  console.log(
+    ["settlement", "include fees", "refunds", "gas"]
       .map((header) => chalk.cyan(pad(header)))
       .join(chalk.gray("|")),
   );
-  console.log(chalk.gray("--------------+--------------+--------------"));
-  for (const [kind, includeFees] of [
-    ["standard", undefined],
-    ["single", true],
-    ["single", false],
+  console.log(
+    chalk.gray("--------------+--------------+--------------+--------------"),
+  );
+  for (const [kind, includeFees, refunds] of [
+    ["standard", undefined, 0],
+    ["single", true, 0],
+    ["single", false, 0],
+    ["standard", undefined, 1],
+    ["single", true, 1],
+    ["single", false, 1],
+    ["standard", undefined, 2],
+    ["single", true, 2],
+    ["single", false, 2],
   ] as const) {
     const { gasUsed } =
       kind === "standard"
@@ -25,15 +35,16 @@ async function main() {
             tokens: 2,
             trades: 1,
             interactions: 1,
-            refunds: 0,
+            refunds,
           })
         : await fixture.settleOrder({
             includeFees: includeFees === true,
+            refunds,
           });
 
     console.log(
       [
-        ...[kind, includeFees ?? "-"].map(pad),
+        ...[kind, includeFees ?? "-", refunds].map(pad),
         chalk.yellow(pad(gasUsed.toString())),
       ].join(chalk.gray("|")),
     );

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -157,7 +157,8 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
         IERC20[] calldata tokens,
         GPv2Trade.Data calldata trade,
         GPv2AllowanceManager.Transfer[] calldata transfers,
-        GPv2Interaction.Data[] calldata interactions
+        GPv2Interaction.Data[] calldata interactions,
+        bytes[] calldata filledAmountRefunds
     ) external nonReentrant onlySolver {
         RecoveredOrder memory recoveredOrder = allocateRecoveredOrder();
         recoverOrderFromTrade(recoveredOrder, tokens, trade);
@@ -168,6 +169,8 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
             interactions,
             trade.feeDiscount
         );
+
+        freeOrderStorage(filledAmountRefunds, filledAmount);
 
         emit Settlement(msg.sender);
     }

--- a/src/ts/settlement.ts
+++ b/src/ts/settlement.ts
@@ -163,6 +163,8 @@ export type EncodedSingleTradeSettlement = [
   Transfer[],
   /** Encoded interactions for executing a single trade order. */
   Interaction[],
+  /** Encoded filled amount refunds. */
+  BytesLike[],
 ];
 
 /**
@@ -317,11 +319,11 @@ export class SettlementEncoder {
    */
   public get isSingleTradeSettlement(): boolean {
     const [preInteractions, , postInteractions] = this.interactions;
-    const { filledAmounts, preSignatures } = this.orderRefunds;
+    const { preSignatures } = this.orderRefunds;
     return (
       this.tokens.length === 2 &&
       this.trades.length === 1 &&
-      [preInteractions, postInteractions, filledAmounts, preSignatures].every(
+      [preInteractions, postInteractions, preSignatures].every(
         ({ length }) => length === 0,
       )
     );
@@ -479,6 +481,7 @@ export class SettlementEncoder {
       trade,
       transfers,
       this.interactions[InteractionStage.INTRA],
+      this.orderRefunds.filledAmounts,
     ];
   }
 


### PR DESCRIPTION
This PR adds filled amount storage gas refunds to the single trade "fast-path" settlement.

@fleupold. So it looks like if we collect fees and refund one order, then the total cost is `167402` compared to `112166` for a direct Uniswap.

### Test Plan

Added a new unit test and benchmarks for single trades now have rows for different amounts of order refunds.

![image](https://user-images.githubusercontent.com/4210206/107785966-8bc84780-6d4d-11eb-82d5-b21ee6d97820.png)

