### PR TITLE
Build lib with different options

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "solvers": "hardhat solvers",
     "build": "yarn build:sol && yarn build:ts",
     "build:sol": "hardhat compile",
-    "build:ts": "tsc && tsc -p tsconfig.lib.commonjs.json && tsc -p tsconfig.lib.esm.json",
+    "build:ts": "tsc && tsc -p tsconfig.lib.esm.json && tsc -p tsconfig.lib.commonjs.json",
     "lint": "yarn lint:sol && yarn lint:ts",
     "lint:sol": "solhint 'src/contracts/**/*.sol'",
     "lint:ts": "eslint --max-warnings 0 .",
@@ -68,8 +68,8 @@
     "yargs": "^16.2.0"
   },
   "main": "lib/commonjs/index.js",
-  "types": "lib/commonjs/index.d.ts",
   "module": "lib/esm/index.js",
+  "types": "lib/esm/index.d.ts",
   "files": [
     "build/",
     "deployments/",

--- a/package.json
+++ b/package.json
@@ -3,11 +3,16 @@
   "version": "0.0.1-alpha.13",
   "license": "LGPL-3.0-or-later",
   "scripts": {
-    "build": "tsc && hardhat compile",
     "deploy": "hardhat deploy",
     "verify:etherscan": "hardhat etherscan-verify --license LGPL-3.0 --force-license",
     "verify:tenderly": "hardhat tenderly",
     "solvers": "hardhat solvers",
+    "build": "yarn build:sol && yarn build:ts",
+    "build:sol": "hardhat compile",
+    "build:ts": "tsc && tsc -p tsconfig.lib.commonjs.json && tsc -p tsconfig.lib.esm.json",
+    "lint": "yarn lint:sol && yarn lint:ts",
+    "lint:sol": "solhint 'src/contracts/**/*.sol'",
+    "lint:ts": "eslint --max-warnings 0 .",
     "test": "hardhat test",
     "test:ignored-in-coverage": "MOCHA_CONF='ignored in coverage' hardhat test",
     "coverage": "MOCHA_CONF='coverage' hardhat coverage",
@@ -16,9 +21,6 @@
     "bench:single": "hardhat run bench/single.ts",
     "bench:trace": "hardhat run bench/trace/index.ts",
     "bench:uniswap": "hardhat run bench/uniswap/index.ts",
-    "lint": "yarn lint:sol && yarn lint:ts",
-    "lint:sol": "solhint 'src/contracts/**/*.sol'",
-    "lint:ts": "eslint --max-warnings 0 .",
     "fmt:sol": "prettier 'src/contracts/**/*.sol' -w",
     "prepack": "yarn build"
   },
@@ -65,12 +67,13 @@
     "typescript": "^4.2.3",
     "yargs": "^16.2.0"
   },
-  "main": "lib/src/ts/index.js",
-  "types": "lib/src/ts/index.d.ts",
+  "main": "lib/commonjs/index.js",
+  "types": "lib/commonjs/index.d.ts",
+  "module": "lib/esm/index.js",
   "files": [
     "build/",
     "deployments/",
-    "lib/src/",
+    "lib/",
     "networks.json",
     "src/"
   ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,11 @@
 {
   "compilerOptions": {
-    "declaration": true,
-    "esModuleInterop": true,
+    "target": "es2020",
     "module": "commonjs",
-    "moduleResolution": "node",
-    "outDir": "lib",
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
+    "noEmit": true,
     "strict": true,
-    "target": "es2020"
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
+    "moduleResolution": "node",
     "noEmit": true,
     "strict": true,
     "esModuleInterop": true,

--- a/tsconfig.lib.commonjs.json
+++ b/tsconfig.lib.commonjs.json
@@ -1,13 +1,9 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.lib.esm.json",
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
     "outDir": "lib/commonjs/",
-    "declaration": true,
-    "sourceMap": true,
-    "rootDir": "src/ts/",
-    "noEmit": false
-  },
-  "include": ["src/ts/**/*"]
+    "declaration": false
+  }
 }

--- a/tsconfig.lib.commonjs.json
+++ b/tsconfig.lib.commonjs.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "outDir": "lib/commonjs/",
+    "declaration": true,
+    "sourceMap": true,
+    "rootDir": "src/ts/",
+    "noEmit": false
+  },
+  "include": ["src/ts/**/*"]
+}

--- a/tsconfig.lib.esm.json
+++ b/tsconfig.lib.esm.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.lib.commonjs.json",
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "es2020",
+    "moduleResolution": "node",
+    "outDir": "lib/esm/",
+    "declaration": false
+  }
+}

--- a/tsconfig.lib.esm.json
+++ b/tsconfig.lib.esm.json
@@ -1,10 +1,13 @@
 {
-  "extends": "./tsconfig.lib.commonjs.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "target": "es2020",
     "module": "es2020",
-    "moduleResolution": "node",
     "outDir": "lib/esm/",
-    "declaration": false
-  }
+    "declaration": true,
+    "sourceMap": true,
+    "rootDir": "src/ts/",
+    "noEmit": false
+  },
+  "include": ["src/ts/**/*"]
 }


### PR DESCRIPTION
Closes #506 

This PR adds additional TypeScript configuration files for targeting both CommonJS and ES modules. Additionally, it produces `es5` output in order to be more compatible with the FE. Additionally, and ESM build is included so that it can work better with tools like Babel and take better advantage of things like tree shaking to reduce bundle sizes.

### Test Plan

Deploy this package and make sure it works with the FE.
