### PR TITLE
Revert "Bump @openzeppelin/contracts from 3.4.0-solc-0.7 to 3.4.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@gnosis.pm/util-contracts": "=3.1.0-solc-7",
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
-    "@openzeppelin/contracts": "=3.4.0",
+    "@openzeppelin/contracts": "=3.4.0-solc-0.7",
     "@types/chai": "^4.2.15",
     "@types/debug": "^4.1.5",
     "@types/mocha": "^8.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -579,10 +579,10 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@=3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.0.tgz#9a1669ad5f9fdfb6e273bb5a4fed10cb4cc35eb0"
-  integrity sha512-qh+EiHWzfY/9CORr+eRUkeEUP1WiFUcq3974bLHwyYzLBUtK6HPaMkIUHi74S1rDTZ0sNz42DwPc5A4IJvN3rg==
+"@openzeppelin/contracts@=3.4.0-solc-0.7":
+  version "3.4.0-solc-0.7"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.0-solc-0.7.tgz#c4fbd1b761714745c4bce6fc97e8b44d4c29d5b9"
+  integrity sha512-bJz1YgmeKRYVnYZedYSiy5/YmaYTxOhb76ftCseN1z2r4DK7PwCGvRCF2fRavTxAmGkIC/Q5zSy/Dr3OerPw0w==
 
 "@redux-saga/core@^1.0.0":
   version "1.1.3"


### PR DESCRIPTION
Reverts gnosis/gp-v2-contracts#455

Looks like we are fighting with dependabot :stuck_out_tongue: 

In #451, we modified the `package.json` to use the `solc-0.7` specific version for OZ contracts to suppress some build warnings. Looks like dependabot decided it was a outdated dependency. This PR just reverts that decision.