### PR TITLE
Introduce transfer library for doing batched vault transfers

### DIFF
--- a/src/contracts/libraries/GPv2Transfer.sol
+++ b/src/contracts/libraries/GPv2Transfer.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.7.6;
+pragma abicoder v2;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "../interfaces/IVault.sol";
+import "./GPv2SafeERC20.sol";
+
+/// @title Gnosis Protocol v2 Transfers
+/// @author Gnosis Developers
+library GPv2Transfer {
+    using GPv2SafeERC20 for IERC20;
+
+    /// @dev Transfer data.
+    struct Data {
+        address account;
+        IERC20 token;
+        uint256 amount;
+        bool useInternalBalance;
+    }
+
+    /// @dev Ether marker address used to indicate an Ether transfer.
+    address internal constant BUY_ETH_ADDRESS =
+        0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    /// @dev Execute the specified transfers from the specified accounts to a
+    /// single recipient.
+    ///
+    /// This method is used for accumulating user balances into the settlement
+    /// contract.
+    ///
+    /// @param vault The Balancer vault to use.
+    /// @param recipient The single recipient for all the transfers.
+    /// @param transfers The batched transfers to perform.
+    function transferToRecipient(
+        IVault vault,
+        address recipient,
+        Data[] calldata transfers
+    ) internal {
+        // NOTE: Pre-allocate an array of vault balance tranfers large enough to
+        // hold all transfers. This allows us to efficiently batch internal
+        // balance transfers into a single Vault call.
+        IVault.BalanceTransfer[] memory vaultTransfers =
+            new IVault.BalanceTransfer[](transfers.length);
+        uint256 vaultTransferCount = 0;
+
+        for (uint256 i = 0; i < transfers.length; i++) {
+            Data calldata transfer = transfers[i];
+            require(
+                address(transfer.token) != BUY_ETH_ADDRESS,
+                "GPv2: cannot transfer native ETH"
+            );
+
+            if (transfer.useInternalBalance) {
+                IVault.BalanceTransfer memory vaultTransfer =
+                    vaultTransfers[vaultTransferCount++];
+                vaultTransfer.token = transfer.token;
+                vaultTransfer.amount = transfer.amount;
+                vaultTransfer.sender = transfer.account;
+                vaultTransfer.recipient = recipient;
+            } else {
+                transfer.token.safeTransferFrom(
+                    transfer.account,
+                    recipient,
+                    transfer.amount
+                );
+            }
+        }
+
+        if (vaultTransferCount > 0) {
+            // NOTE: Truncate the vault transfers array so that its length is
+            // the number of vault transfers we want to perform. This is done
+            // by setting the array's length in which occupies the first word
+            // in memory pointed to by the `vaultTransfers` memory variable.
+            // <https://docs.soliditylang.org/en/v0.7.6/internals/layout_in_memory.html>
+            // solhint-disable-next-line no-inline-assembly
+            assembly {
+                mstore(vaultTransfers, vaultTransferCount)
+            }
+            vault.withdrawFromInternalBalance(vaultTransfers);
+        }
+    }
+}

--- a/src/contracts/test/GPv2TransferTestInterface.sol
+++ b/src/contracts/test/GPv2TransferTestInterface.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.7.6;
+pragma abicoder v2;
+
+import "../libraries/GPv2Transfer.sol";
+
+contract GPv2TransferTestInterface {
+    function transferToRecipientTest(
+        IVault vault,
+        address recipient,
+        GPv2Transfer.Data[] calldata transfers
+    ) external {
+        GPv2Transfer.transferToRecipient(vault, recipient, transfers);
+    }
+
+    // solhint-disable-next-line no-empty-blocks
+    receive() external payable {}
+}

--- a/test/GPv2Transfer.test.ts
+++ b/test/GPv2Transfer.test.ts
@@ -1,0 +1,160 @@
+import IERC20 from "@openzeppelin/contracts/build/contracts/IERC20.json";
+import { expect } from "chai";
+import { MockContract } from "ethereum-waffle";
+import { Contract } from "ethers";
+import { artifacts, ethers, waffle } from "hardhat";
+
+import { BUY_ETH_ADDRESS } from "../src/ts";
+
+describe("GPv2Transfer", () => {
+  const [deployer, recipient, ...traders] = waffle.provider.getWallets();
+
+  let transfer: Contract;
+  let vault: MockContract;
+  let token: MockContract;
+
+  beforeEach(async () => {
+    const GPv2Transfer = await ethers.getContractFactory(
+      "GPv2TransferTestInterface",
+    );
+    transfer = await GPv2Transfer.deploy();
+
+    const IVault = await artifacts.readArtifact("IVault");
+    vault = await waffle.deployMockContract(deployer, IVault.abi);
+    token = await waffle.deployMockContract(deployer, IERC20.abi);
+  });
+
+  describe("transferToRecipient", () => {
+    const amount = ethers.utils.parseEther("13.37");
+
+    it("should transfer external amount to recipient", async () => {
+      await token.mock.transferFrom
+        .withArgs(traders[0].address, recipient.address, amount)
+        .returns(true);
+      await expect(
+        transfer.transferToRecipientTest(vault.address, recipient.address, [
+          {
+            account: traders[0].address,
+            token: token.address,
+            amount: amount,
+            useInternalBalance: false,
+          },
+        ]),
+      ).to.not.be.reverted;
+    });
+
+    it("should transfer internal amount to recipient", async () => {
+      await vault.mock.withdrawFromInternalBalance
+        .withArgs([
+          {
+            token: token.address,
+            amount,
+            sender: traders[0].address,
+            recipient: recipient.address,
+          },
+        ])
+        .returns();
+      await expect(
+        transfer.transferToRecipientTest(vault.address, recipient.address, [
+          {
+            account: traders[0].address,
+            token: token.address,
+            amount,
+            useInternalBalance: true,
+          },
+        ]),
+      ).to.not.be.reverted;
+    });
+
+    it("should transfer many external and internal amounts to recipient", async () => {
+      const transfers = traders.map((trader, i) => ({
+        account: trader.address,
+        token: token.address,
+        amount,
+        useInternalBalance: (i & 1) == 1,
+      }));
+
+      for (const { account } of transfers.filter(
+        (transfer) => !transfer.useInternalBalance,
+      )) {
+        await token.mock.transferFrom
+          .withArgs(account, recipient.address, amount)
+          .returns(true);
+      }
+      await vault.mock.withdrawFromInternalBalance
+        .withArgs(
+          transfers
+            .filter((transfer) => transfer.useInternalBalance)
+            .map(({ account }) => ({
+              token: token.address,
+              amount,
+              sender: account,
+              recipient: recipient.address,
+            })),
+        )
+        .returns();
+
+      await expect(
+        transfer.transferToRecipientTest(
+          vault.address,
+          recipient.address,
+          transfers,
+        ),
+      ).to.not.be.reverted;
+    });
+
+    it("reverts when mistakenly trying to transfer ETH", async () => {
+      await expect(
+        transfer.transferToRecipientTest(vault.address, recipient.address, [
+          {
+            account: traders[0].address,
+            token: BUY_ETH_ADDRESS,
+            amount: amount,
+            useInternalBalance: false,
+          },
+        ]),
+      ).to.be.revertedWith("GPv2: cannot transfer native ETH");
+    });
+
+    it("should revert on failed ERC20 transfers", async () => {
+      await token.mock.transferFrom
+        .withArgs(traders[0].address, recipient.address, amount)
+        .revertsWithReason("test error");
+
+      await expect(
+        transfer.transferToRecipientTest(vault.address, recipient.address, [
+          {
+            account: traders[0].address,
+            token: token.address,
+            amount: amount,
+            useInternalBalance: false,
+          },
+        ]),
+      ).to.be.revertedWith("test error");
+    });
+
+    it("should revert on failed Vault withdrawal", async () => {
+      await vault.mock.withdrawFromInternalBalance
+        .withArgs([
+          {
+            token: token.address,
+            amount,
+            sender: traders[0].address,
+            recipient: recipient.address,
+          },
+        ])
+        .revertsWithReason("test error");
+
+      await expect(
+        transfer.transferToRecipientTest(vault.address, recipient.address, [
+          {
+            account: traders[0].address,
+            token: token.address,
+            amount,
+            useInternalBalance: true,
+          },
+        ]),
+      ).to.be.revertedWith("test error");
+    });
+  });
+});


### PR DESCRIPTION
This PR introduces a transfer library for performing batched Vault transfers and will be used by the vault relayer in an upcomming PR.

There is a significant overlap with `GPv2TradeExecution` library which will eventually be fazed out once the contracts become more vault-centric

### Test Plan

Added new unit tests.
