### PR TITLE
Add benchmarks for optimal refund batching

### DIFF
--- a/bench/single.ts
+++ b/bench/single.ts
@@ -21,7 +21,10 @@ async function main() {
   for (const [settlements, refunds, gasToken] of [
     [1, 0, 0],
     [1, 1, 0],
+    [6, 6, 0],
+    [7, 7, 0],
     [8, 8, 0],
+    [9, 9, 0],
     [1, 4, 2],
     [1, 0, 5],
   ]) {

--- a/bench/single.ts
+++ b/bench/single.ts
@@ -7,35 +7,58 @@ async function main() {
 
   const pad = (x: unknown) => ` ${x} `.padStart(14);
   console.log(chalk.bold("=== Single Order Gas Benchmarks ==="));
-  console.log(chalk.gray("--------------+--------------+--------------"));
   console.log(
-    ["refunds", "gasToken", "gas"]
+    chalk.gray("--------------+--------------+--------------+--------------"),
+  );
+  console.log(
+    ["settlements", "refunds", "gasToken", "gas/order"]
       .map((header) => chalk.cyan(pad(header)))
       .join(chalk.gray("|")),
   );
-  console.log(chalk.gray("--------------+--------------+--------------"));
-  for (const [refunds, gasToken] of [
-    [0, 0],
-    [2, 0],
-    [4, 0],
-    [8, 0],
-    [0, 2],
-    [2, 2],
-    [4, 2],
-    [0, 5],
+  console.log(
+    chalk.gray("--------------+--------------+--------------+--------------"),
+  );
+  for (const [settlements, refunds, gasToken] of [
+    [1, 0, 0],
+    [1, 1, 0],
+    [8, 8, 0],
+    [1, 4, 2],
+    [1, 0, 5],
   ]) {
-    const { gasUsed } = await fixture.settle({
+    let { gasUsed } = await fixture.settle({
       tokens: 2,
       trades: 1,
       interactions: 1,
       refunds,
       gasToken,
     });
+    if (settlements > 1) {
+      const { gasUsed: refundlessGasUsed } = await fixture.settle({
+        tokens: 2,
+        trades: 1,
+        interactions: 1,
+        refunds: 0,
+        gasToken: 0,
+      });
+
+      // NOTE: We are simulating running `settlements - 1` settlements without
+      // any gas refunds, and then a last one with "lots" of refunds. This is
+      // so we can simulate "continuous" gas costs where refunds are bundled up
+      // into larger batches instead of applying on refund per settlement.
+      // Compute the average gas used per order.
+      gasUsed = refundlessGasUsed
+        .mul(settlements - 1)
+        .add(gasUsed)
+        .div(settlements);
+    }
 
     console.log(
-      [pad(refunds), pad(gasToken), chalk.yellow(pad(gasUsed.toString()))].join(
-        chalk.gray("|"),
-      ),
+      [
+        pad(settlements),
+        pad(refunds),
+        pad(gasToken),
+        chalk.yellow(pad(gasUsed.toString())),
+      ].join(chalk.gray("|")),
     );
   }
 }


### PR DESCRIPTION
This PR modifies the `single` settlement benchmarks to run multiple settlements and simulate batching refunds for optimal order gas refund results.

/cc @fedgiac Does this address your concerns from https://github.com/gnosis/gp-v2-contracts/pull/445#issuecomment-787761685

### Test Plan

`yarn bench:single`

```
=== Single Order Gas Benchmarks ===
--------------+--------------+--------------+--------------
  settlements |      refunds |     gasToken |    gas/order 
--------------+--------------+--------------+--------------
            1 |            0 |            0 |       187285 
            1 |            1 |            0 |       184666 
            8 |            8 |            0 |       180509 
            1 |            4 |            2 |       148431 
            1 |            0 |            5 |       121983
```
