### PR TITLE
Bump version and remove imports for non-dependant packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v2-contracts",
-  "version": "0.0.1-alpha.14",
+  "version": "0.0.1-alpha.15",
   "license": "LGPL-3.0-or-later",
   "scripts": {
     "deploy": "hardhat deploy",

--- a/src/ts/order.ts
+++ b/src/ts/order.ts
@@ -1,7 +1,6 @@
-import { TypedDataField } from "@ethersproject/abstract-signer";
 import { BigNumberish, BytesLike, ethers } from "ethers";
 
-import { TypedDataDomain } from "./types/ethers";
+import { TypedDataDomain, TypedDataTypes } from "./types/ethers";
 
 /**
  * Gnosis Protocol v2 order data.
@@ -194,7 +193,7 @@ export function normalizeOrder(order: Order): NormalizedOrder {
  */
 export function hashTypedData(
   domain: TypedDataDomain,
-  types: Record<string, TypedDataField[]>,
+  types: TypedDataTypes,
   data: Record<string, unknown>,
 ): string {
   return ethers.utils._TypedDataEncoder.hash(domain, types, data);

--- a/src/ts/sign.ts
+++ b/src/ts/sign.ts
@@ -1,4 +1,3 @@
-import { TypedDataField } from "@ethersproject/abstract-signer";
 import { BytesLike, ethers, Signer } from "ethers";
 
 import {
@@ -9,6 +8,7 @@ import {
   hashTypedData,
 } from "./order";
 import {
+  TypedDataTypes,
   SignatureLike,
   isTypedDataSigner,
   TypedDataDomain,
@@ -125,7 +125,7 @@ function ecdsaSignTypedData(
   scheme: EcdsaSigningScheme,
   owner: Signer,
   domain: TypedDataDomain,
-  types: Record<string, TypedDataField[]>,
+  types: TypedDataTypes,
   data: Record<string, unknown>,
 ): Promise<string> {
   switch (scheme) {

--- a/src/ts/types/ethers.ts
+++ b/src/ts/types/ethers.ts
@@ -13,6 +13,13 @@ export type TypedDataDomain = Parameters<
 >[0];
 
 /**
+ * EIP-712 typed data type definitions.
+ */
+export type TypedDataTypes = Parameters<
+  typeof ethers.utils._TypedDataEncoder.hashStruct
+>[1];
+
+/**
  * Ethers EIP-712 typed data signer interface.
  */
 export interface TypedDataSigner extends Signer {


### PR DESCRIPTION
This PR prepares a new `alpha.15` release with the added order cancellation method (as it will be needed by the FE).

In doing a once-over on the dependencies used by the exported TypeScript library, I noticed that we depend on a type from a package we don't directly depend on. I removed the import statement as it might cause issues by packages that use this library and followed the same pattern we used for the typed signer. The name `TypedDataTypes` is a little unfortunate, but is chosen for [consistency with EIP-712, as it represents the `types` field in the `TypedData` structure](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#specification-of-the-eth_signtypeddata-json-rpc).

### Test Plan

CI still passes.
