### PR TITLE
Remove hardhat imports from exported library code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v2-contracts",
-  "version": "0.0.1-alpha.12",
+  "version": "0.0.1-alpha.13",
   "license": "LGPL-3.0-or-later",
   "scripts": {
     "build": "tsc && hardhat compile",

--- a/src/ts/proxy.ts
+++ b/src/ts/proxy.ts
@@ -1,15 +1,18 @@
-// defined in https://eips.ethereum.org/EIPS/eip-1967
+import { BigNumber, BytesLike, Contract, ethers } from "ethers";
 
-import { BigNumber, Contract, ethers } from "ethers";
-
-// The proxy contract used by hardhat-deploy implements EIP-1967 (Standard Proxy
-// Storage Slot). See <https://eips.ethereum.org/EIPS/eip-1967>.
-function slot(string: string) {
+/**
+ * Compute an EIP-1967 slot for the specified name. The proxy contract used by
+ * `hardhat-deploy` implements EIP-1967 (Standard Proxy Storage Slot).
+ *
+ * <https://eips.ethereum.org/EIPS/eip-1967>.
+ */
+function slot(name: string): BytesLike {
   return ethers.utils.defaultAbiCoder.encode(
     ["bytes32"],
-    [BigNumber.from(ethers.utils.id(string)).sub(1)],
+    [BigNumber.from(ethers.utils.id(name)).sub(1)],
   );
 }
+
 const IMPLEMENTATION_STORAGE_SLOT = slot("eip1967.proxy.implementation");
 const OWNER_STORAGE_SLOT = slot("eip1967.proxy.admin");
 
@@ -50,7 +53,9 @@ export async function ownerAddress(
 }
 
 /**
- * EIP-173 proxy ABI in "Human-readable ABI format".
+ * EIP-173 proxy ABI in "human-readable ABI" format. The proxy used by the
+ * deployment plugin implements this interface, and copying it here avoids
+ * pulling in `hardhat` as a dependency for just this ABI.
  *
  * <https://eips.ethereum.org/EIPS/eip-173#specification>
  */

--- a/src/ts/proxy.ts
+++ b/src/ts/proxy.ts
@@ -1,8 +1,6 @@
 // defined in https://eips.ethereum.org/EIPS/eip-1967
 
-import { BigNumber, Contract } from "ethers";
-import { ethers } from "hardhat";
-import Proxy from "hardhat-deploy/extendedArtifacts/EIP173Proxy.json";
+import { BigNumber, Contract, ethers } from "ethers";
 
 // The proxy contract used by hardhat-deploy implements EIP-1967 (Standard Proxy
 // Storage Slot). See <https://eips.ethereum.org/EIPS/eip-1967>.
@@ -22,10 +20,13 @@ const OWNER_STORAGE_SLOT = slot("eip1967.proxy.admin");
  * @param proxy Address of the proxy contract.
  * @returns The address of the contract storing the proxy implementation.
  */
-export async function implementationAddress(proxy: string): Promise<string> {
+export async function implementationAddress(
+  provider: ethers.providers.Provider,
+  proxy: string,
+): Promise<string> {
   const [implementation] = ethers.utils.defaultAbiCoder.decode(
     ["address"],
-    await ethers.provider.getStorageAt(proxy, IMPLEMENTATION_STORAGE_SLOT),
+    await provider.getStorageAt(proxy, IMPLEMENTATION_STORAGE_SLOT),
   );
   return implementation;
 }
@@ -37,13 +38,28 @@ export async function implementationAddress(proxy: string): Promise<string> {
  * @param proxy Address of the proxy contract.
  * @returns The address of the administrator of the proxy.
  */
-export async function ownerAddress(proxy: string): Promise<string> {
+export async function ownerAddress(
+  provider: ethers.providers.Provider,
+  proxy: string,
+): Promise<string> {
   const [owner] = ethers.utils.defaultAbiCoder.decode(
     ["address"],
-    await ethers.provider.getStorageAt(proxy, OWNER_STORAGE_SLOT),
+    await provider.getStorageAt(proxy, OWNER_STORAGE_SLOT),
   );
   return owner;
 }
+
+/**
+ * EIP-173 proxy ABI in "Human-readable ABI format".
+ *
+ * <https://eips.ethereum.org/EIPS/eip-173#specification>
+ */
+export const EIP173_PROXY_ABI = [
+  "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)",
+  "function owner() view external returns(address)",
+  "function transferOwnership(address newOwner) external",
+  "function supportsInterface(bytes4 interfaceID) external view returns (bool)",
+];
 
 /**
  * Returns the proxy interface for the specified address.
@@ -52,10 +68,9 @@ export async function ownerAddress(proxy: string): Promise<string> {
  * @returns A Ethers.js contract instance for interacting with the proxy.
  */
 export function proxyInterface(contract: Contract): Contract {
-  const { abi } = Proxy;
   return new Contract(
     contract.address,
-    abi,
+    EIP173_PROXY_ABI,
     contract.signer ?? contract.provider,
   );
 }

--- a/test/e2e/deployment.test.ts
+++ b/test/e2e/deployment.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { Contract, Wallet } from "ethers";
-import { artifacts } from "hardhat";
+import { artifacts, ethers } from "hardhat";
 import Proxy from "hardhat-deploy/extendedArtifacts/EIP173Proxy.json";
 
 import {
@@ -50,7 +50,7 @@ describe("E2E: Deployment", () => {
     it("authenticator", async () => {
       expect(
         await builtAndDeployedMetadataCoincide(
-          await implementationAddress(authenticator.address),
+          await implementationAddress(ethers.provider, authenticator.address),
           "GPv2AllowListAuthentication",
         ),
       ).to.be.true;
@@ -80,7 +80,7 @@ describe("E2E: Deployment", () => {
       it("proxy", async () => {
         expect(
           deterministicDeploymentAddress(Proxy, [
-            await implementationAddress(authenticator.address),
+            await implementationAddress(ethers.provider, authenticator.address),
             authenticator.interface.encodeFunctionData("initializeManager", [
               manager.address,
             ]),
@@ -91,7 +91,7 @@ describe("E2E: Deployment", () => {
 
       it("implementation", async () => {
         expect(await contractAddress("GPv2AllowListAuthentication")).to.equal(
-          await implementationAddress(authenticator.address),
+          await implementationAddress(ethers.provider, authenticator.address),
         );
       });
     });


### PR DESCRIPTION
Fixes part of #506

This PR removes the `import "hardhat*"` statements from the TypeScript library code, as its a `devDependency`, and as such not available to dependent pacakges.

### Test Plan

Release `alpha.13` and see if it resolves the issues. We may need to also switch the `target` library in the TS config, but I'm hopeful that we won't have to.
