### PR TITLE
Add Github-native dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "02:00"
+  ignore:
+  - dependency-name: "@gnosis.pm/util-contracts"
+  - dependency-name: "@openzeppelin/contracts"

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "ethers": "~5.0.18"
   },
   "devDependencies": {
-    "@0x/contract-artifacts": "=2.2.2",
-    "@gnosis.pm/safe-contracts": "=1.2.0",
+    "@0x/contract-artifacts-v2": "npm:@0x/contract-artifacts@^2.2.2",
+    "@gnosis.pm/safe-contracts": "^1.2.0",
     "@gnosis.pm/util-contracts": "=3.1.0-solc-7",
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-waffle": "^2.0.1",

--- a/test/e2e/zero-ex/v2/index.ts
+++ b/test/e2e/zero-ex/v2/index.ts
@@ -1,4 +1,4 @@
-import { ERC20Proxy, Exchange, ZRXToken } from "@0x/contract-artifacts";
+import { ERC20Proxy, Exchange, ZRXToken } from "@0x/contract-artifacts-v2";
 import { BigNumberish, BytesLike, Contract, Wallet } from "ethers";
 import { ethers, waffle } from "hardhat";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@0x/contract-artifacts@=2.2.2":
+"@0x/contract-artifacts-v2@npm:@0x/contract-artifacts@^2.2.2":
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/@0x/contract-artifacts/-/contract-artifacts-2.2.2.tgz#e6d771afb58d0b59c19c5364af5a42a3dfd17219"
   integrity sha512-sbFnSXE6PlmYsbPXpKtEOR3YdVlSn63HhbPgQB3J5jm27wwQtnZ2Lf21I7BdiRBsHwwbf75C/s2pjNqafaRrgQ==
@@ -507,7 +507,7 @@
     "@ethersproject/properties" "^5.0.7"
     "@ethersproject/strings" "^5.0.8"
 
-"@gnosis.pm/safe-contracts@=1.2.0":
+"@gnosis.pm/safe-contracts@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-contracts/-/safe-contracts-1.2.0.tgz#33e8332e09c19e8822fccb06c7d3eff806d091f6"
   integrity sha512-lcpZodqztDgMICB0kAc8aJdQePwCaLJnbeNjgVTfLAo3fBckVRV06VHXg5IsZ26qLA4JfZ690Cb7TsDVE9ZF3w==


### PR DESCRIPTION
This PR adds a Github-native Dependabot configuration file (instead of using the Dependabot app). Additionally:

- It updates the 0x contracts to use an alias (this is so we can have an E2E test for both the v2 and v4 contracts (once they are released)
- It adds `ignore` directives for specific dependencies that we don't want to automatically update (as we are using a separate tagged version for Solidity 0.7 while the "latest" tag is for Solidity 0.6)

### Test Plan

CI should still pass.
