### PR TITLE
Implement paying our proceeds in internal balances

### DIFF
--- a/src/contracts/libraries/GPv2Transfer.sol
+++ b/src/contracts/libraries/GPv2Transfer.sol
@@ -68,16 +68,71 @@ library GPv2Transfer {
         }
 
         if (vaultTransferCount > 0) {
-            // NOTE: Truncate the vault transfers array so that its length is
-            // the number of vault transfers we want to perform. This is done
-            // by setting the array's length in which occupies the first word
-            // in memory pointed to by the `vaultTransfers` memory variable.
-            // <https://docs.soliditylang.org/en/v0.7.6/internals/layout_in_memory.html>
-            // solhint-disable-next-line no-inline-assembly
-            assembly {
-                mstore(vaultTransfers, vaultTransferCount)
-            }
+            truncateTransfersArray(vaultTransfers, vaultTransferCount);
             vault.withdrawFromInternalBalance(vaultTransfers);
+        }
+    }
+
+    /// @dev Execute the specified transfers to their respective accounts.
+    ///
+    /// This method is used for paying out trade proceeds from the settlement
+    /// contract.
+    ///
+    /// @param vault The Balancer vault to use.
+    /// @param transfers The batched transfers to perform.
+    function transferToAccounts(IVault vault, Data[] memory transfers)
+        internal
+    {
+        IVault.BalanceTransfer[] memory vaultTransfers =
+            new IVault.BalanceTransfer[](transfers.length);
+        uint256 vaultTransferCount = 0;
+
+        for (uint256 i = 0; i < transfers.length; i++) {
+            Data memory transfer = transfers[i];
+
+            if (address(transfer.token) == BUY_ETH_ADDRESS) {
+                require(
+                    !transfer.useInternalBalance,
+                    "GPv2: unsupported internal ETH"
+                );
+                payable(transfer.account).transfer(transfer.amount);
+            } else if (transfer.useInternalBalance) {
+                IVault.BalanceTransfer memory vaultTransfer =
+                    vaultTransfers[vaultTransferCount++];
+                vaultTransfer.token = transfer.token;
+                vaultTransfer.amount = transfer.amount;
+                vaultTransfer.sender = address(this);
+                vaultTransfer.recipient = transfer.account;
+            } else {
+                transfer.token.safeTransfer(transfer.account, transfer.amount);
+            }
+        }
+
+        if (vaultTransferCount > 0) {
+            truncateTransfersArray(vaultTransfers, vaultTransferCount);
+            vault.depositToInternalBalance(vaultTransfers);
+        }
+    }
+
+    /// @dev Truncate a Vault balance transfer array to its actual size.
+    ///
+    /// This method **does not** check whether or not the new length is valid,
+    /// and specifying a size that is larger than the array's actual length is
+    /// undefined behaviour.
+    ///
+    /// @param vaultTransfers The memory array of vault transfers to truncate.
+    /// @param length The new length to set.
+    function truncateTransfersArray(
+        IVault.BalanceTransfer[] memory vaultTransfers,
+        uint256 length
+    ) private pure {
+        // NOTE: Truncate the vault transfers array to the specified length.
+        // This is done by setting the array's length which occupies the first
+        // word in memory pointed to by the `vaultTransfers` memory variable.
+        // <https://docs.soliditylang.org/en/v0.7.6/internals/layout_in_memory.html>
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            mstore(vaultTransfers, length)
         }
     }
 }

--- a/src/contracts/test/GPv2TransferTestInterface.sol
+++ b/src/contracts/test/GPv2TransferTestInterface.sol
@@ -13,6 +13,13 @@ contract GPv2TransferTestInterface {
         GPv2Transfer.transferToRecipient(vault, recipient, transfers);
     }
 
+    function transferToAccountsTest(
+        IVault vault,
+        GPv2Transfer.Data[] memory transfers
+    ) external {
+        GPv2Transfer.transferToAccounts(vault, transfers);
+    }
+
     // solhint-disable-next-line no-empty-blocks
     receive() external payable {}
 }


### PR DESCRIPTION
This PR adds method for batched transfer for paying trade proceeds to users. This code effectively does the inverse of the previously implemented transfer function, with Ether transfer support.

### Test Plan

Added new unit tests.
