### PR TITLE
Add Vault relayer contract

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,3 +1,5 @@
 module.exports = {
-  skipFiles: ["test/"],
+  // TODO(nlordell): Stop skipping coverage for the vault relayer once it starts
+  // actually doing stuff.
+  skipFiles: ["test/", "src/contracts/GPv2VaultRelayer.sol"],
 };

--- a/.solcover.js
+++ b/.solcover.js
@@ -1,5 +1,3 @@
 module.exports = {
-  // TODO(nlordell): Stop skipping coverage for the vault relayer once it starts
-  // actually doing stuff.
-  skipFiles: ["test/", "src/contracts/GPv2VaultRelayer.sol"],
+  skipFiles: ["test/"],
 };

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -121,6 +121,7 @@ export default {
       default: "0x6Fb5916c0f57f88004d5b5EB25f6f4D77353a1eD",
       hardhat: 2,
     },
+    vault: "0xfefeFEFeFEFEFEFEFeFefefefefeFEfEfefefEfe",
   },
   gasReporter: {
     enabled: REPORT_GAS ? true : false,

--- a/src/contracts/GPv2AllowanceManager.sol
+++ b/src/contracts/GPv2AllowanceManager.sol
@@ -4,39 +4,25 @@ pragma abicoder v2;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./libraries/GPv2TradeExecution.sol";
+import "./mixins/GPv2OnlyCreator.sol";
 
 /// @title Gnosis Protocol v2 Allowance Manager Contract
 /// @author Gnosis Developers
-contract GPv2AllowanceManager {
+contract GPv2AllowanceManager is GPv2OnlyCreator {
     using GPv2TradeExecution for GPv2TradeExecution.Data;
-
-    /// @dev The recipient of all transfers made by the allowance manager. The
-    /// recipient is set at creation time and cannot change.
-    address private immutable recipient;
-
-    constructor() {
-        recipient = msg.sender;
-    }
-
-    /// @dev Modifier that ensures that a function can only be called by the
-    /// recipient of this contract.
-    modifier onlyRecipient {
-        require(msg.sender == recipient, "GPv2: not allowance recipient");
-        _;
-    }
 
     /// @dev Transfers all sell amounts for the executed trades from their
     /// owners to the caller.
     ///
     /// This function reverts if:
-    /// - The caller is not the recipient of the allowance manager
+    /// - The caller is not the creator of the allowance manager
     /// - Any ERC20 transfer fails
     ///
     /// @param trades The executed trades whose sell amounts need to be
     /// transferred in.
     function transferIn(GPv2TradeExecution.Data[] calldata trades)
         external
-        onlyRecipient
+        onlyCreator
     {
         for (uint256 i = 0; i < trades.length; i++) {
             GPv2TradeExecution.transferSellAmountToRecipient(

--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -8,7 +8,9 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 import "./GPv2AllowanceManager.sol";
+import "./GPv2VaultRelayer.sol";
 import "./interfaces/GPv2Authentication.sol";
+import "./interfaces/IVault.sol";
 import "./libraries/GPv2Interaction.sol";
 import "./libraries/GPv2Order.sol";
 import "./libraries/GPv2Trade.sol";
@@ -31,6 +33,10 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
     /// @dev The allowance manager which has access to order funds. This
     /// contract is created during deployment
     GPv2AllowanceManager public immutable allowanceManager;
+
+    /// @dev The Balancer Vault relayer which can interact on behalf of users.
+    /// This contract is created during deployment
+    GPv2VaultRelayer public immutable vaultRelayer;
 
     /// @dev Map each user order by UID to the amount that has been filled so
     /// far. If this amount is larger than or equal to the amount traded in the
@@ -64,9 +70,10 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
     /// @dev Event emitted when an order is invalidated.
     event OrderInvalidated(address indexed owner, bytes orderUid);
 
-    constructor(GPv2Authentication authenticator_) {
+    constructor(GPv2Authentication authenticator_, IVault vault) {
         authenticator = authenticator_;
         allowanceManager = new GPv2AllowanceManager();
+        vaultRelayer = new GPv2VaultRelayer(vault);
     }
 
     // solhint-disable-next-line no-empty-blocks
@@ -341,7 +348,8 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
             // To prevent possible attack on user funds, we explicitly disable
             // any interactions with AllowanceManager contract.
             require(
-                interaction.target != address(allowanceManager),
+                interaction.target != address(allowanceManager) &&
+                    interaction.target != address(vaultRelayer),
                 "GPv2: forbidden interaction"
             );
             GPv2Interaction.execute(interaction);

--- a/src/contracts/GPv2VaultRelayer.sol
+++ b/src/contracts/GPv2VaultRelayer.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.7.6;
+pragma abicoder v2;
+
+import "./interfaces/IVault.sol";
+import "./mixins/GPv2OnlyCreator.sol";
+
+/// @title Gnosis Protocol v2 Vault Relayer Contract
+/// @author Gnosis Developers
+contract GPv2VaultRelayer is GPv2OnlyCreator {
+    /// @dev The vault this relayer is for.
+    IVault private immutable vault;
+
+    constructor(IVault vault_) {
+        vault = vault_;
+    }
+
+    // NOTE: Add a unused external method so that the compiler doesn't optimize
+    // away the two immutables so we can read them for unit tests. Once this
+    // contract actually does something, this can be removed.
+    function unused() external view onlyCreator returns (bytes32 random) {
+        random = keccak256(abi.encodePacked(vault));
+    }
+}

--- a/src/contracts/interfaces/IVault.sol
+++ b/src/contracts/interfaces/IVault.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.7.6;
+pragma abicoder v2;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IVault {
+    struct BalanceTransfer {
+        IERC20 token;
+        uint256 amount;
+        address sender;
+        address recipient;
+    }
+
+    struct FundManagement {
+        address sender;
+        bool fromInternalBalance;
+        address recipient;
+        bool toInternalBalance;
+    }
+
+    struct SwapIn {
+        bytes32 poolId;
+        uint256 tokenInIndex;
+        uint256 tokenOutIndex;
+        uint256 amountIn;
+        bytes userData;
+    }
+
+    struct SwapOut {
+        bytes32 poolId;
+        uint256 tokenInIndex;
+        uint256 tokenOutIndex;
+        uint256 amountOut;
+        bytes userData;
+    }
+
+    function depositToInternalBalance(BalanceTransfer[] calldata transfers)
+        external;
+
+    function withdrawFromInternalBalance(BalanceTransfer[] calldata transfers)
+        external;
+
+    function transferInternalBalance(BalanceTransfer[] calldata transfers)
+        external;
+
+    function batchSwapGivenIn(
+        SwapIn[] calldata swaps,
+        IERC20[] memory tokens,
+        FundManagement calldata funds,
+        int256[] memory limits,
+        uint256 deadline
+    ) external returns (int256[] memory);
+
+    function batchSwapGivenOut(
+        SwapOut[] calldata swaps,
+        IERC20[] memory tokens,
+        FundManagement calldata funds,
+        int256[] memory limits,
+        uint256 deadline
+    ) external returns (int256[] memory);
+}

--- a/src/contracts/mixins/GPv2OnlyCreator.sol
+++ b/src/contracts/mixins/GPv2OnlyCreator.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.7.6;
+
+/// @title Gnosis Protocol v2 Creator Access Control Contract
+/// @author Gnosis Developers
+abstract contract GPv2OnlyCreator {
+    /// @dev The creator of the contract which has special permissions. This
+    /// value is set at creation time and cannot change.
+    address private immutable creator;
+
+    constructor() {
+        creator = msg.sender;
+    }
+
+    /// @dev Modifier that ensures that a function can only be called by the
+    /// creator of this contract.
+    modifier onlyCreator {
+        require(msg.sender == creator, "GPv2: not creator");
+        _;
+    }
+}

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -8,8 +8,8 @@ import "../libraries/GPv2Trade.sol";
 import "../libraries/GPv2TradeExecution.sol";
 
 contract GPv2SettlementTestInterface is GPv2Settlement {
-    constructor(GPv2Authentication authenticator_)
-        GPv2Settlement(authenticator_)
+    constructor(GPv2Authentication authenticator_, IVault vault)
+        GPv2Settlement(authenticator_, vault)
     // solhint-disable-next-line no-empty-blocks
     {
 

--- a/src/deploy/002_settlement.ts
+++ b/src/deploy/002_settlement.ts
@@ -7,7 +7,7 @@ const deploySettlement: DeployFunction = async function ({
   deployments,
   getNamedAccounts,
 }: HardhatRuntimeEnvironment) {
-  const { deployer } = await getNamedAccounts();
+  const { deployer, vault } = await getNamedAccounts();
   const { deploy, get } = deployments;
 
   const { authenticator, settlement } = CONTRACT_NAMES;
@@ -16,7 +16,7 @@ const deploySettlement: DeployFunction = async function ({
   await deploy(settlement, {
     from: deployer,
     gasLimit: 4e6,
-    args: [authenticatorAddress],
+    args: [authenticatorAddress, vault],
     deterministicDeployment: SALT,
     log: true,
   });

--- a/src/deploy/999_networks.ts
+++ b/src/deploy/999_networks.ts
@@ -60,6 +60,10 @@ const updateNetworks: DeployFunction = async function ({
     address: await settlement.allowanceManager(),
     transactionHash: settlementRecord.transactionHash,
   });
+  updateRecord("GPv2VaultRelayer", {
+    address: await settlement.vaultRelayer(),
+    transactionHash: settlementRecord.transactionHash,
+  });
 
   await fs.writeFile(NETWORKS_PATH, JSON.stringify(networks, null, INDENT));
 };

--- a/src/ts/deploy.ts
+++ b/src/ts/deploy.ts
@@ -36,7 +36,7 @@ export type DeploymentArguments<
 > = T extends typeof CONTRACT_NAMES.authenticator
   ? never
   : T extends typeof CONTRACT_NAMES.settlement
-  ? [string]
+  ? [string, string]
   : unknown[];
 
 /**

--- a/test/GPv2AllowanceManager.test.ts
+++ b/test/GPv2AllowanceManager.test.ts
@@ -8,8 +8,8 @@ import { encodeInTransfers } from "./encoding";
 describe("GPv2AllowanceManager", () => {
   const [
     deployer,
-    recipient,
-    nonRecipient,
+    creator,
+    nonCreator,
     ...traders
   ] = waffle.provider.getWallets();
 
@@ -18,17 +18,17 @@ describe("GPv2AllowanceManager", () => {
   beforeEach(async () => {
     const GPv2AllowanceManager = await ethers.getContractFactory(
       "GPv2AllowanceManager",
-      recipient,
+      creator,
     );
 
     allowanceManager = await GPv2AllowanceManager.deploy();
   });
 
   describe("transferIn", () => {
-    it("should revert if not called by the recipient", async () => {
+    it("should revert if not called by the creator", async () => {
       await expect(
-        allowanceManager.connect(nonRecipient).transferIn([]),
-      ).to.be.revertedWith("not allowance recipient");
+        allowanceManager.connect(nonCreator).transferIn([]),
+      ).to.be.revertedWith("not creator");
     });
 
     it("should execute ERC20 transfers", async () => {
@@ -39,10 +39,10 @@ describe("GPv2AllowanceManager", () => {
 
       const amount = ethers.utils.parseEther("13.37");
       await tokens[0].mock.transferFrom
-        .withArgs(traders[0].address, recipient.address, amount)
+        .withArgs(traders[0].address, creator.address, amount)
         .returns(true);
       await tokens[1].mock.transferFrom
-        .withArgs(traders[1].address, recipient.address, amount)
+        .withArgs(traders[1].address, creator.address, amount)
         .returns(true);
 
       await expect(
@@ -68,7 +68,7 @@ describe("GPv2AllowanceManager", () => {
 
       const amount = ethers.utils.parseEther("4.2");
       await token.mock.transferFrom
-        .withArgs(traders[0].address, recipient.address, amount)
+        .withArgs(traders[0].address, creator.address, amount)
         .revertsWithReason("test error");
 
       await expect(

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -22,8 +22,8 @@ import {
 
 import {
   builtAndDeployedMetadataCoincide,
-  immutableAsAddress,
-  readImmutables,
+  readAllowanceManagerImmutables,
+  readVaultRelayerImmutables,
 } from "./bytecode";
 import { encodeOutTransfers } from "./encoding";
 
@@ -84,42 +84,39 @@ describe("GPv2Settlement", () => {
     });
 
     it("should have the settlement contract as the creator", async () => {
-      const [creator] = await readImmutables(
-        "src/contracts/GPv2AllowanceManager.sol:GPv2AllowanceManager",
+      const { creator } = await readAllowanceManagerImmutables(
         await settlement.allowanceManager(),
       );
 
-      expect(immutableAsAddress(creator)).to.equal(settlement.address);
+      expect(creator).to.equal(settlement.address);
     });
   });
 
   describe("vaultRelayer", () => {
     it("should deploy a vault relayer", async () => {
-      const deployedAllowanceManager = await settlement.allowanceManager();
+      const deployedVaultRelayer = await settlement.vaultRelayer();
       expect(
         await builtAndDeployedMetadataCoincide(
-          deployedAllowanceManager,
-          "GPv2AllowanceManager",
+          deployedVaultRelayer,
+          "GPv2VaultRelayer",
         ),
       ).to.be.true;
     });
 
     it("should set the vault immutable", async () => {
-      const [vaultAddr] = await readImmutables(
-        "src/contracts/GPv2VaultRelayer.sol:GPv2VaultRelayer",
+      const { vault: vaultAddr } = await readVaultRelayerImmutables(
         await settlement.vaultRelayer(),
       );
 
-      expect(immutableAsAddress(vaultAddr)).to.equal(vault.address);
+      expect(vaultAddr).to.equal(vault.address);
     });
 
     it("should have the settlement contract as the creator", async () => {
-      const [, creator] = await readImmutables(
-        "src/contracts/GPv2VaultRelayer.sol:GPv2VaultRelayer",
+      const { creator } = await readVaultRelayerImmutables(
         await settlement.vaultRelayer(),
       );
 
-      expect(immutableAsAddress(creator)).to.equal(settlement.address);
+      expect(creator).to.equal(settlement.address);
     });
   });
 

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -1064,6 +1064,18 @@ describe("GPv2Settlement", () => {
       ).to.be.revertedWith("GPv2: forbidden interaction");
     });
 
+    it("should revert when target is vaultRelayer", async () => {
+      const invalidInteraction: Interaction = {
+        target: await settlement.vaultRelayer(),
+        callData: [],
+        value: 0,
+      };
+
+      await expect(
+        settlement.executeInteractionsTest([invalidInteraction]),
+      ).to.be.revertedWith("GPv2: forbidden interaction");
+    });
+
     it("reverts if the settlement contract does not have sufficient Ether balance", async () => {
       const value = ethers.utils.parseEther("1000000.0");
       expect(value.gt(await ethers.provider.getBalance(settlement.address))).to

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -1,5 +1,6 @@
 import IERC20 from "@openzeppelin/contracts/build/contracts/IERC20.json";
 import { expect } from "chai";
+import { MockContract } from "ethereum-waffle";
 import { BigNumber, Contract, ContractReceipt, Event } from "ethers";
 import { artifacts, ethers, waffle } from "hardhat";
 
@@ -19,7 +20,11 @@ import {
   packOrderUidParams,
 } from "../src/ts";
 
-import { builtAndDeployedMetadataCoincide } from "./bytecode";
+import {
+  builtAndDeployedMetadataCoincide,
+  immutableAsAddress,
+  readImmutables,
+} from "./bytecode";
 import { encodeOutTransfers } from "./encoding";
 
 function toNumberLossy(value: BigNumber): number {
@@ -33,6 +38,7 @@ describe("GPv2Settlement", () => {
   const [deployer, owner, solver, ...traders] = waffle.provider.getWallets();
 
   let authenticator: Contract;
+  let vault: MockContract;
   let settlement: Contract;
   let testDomain: TypedDataDomain;
 
@@ -44,11 +50,17 @@ describe("GPv2Settlement", () => {
     authenticator = await GPv2AllowListAuthentication.deploy();
     await authenticator.initializeManager(owner.address);
 
+    const IVault = await artifacts.readArtifact("IVault");
+    vault = await waffle.deployMockContract(deployer, IVault.abi);
+
     const GPv2Settlement = await ethers.getContractFactory(
       "GPv2SettlementTestInterface",
       deployer,
     );
-    settlement = await GPv2Settlement.deploy(authenticator.address);
+    settlement = await GPv2Settlement.deploy(
+      authenticator.address,
+      vault.address,
+    );
 
     const { chainId } = await ethers.provider.getNetwork();
     testDomain = domain(chainId, settlement.address);
@@ -71,39 +83,43 @@ describe("GPv2Settlement", () => {
       ).to.be.true;
     });
 
-    it("should have the settlement contract as the recipient", async () => {
-      const ADDRESS_BYTE_LENGTH = 20;
-
-      // NOTE: In order to avoid having the allowance manager add a public
-      // accessor for its recipient just for testing, which would add minor
-      // costs at both deployment time and runtime, just read the contract code
-      // to get the immutable value.
-      const buildInfo = await artifacts.getBuildInfo(
+    it("should have the settlement contract as the creator", async () => {
+      const [creator] = await readImmutables(
         "src/contracts/GPv2AllowanceManager.sol:GPv2AllowanceManager",
-      );
-      if (buildInfo === undefined) {
-        throw new Error("missing GPv2AllowanceManager build info");
-      }
-
-      const [[recipientImmutableReference]] = Object.values(
-        buildInfo.output.contracts["src/contracts/GPv2AllowanceManager.sol"]
-          .GPv2AllowanceManager.evm.deployedBytecode.immutableReferences || {},
+        await settlement.allowanceManager(),
       );
 
+      expect(immutableAsAddress(creator)).to.equal(settlement.address);
+    });
+  });
+
+  describe("vaultRelayer", () => {
+    it("should deploy a vault relayer", async () => {
       const deployedAllowanceManager = await settlement.allowanceManager();
-      const code = await ethers.provider.send("eth_getCode", [
-        deployedAllowanceManager,
-        "latest",
-      ]);
-      const recipient = ethers.utils.hexlify(
-        ethers.utils
-          .arrayify(code)
-          .subarray(recipientImmutableReference.start)
-          .subarray(recipientImmutableReference.length - ADDRESS_BYTE_LENGTH)
-          .slice(0, ADDRESS_BYTE_LENGTH),
+      expect(
+        await builtAndDeployedMetadataCoincide(
+          deployedAllowanceManager,
+          "GPv2AllowanceManager",
+        ),
+      ).to.be.true;
+    });
+
+    it("should set the vault immutable", async () => {
+      const [vaultAddr] = await readImmutables(
+        "src/contracts/GPv2VaultRelayer.sol:GPv2VaultRelayer",
+        await settlement.vaultRelayer(),
       );
 
-      expect(ethers.utils.getAddress(recipient)).to.equal(settlement.address);
+      expect(immutableAsAddress(vaultAddr)).to.equal(vault.address);
+    });
+
+    it("should have the settlement contract as the creator", async () => {
+      const [, creator] = await readImmutables(
+        "src/contracts/GPv2VaultRelayer.sol:GPv2VaultRelayer",
+        await settlement.vaultRelayer(),
+      );
+
+      expect(immutableAsAddress(creator)).to.equal(settlement.address);
     });
   });
 

--- a/test/bytecode.ts
+++ b/test/bytecode.ts
@@ -68,3 +68,35 @@ export function immutableAsAddress(value: string): string {
     ),
   );
 }
+
+export async function readAllowanceManagerImmutables(
+  contractAddress: string,
+): Promise<{
+  creator: string;
+}> {
+  const [creator] = await readImmutables(
+    "src/contracts/GPv2AllowanceManager.sol:GPv2AllowanceManager",
+    contractAddress,
+  );
+
+  return {
+    creator: immutableAsAddress(creator),
+  };
+}
+
+export async function readVaultRelayerImmutables(
+  contractAddress: string,
+): Promise<{
+  vault: string;
+  creator: string;
+}> {
+  const [vault, creator] = await readImmutables(
+    "src/contracts/GPv2VaultRelayer.sol:GPv2VaultRelayer",
+    contractAddress,
+  );
+
+  return {
+    vault: immutableAsAddress(vault),
+    creator: immutableAsAddress(creator),
+  };
+}

--- a/test/bytecode.ts
+++ b/test/bytecode.ts
@@ -19,3 +19,52 @@ export async function builtAndDeployedMetadataCoincide(
 
   return metadata(code) === metadata(contractArtifacts.deployedBytecode);
 }
+
+export async function readImmutables(
+  fullyQualifiedContractName: string,
+  contractAddress: string,
+): Promise<string[]> {
+  const buildInfo = await artifacts.getBuildInfo(fullyQualifiedContractName);
+  if (buildInfo === undefined) {
+    throw new Error(`missing ${fullyQualifiedContractName} build info`);
+  }
+
+  const [sourcePath, contractName] = fullyQualifiedContractName.split(":");
+  const immutableReferences =
+    buildInfo.output.contracts[sourcePath][contractName].evm.deployedBytecode
+      .immutableReferences || {};
+
+  // NOTE: For each immutable reference, it may have multiple code locations
+  // where it appears in the final bytecode. Just pick the first one so we can
+  // read its value.
+  const immutableLocations = Object.values(immutableReferences).map(
+    ([firstLocation]) => firstLocation,
+  );
+
+  const code = await ethers.provider.send("eth_getCode", [
+    contractAddress,
+    "latest",
+  ]);
+
+  const immutableValues = immutableLocations.map(({ start, length }) =>
+    ethers.utils.hexDataSlice(code, start, start + length),
+  );
+
+  return immutableValues;
+}
+
+export function immutableAsAddress(value: string): string {
+  const ADDRESS_IMMUTABLE_SLOT_LENGTH = 32;
+  const ADDRESS_BYTE_LENGTH = 20;
+
+  if (ethers.utils.hexDataLength(value) !== ADDRESS_IMMUTABLE_SLOT_LENGTH) {
+    throw new Error("invalid address immutable value");
+  }
+
+  return ethers.utils.getAddress(
+    ethers.utils.hexDataSlice(
+      value,
+      ADDRESS_IMMUTABLE_SLOT_LENGTH - ADDRESS_BYTE_LENGTH,
+    ),
+  );
+}

--- a/test/e2e/deployment.test.ts
+++ b/test/e2e/deployment.test.ts
@@ -28,6 +28,7 @@ describe("E2E: Deployment", () => {
   let user: Wallet;
 
   let authenticator: Contract;
+  let vault: Contract;
   let settlement: Contract;
   let allowanceManager: Contract;
 
@@ -37,6 +38,7 @@ describe("E2E: Deployment", () => {
       manager,
       wallets: [user],
       authenticator,
+      vault,
       settlement,
       allowanceManager,
     } = await deployTestContracts());
@@ -98,7 +100,11 @@ describe("E2E: Deployment", () => {
 
     it("settlement", async () => {
       expect(
-        await contractAddress("GPv2Settlement", authenticator.address),
+        await contractAddress(
+          "GPv2Settlement",
+          authenticator.address,
+          vault.address,
+        ),
       ).to.equal(settlement.address);
     });
   });

--- a/test/e2e/fixture.ts
+++ b/test/e2e/fixture.ts
@@ -7,8 +7,10 @@ export interface TestDeployment {
   manager: Wallet;
   wallets: Wallet[];
   authenticator: Contract;
+  vault: Contract;
   settlement: Contract;
   allowanceManager: Contract;
+  vaultRelayer: Contract;
   gasToken: Contract;
 }
 
@@ -26,13 +28,19 @@ export const deployTestContracts: () => Promise<TestDeployment> = deployments.cr
     } = await deployments.fixture();
 
     const allWallets = waffle.provider.getWallets();
-    const { deployer, owner, manager } = await getNamedAccounts();
+    const {
+      deployer,
+      owner,
+      manager,
+      vault: vaultAddress,
+    } = await getNamedAccounts();
     const unnamedAccounts = await getUnnamedAccounts();
 
     const authenticator = await ethers.getContractAt(
       "GPv2AllowListAuthentication",
       GPv2AllowListAuthentication.address,
     );
+    const vault = await ethers.getContractAt("IVault", vaultAddress);
     const settlement = await ethers.getContractAt(
       "GPv2Settlement",
       GPv2Settlement.address,
@@ -40,6 +48,10 @@ export const deployTestContracts: () => Promise<TestDeployment> = deployments.cr
     const allowanceManager = await ethers.getContractAt(
       "GPv2AllowanceManager",
       await settlement.allowanceManager(),
+    );
+    const vaultRelayer = await ethers.getContractAt(
+      "GPv2VaultRelayer",
+      await settlement.vaultRelayer(),
     );
 
     return {
@@ -50,8 +62,10 @@ export const deployTestContracts: () => Promise<TestDeployment> = deployments.cr
         findAccountWallet(allWallets, account),
       ),
       authenticator,
+      vault,
       settlement,
       allowanceManager,
+      vaultRelayer,
       gasToken: await deployGasToken(allWallets[0]),
     };
   },


### PR DESCRIPTION
This PR adds a "vault relayer" contract that will be allowed to interact with the Vault on behalf of users. It functions similarly to the "allowance manager" contract, except for the `Vault` instead of `ERC20`s.

Currently this contract does nothing, this PR just adds it as well as adjusts unit tests, fixtures, etc. So existing CI passes.

One interesting thing to note is that adding a Vault relayer makes it so our deterministic deployment will only yield the same settlement contract address if the Vault we integrate with is **also** deterministically deployed.

### Test Plan

Unit tests that ensure the contract is deployed and the immutables are set with the correct values. Existing unit tests continue to pass with adjustments required because of new deployment considerations.
