### PR TITLE
Add flags for signaling whether or not to use internal balances

### DIFF
--- a/src/contracts/libraries/GPv2Order.sol
+++ b/src/contracts/libraries/GPv2Order.sol
@@ -19,6 +19,8 @@ library GPv2Order {
         uint256 feeAmount;
         bytes32 kind;
         bool partiallyFillable;
+        bool useInternalSellTokenBalance;
+        bool useInternalBuyTokenBalance;
     }
 
     /// @dev The order EIP-712 type hash for the [`GPv2Order.Data`] struct.
@@ -37,11 +39,13 @@ library GPv2Order {
     ///         "uint256 feeAmount," +
     ///         "string kind," +
     ///         "bool partiallyFillable" +
+    ///         "bool useInternalSellTokenBalance" +
+    ///         "bool useInternalBuyTokenBalance" +
     ///     ")"
     /// )
     /// ```
     bytes32 internal constant TYPE_HASH =
-        hex"d604be04a8c6d2df582ec82eba9b65ce714008acbf9122dd95e499569c8f1a80";
+        hex"e2dc073fc74b3a79b74490a80ce2541fc2191b237c79ab2b8a60f3be54432ce9";
 
     /// @dev The marker value for a sell order for computing the order struct
     /// hash. This allows the EIP-712 compatible wallets to display a
@@ -105,14 +109,14 @@ library GPv2Order {
 
         // NOTE: Compute the EIP-712 order struct hash in place. As suggested
         // in the EIP proposal, noting that the order struct has 10 fields, and
-        // including the type hash `(10 + 1) * 32 = 352` bytes to hash.
+        // including the type hash `(12 + 1) * 32 = 416` bytes to hash.
         // <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#rationale-for-encodedata>
         // solhint-disable-next-line no-inline-assembly
         assembly {
             let dataStart := sub(order, 32)
             let temp := mload(dataStart)
             mstore(dataStart, TYPE_HASH)
-            structHash := keccak256(dataStart, 352)
+            structHash := keccak256(dataStart, 416)
             mstore(dataStart, temp)
         }
 

--- a/src/contracts/test/GPv2TradeTestInterface.sol
+++ b/src/contracts/test/GPv2TradeTestInterface.sol
@@ -19,6 +19,8 @@ contract GPv2TradeTestInterface {
         returns (
             bytes32 kind,
             bool partiallyFillable,
+            bool useInternalSellTokenBalance,
+            bool useInternalBuyTokenBalance,
             GPv2Signing.Scheme signingScheme
         )
     {

--- a/src/ts/order.ts
+++ b/src/ts/order.ts
@@ -59,6 +59,16 @@ export interface Order {
    * Specifies whether or not the order is partially fillable.
    */
   partiallyFillable: boolean;
+  /**
+   * Specifies whether or not internal balances should be used for transferring
+   * sell tokens when settling directly with Balancer.
+   */
+  useInternalSellTokenBalance?: boolean;
+  /**
+   * Specifies whether or not trade proceeds in the buy token should be payed in
+   * internal balances when settling directly with Balancer.
+   */
+  useInternalBuyTokenBalance?: boolean;
 }
 
 /**
@@ -73,7 +83,13 @@ export const BUY_ETH_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 /**
  * Gnosis Protocol v2 order flags.
  */
-export type OrderFlags = Pick<Order, "kind" | "partiallyFillable">;
+export type OrderFlags = Pick<
+  Order,
+  | "kind"
+  | "partiallyFillable"
+  | "useInternalSellTokenBalance"
+  | "useInternalBuyTokenBalance"
+>;
 
 /**
  * A timestamp value.
@@ -113,6 +129,8 @@ export const ORDER_TYPE_FIELDS = [
   { name: "feeAmount", type: "uint256" },
   { name: "kind", type: "string" },
   { name: "partiallyFillable", type: "bool" },
+  { name: "useInternalSellTokenBalance", type: "bool" },
+  { name: "useInternalBuyTokenBalance", type: "bool" },
 ];
 
 /**
@@ -152,6 +170,8 @@ export type NormalizedOrder = Omit<Order, "validTo" | "appData" | "kind"> & {
   validTo: number;
   appData: string;
   kind: string;
+  useInternalSellTokenBalance: boolean;
+  useInternalBuyTokenBalance: boolean;
 };
 
 /**
@@ -163,6 +183,8 @@ export type NormalizedOrder = Omit<Order, "validTo" | "appData" | "kind"> & {
 export function normalizeOrder(order: Order): NormalizedOrder {
   return {
     receiver: ethers.constants.AddressZero,
+    useInternalSellTokenBalance: false,
+    useInternalBuyTokenBalance: false,
     ...order,
     validTo: timestamp(order.validTo),
     appData: hashify(order.appData),

--- a/src/ts/sign.ts
+++ b/src/ts/sign.ts
@@ -34,21 +34,21 @@ export const enum SigningScheme {
    *
    * <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-domainseparator>
    */
-  EIP712,
+  EIP712 = 0b00,
   /**
    * Message signed using eth_sign RPC call.
    */
-  ETHSIGN,
+  ETHSIGN = 0b01,
   /**
    * Smart contract signatures as defined in EIP-1271.
    *
    * <https://eips.ethereum.org/EIPS/eip-1271>
    */
-  EIP1271,
+  EIP1271 = 0b10,
   /**
    * Pre-signed order.
    */
-  PRESIGN,
+  PRESIGN = 0b11,
 }
 
 export type EcdsaSigningScheme = SigningScheme.EIP712 | SigningScheme.ETHSIGN;

--- a/test/GPv2Signing.test.ts
+++ b/test/GPv2Signing.test.ts
@@ -137,6 +137,8 @@ describe("GPv2Signing", () => {
         feeAmount: fillUint(256, 0x08),
         kind: OrderKind.BUY,
         partiallyFillable: true,
+        useInternalSellTokenBalance: true,
+        useInternalBuyTokenBalance: true,
       };
       const tradeExecution = {
         executedAmount: fillUint(256, 0x09),

--- a/test/GPv2Trade.test.ts
+++ b/test/GPv2Trade.test.ts
@@ -61,6 +61,8 @@ describe("GPv2Trade", () => {
         feeAmount: fillUint(256, 0x08),
         kind: OrderKind.BUY,
         partiallyFillable: true,
+        useInternalSellTokenBalance: true,
+        useInternalBuyTokenBalance: true,
       };
       const tradeExecution = {
         executedAmount: fillUint(256, 0x09),
@@ -115,18 +117,42 @@ describe("GPv2Trade", () => {
   describe("extractFlags", () => {
     it("should extract all supported order flags", async () => {
       for (const flags of [
-        { kind: OrderKind.SELL, partiallyFillable: false },
-        { kind: OrderKind.BUY, partiallyFillable: false },
-        { kind: OrderKind.SELL, partiallyFillable: true },
-        { kind: OrderKind.BUY, partiallyFillable: true },
+        {
+          kind: OrderKind.SELL,
+          partiallyFillable: false,
+          useInternalSellTokenBalance: true,
+          useInternalBuyTokenBalance: true,
+        },
+        {
+          kind: OrderKind.BUY,
+          partiallyFillable: false,
+          useInternalSellTokenBalance: false,
+          useInternalBuyTokenBalance: true,
+        },
+        {
+          kind: OrderKind.SELL,
+          partiallyFillable: true,
+          useInternalSellTokenBalance: true,
+          useInternalBuyTokenBalance: false,
+        },
+        {
+          kind: OrderKind.BUY,
+          partiallyFillable: true,
+          useInternalSellTokenBalance: false,
+          useInternalBuyTokenBalance: false,
+        },
       ]) {
         const {
           kind: encodedKind,
           partiallyFillable,
+          useInternalSellTokenBalance,
+          useInternalBuyTokenBalance,
         } = await tradeLib.extractFlagsTest(encodeOrderFlags(flags));
         expect({
           kind: decodeOrderKind(encodedKind),
           partiallyFillable,
+          useInternalSellTokenBalance,
+          useInternalBuyTokenBalance,
         }).to.deep.equal(flags);
       }
     });
@@ -146,7 +172,7 @@ describe("GPv2Trade", () => {
     });
 
     it("should revert when encoding invalid flags", async () => {
-      await expect(tradeLib.extractFlagsTest(0b10000)).to.be.reverted;
+      await expect(tradeLib.extractFlagsTest(0b1000000)).to.be.reverted;
     });
   });
 });

--- a/test/encoding.ts
+++ b/test/encoding.ts
@@ -14,6 +14,8 @@ export type AbiOrder = [
   BigNumber,
   string,
   boolean,
+  boolean,
+  boolean,
 ];
 
 export function encodeOrder(order: Order): AbiOrder {
@@ -29,6 +31,8 @@ export function encodeOrder(order: Order): AbiOrder {
     BigNumber.from(o.feeAmount),
     ethers.utils.id(o.kind),
     o.partiallyFillable,
+    o.useInternalSellTokenBalance,
+    o.useInternalBuyTokenBalance,
   ];
 }
 
@@ -53,6 +57,8 @@ export function decodeOrder(order: AbiOrder): Order {
     feeAmount: order[7],
     kind: decodeOrderKind(order[8]),
     partiallyFillable: order[9],
+    useInternalSellTokenBalance: order[10],
+    useInternalBuyTokenBalance: order[11],
   };
 }
 


### PR DESCRIPTION
This PR adds internal balance flags to the signed order data to indicate whether tokens should be taken from/deposited into Balancer Vault internal balances.

### Test Plan

Adjusted unit tests to exercise new flags. They are currently unused. As expected, this raises the settlement consts per trade slightly (as there is new data to extract, write to memory and hash). It is a fairly small amount (~110 gas).

<details><summary>Benchmarks</summary>

```
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
            2 |           10 |            0 |            0 |       753667  (change: 108 / trade)
            3 |           10 |            0 |            0 |       754235  (change: 114 / trade)
            4 |           10 |            0 |            0 |       763143  (change: 108 / trade)
            5 |           10 |            0 |            0 |       767899  (change: 115 / trade)
            6 |           10 |            0 |            0 |       764219  (change: 110 / trade)
            7 |           10 |            0 |            0 |       773139  (change: 112 / trade)
            8 |           10 |            0 |            0 |       777823  (change: 115 / trade)
            8 |           20 |            0 |            0 |      1465681  (change: 114 / trade)
            8 |           30 |            0 |            0 |      2115200  (change: 109 / trade)
            8 |           40 |            0 |            0 |      2769140  (change: 109 / trade)
            8 |           50 |            0 |            0 |      3423544  (change: 109 / trade)
            8 |           60 |            0 |            0 |      4074136  (change: 109 / trade)
            8 |           70 |            0 |            0 |      4728966  (change: 110 / trade)
            8 |           80 |            0 |            0 |      5382925  (change: 110 / trade)
            2 |           10 |            1 |            0 |       825459  (change: 114 / trade)
            2 |           10 |            2 |            0 |       872515  (change: 112 / trade)
            2 |           10 |            3 |            0 |       919571  (change: 114 / trade)
            2 |           10 |            4 |            0 |       966615  (change: 112 / trade)
            2 |           10 |            5 |            0 |      1013659  (change: 109 / trade)
            2 |           10 |            6 |            0 |      1060703  (change: 114 / trade)
            2 |           10 |            7 |            0 |      1107723  (change: 112 / trade)
            2 |           10 |            8 |            0 |      1154815  (change: 115 / trade)
            2 |           50 |            0 |           10 |      3132111  (change: 110 / trade)
            2 |           50 |            0 |           15 |      3091203  (change: 110 / trade)
            2 |           50 |            0 |           20 |      3050367  (change: 110 / trade)
            2 |           50 |            0 |           25 |      3009507  (change: 111 / trade)
            2 |           50 |            0 |           30 |      2968611  (change: 110 / trade)
            2 |           50 |            0 |           35 |      2927727  (change: 109 / trade)
            2 |           50 |            0 |           40 |      2886819  (change: 108 / trade)
            2 |           50 |            0 |           45 |      2845947  (change: 109 / trade)
            2 |           50 |            0 |           50 |      2805147  (change: 109 / trade)
            2 |            2 |            0 |            0 |       187041  (change: 130 / trade)
            2 |            1 |            1 |            0 |       187840  (change: 139 / trade)
           10 |          100 |           10 |           20 |      6634253  (change: 108 / trade)
```

</details>
