### PR TITLE
Add workflow skeleton for deploy and publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,10 @@
+name: Deploy GPv2 contracts
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,10 @@
+ame: Publish package to NPM
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true


### PR DESCRIPTION
To manually trigger a workflow, that workflow must appear in the default branch ([docs](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow-on-github)).

This PR creates two new no-op workflows. Once merged into main, this PR will allow to run the workflows defined in PRs #452, #468 while pointing to their respective branches.

### Test Plan

None!