### PR TITLE
Remove additional hardhat import in src/

### DIFF
--- a/src/ts/deploy.ts
+++ b/src/ts/deploy.ts
@@ -1,5 +1,4 @@
 import { utils } from "ethers";
-import { Artifact } from "hardhat/types";
 
 /**
  * The salt used when deterministically deploying smart contracts.
@@ -40,9 +39,17 @@ export type DeploymentArguments<
   : unknown[];
 
 /**
+ * Allowed ABI definition types by Ethers.js.
+ */
+export type Abi = ConstructorParameters<typeof utils.Interface>[0];
+
+/**
  * Artifact information important for computing deterministic deployments.
  */
-export type ArtifactDeployment = Pick<Artifact, "abi" | "bytecode">;
+export interface ArtifactDeployment {
+  abi: Abi;
+  bytecode: string;
+}
 
 /**
  * An artifact with a contract name matching one of the deterministically

--- a/src/ts/types/ethers.ts
+++ b/src/ts/types/ethers.ts
@@ -12,6 +12,9 @@ export type TypedDataDomain = Parameters<
   typeof ethers.utils._TypedDataEncoder.hashDomain
 >[0];
 
+/**
+ * Ethers EIP-712 typed data signer interface.
+ */
 export interface TypedDataSigner extends Signer {
   /**
    * Signs the typed data value with types data structure for domain using the
@@ -20,6 +23,9 @@ export interface TypedDataSigner extends Signer {
   _signTypedData: typeof ethers.VoidSigner.prototype._signTypedData;
 }
 
+/**
+ * Checks whether the specified signer is a typed data signer.
+ */
 export function isTypedDataSigner(signer: Signer): signer is TypedDataSigner {
   return "_signTypedData" in signer;
 }


### PR DESCRIPTION
This PR removes an additional `hardhat` dependency import under `src/` that shouldn't be there.

I tried really hard to get TypeScript to fail builds when dependencies other than `ethers` were included when building `lib`, but to no avail.
