### PR TITLE
Workflow typo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,4 +7,4 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - run: true
+      - run: 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-ame: Publish package to NPM
+name: Publish package to NPM
 
 on:
   workflow_dispatch:
@@ -7,4 +7,4 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - run: true
+      - run: 'true'


### PR DESCRIPTION
Tiny fix to the "no-op" workflows.

The `true` was changed to `'true'` because 

![image](https://user-images.githubusercontent.com/4210206/109994440-9b63fc00-7d0d-11eb-9e3b-1dc58ee620a5.png)

