### PR TITLE
Implement Balancer Fast-Path settlement logic

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -3,9 +3,10 @@ pragma solidity ^0.7.6;
 pragma abicoder v2;
 
 import "@gnosis.pm/util-contracts/contracts/StorageAccessible.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/SafeCast.sol";
 
 import "./GPv2VaultRelayer.sol";
 import "./interfaces/GPv2Authentication.sol";
@@ -21,6 +22,7 @@ import "./mixins/GPv2Signing.sol";
 contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
     using GPv2Order for bytes;
     using GPv2Transfer for IVault;
+    using SafeCast for uint256;
     using SafeMath for uint256;
 
     /// @dev The authenticator is used to determine who can call the settle function.
@@ -138,6 +140,69 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
         executeInteractions(interactions[2]);
 
         emit Settlement(msg.sender);
+    }
+
+    /// @dev Settle an order directly against Balancer V2 pools.
+    function swap(
+        IVault.SwapRequest[] calldata swaps,
+        IERC20[] calldata tokens,
+        GPv2Trade.Data calldata trade
+    ) external nonReentrant onlySolver {
+        RecoveredOrder memory recoveredOrder = allocateRecoveredOrder();
+        GPv2Order.Data memory order = recoveredOrder.data;
+        recoverOrderFromTrade(recoveredOrder, tokens, trade);
+
+        IVault.SwapKind kind =
+            order.kind == GPv2Order.SELL
+                ? IVault.SwapKind.GIVEN_IN
+                : IVault.SwapKind.GIVEN_OUT;
+
+        IVault.FundManagement memory funds;
+        funds.sender = recoveredOrder.owner;
+        funds.fromInternalBalance = order.useInternalSellTokenBalance;
+        funds.recipient = recoveredOrder.receiver;
+        funds.toInternalBalance = order.useInternalBuyTokenBalance;
+
+        int256[] memory limits = new int256[](tokens.length);
+        // NOTE: Array allocation initializes elements to 0, so we only need to
+        // set the limits we care about.
+        limits[trade.sellTokenIndex] = order.sellAmount.toInt256();
+        limits[trade.buyTokenIndex] = -order.buyAmount.toInt256();
+
+        GPv2Transfer.Data memory feeTransfer;
+        feeTransfer.account = recoveredOrder.owner;
+        feeTransfer.token = order.sellToken;
+        feeTransfer.amount = order.feeAmount;
+        feeTransfer.useInternalBalance = order.useInternalSellTokenBalance;
+
+        int256[] memory tokenDeltas =
+            vaultRelayer.batchSwapWithFee(
+                kind,
+                swaps,
+                tokens,
+                funds,
+                limits,
+                order.validTo,
+                feeTransfer
+            );
+
+        // NOTE: Check that the orders were completely filled and update their
+        // filled amounts to avoid replaying them.
+        require(filledAmount[recoveredOrder.uid] == 0, "GPv2: order filled");
+        if (order.kind == GPv2Order.SELL) {
+            require(
+                tokenDeltas[trade.sellTokenIndex] ==
+                    order.sellAmount.toInt256(),
+                "GPv2: sell amount not respected"
+            );
+            filledAmount[recoveredOrder.uid] = order.sellAmount;
+        } else {
+            require(
+                tokenDeltas[trade.buyTokenIndex] == -order.buyAmount.toInt256(),
+                "GPv2: buy amount not respected"
+            );
+            filledAmount[recoveredOrder.uid] = order.buyAmount;
+        }
     }
 
     /// @dev Invalidate onchain an order that has been signed offline.

--- a/src/contracts/test/GPv2SettlementTestInterface.sol
+++ b/src/contracts/test/GPv2SettlementTestInterface.sol
@@ -15,6 +15,10 @@ contract GPv2SettlementTestInterface is GPv2Settlement {
 
     }
 
+    function setFilledAmount(bytes calldata orderUid, uint256 amount) external {
+        filledAmount[orderUid] = amount;
+    }
+
     function computeTradeExecutionsTest(
         IERC20[] calldata tokens,
         uint256[] calldata clearingPrices,

--- a/src/deploy/002_settlement.ts
+++ b/src/deploy/002_settlement.ts
@@ -39,7 +39,7 @@ const deploySettlement: DeployFunction = async function ({
 
   await deploy(settlement, {
     from: deployer,
-    gasLimit: 4e6,
+    gasLimit: 4.5e6,
     args: [authenticatorAddress, vaultAddress],
     deterministicDeployment: SALT,
     log: true,

--- a/src/ts/order.ts
+++ b/src/ts/order.ts
@@ -196,6 +196,10 @@ export type NormalizedOrder = Omit<Order, "validTo" | "appData" | "kind"> & {
  * @returns A 32-byte hash encoded as a hex-string.
  */
 export function normalizeOrder(order: Order): NormalizedOrder {
+  if (order.receiver === ethers.constants.AddressZero) {
+    throw new Error("receiver cannot be address(0)");
+  }
+
   return {
     receiver: ethers.constants.AddressZero,
     useInternalSellTokenBalance: false,

--- a/src/ts/settlement.ts
+++ b/src/ts/settlement.ts
@@ -207,6 +207,82 @@ function encodeSignatureData(sig: Signature): string {
 }
 
 /**
+ * Encodes a trade to be used with the settlement contract.
+ */
+export function encodeTrade(
+  tokens: TokenRegistry,
+  order: Order,
+  signature: Signature,
+  { executedAmount }: TradeExecution,
+): Trade {
+  const tradeFlags = {
+    ...order,
+    signingScheme: signature.scheme,
+  };
+  const o = normalizeOrder(order);
+
+  return {
+    sellTokenIndex: tokens.index(o.sellToken),
+    buyTokenIndex: tokens.index(o.buyToken),
+    receiver: o.receiver,
+    sellAmount: o.sellAmount,
+    buyAmount: o.buyAmount,
+    validTo: o.validTo,
+    appData: o.appData,
+    feeAmount: o.feeAmount,
+    flags: encodeTradeFlags(tradeFlags),
+    executedAmount,
+    signature: encodeSignatureData(signature),
+  };
+}
+
+/**
+ * A class used for tracking tokens when encoding settlements.
+ *
+ * This is used as settlement trades reference tokens by index instead of
+ * directly by address for multiple reasons:
+ * - Reduce encoding size of orders to save on `calldata` gas.
+ * - Direct access to a token's clearing price on settlement instead of
+ *   requiring a search.
+ */
+export class TokenRegistry {
+  private readonly _tokens: string[] = [];
+  private readonly _tokenMap: Record<string, number | undefined> = {};
+
+  /**
+   * Gets the array of token addresses currently stored in the registry.
+   */
+  public get addresses(): string[] {
+    // NOTE: Make sure to slice the original array, so it cannot be modified
+    // outside of this class.
+    return this._tokens.slice();
+  }
+
+  /**
+   * Retrieves the token index for the specified token address. If the token is
+   * not in the registry, it will be added.
+   *
+   * @param token The token address to add to the registry.
+   * @return The token index.
+   */
+  public index(token: string): number {
+    // NOTE: Verify and normalize the address into a case-checksummed address.
+    // Not only does this ensure validity of the addresses early on, it also
+    // makes it so `0xff...f` and `0xFF..F` map to the same ID.
+    const tokenAddress = ethers.utils.getAddress(token);
+
+    let tokenIndex = this._tokenMap[tokenAddress];
+    if (tokenIndex === undefined) {
+      tokenIndex = this._tokens.length;
+      this._tokens.push(tokenAddress);
+      this._tokenMap[tokenAddress] = tokenIndex;
+    }
+
+    return tokenIndex;
+  }
+}
+
+/**
  * A class for building calldata for a settlement.
  *
  * The encoder ensures that token addresses are kept track of and performs
@@ -214,15 +290,14 @@ function encodeSignatureData(sig: Signature): string {
  * properly encode order parameters for trades.
  */
 export class SettlementEncoder {
-  private readonly _tokens: string[] = [];
-  private readonly _tokenMap: Record<string, number | undefined> = {};
-  private _trades: Trade[] = [];
-  private _interactions: Record<InteractionStage, Interaction[]> = {
+  private readonly _tokens = new TokenRegistry();
+  private readonly _trades: Trade[] = [];
+  private readonly _interactions: Record<InteractionStage, Interaction[]> = {
     [InteractionStage.PRE]: [],
     [InteractionStage.INTRA]: [],
     [InteractionStage.POST]: [],
   };
-  private _orderRefunds: OrderRefunds = {
+  private readonly _orderRefunds: OrderRefunds = {
     filledAmounts: [],
     preSignatures: [],
   };
@@ -236,21 +311,15 @@ export class SettlementEncoder {
 
   /**
    * Gets the array of token addresses used by the currently encoded orders.
-   *
-   * This is used as encoded orders reference tokens by index instead of
-   * directly by address for multiple reasons:
-   * - Reduce encoding size of orders to save on `calldata` gas.
-   * - Direct access to a token's clearing price on settlement instead of
-   *   requiring a search.
    */
   public get tokens(): string[] {
     // NOTE: Make sure to slice the original array, so it cannot be modified
     // outside of this class.
-    return this._tokens.slice();
+    return this._tokens.addresses;
   }
 
   /**
-   * Gets the encoded trades as a hex-encoded string.
+   * Gets the encoded trades.
    */
   public get trades(): Trade[] {
     return this._trades.slice();
@@ -341,36 +410,17 @@ export class SettlementEncoder {
   public encodeTrade(
     order: Order,
     signature: Signature,
-    tradeExecution?: Partial<TradeExecution>,
+    { executedAmount }: Partial<TradeExecution> = {},
   ): void {
-    const { executedAmount } = tradeExecution || {};
     if (order.partiallyFillable && executedAmount === undefined) {
       throw new Error("missing executed amount for partially fillable trade");
     }
 
-    if (order.receiver === ethers.constants.AddressZero) {
-      throw new Error("receiver cannot be address(0)");
-    }
-
-    const tradeFlags = {
-      ...order,
-      signingScheme: signature.scheme,
-    };
-    const o = normalizeOrder(order);
-
-    this._trades.push({
-      sellTokenIndex: this.tokenIndex(o.sellToken),
-      buyTokenIndex: this.tokenIndex(o.buyToken),
-      receiver: o.receiver,
-      sellAmount: o.sellAmount,
-      buyAmount: o.buyAmount,
-      validTo: o.validTo,
-      appData: o.appData,
-      feeAmount: o.feeAmount,
-      flags: encodeTradeFlags(tradeFlags),
-      executedAmount: executedAmount || 0,
-      signature: encodeSignatureData(signature),
-    });
+    this._trades.push(
+      encodeTrade(this._tokens, order, signature, {
+        executedAmount: executedAmount ?? 0,
+      }),
+    );
   }
 
   /**
@@ -459,21 +509,5 @@ export class SettlementEncoder {
       encoder.encodeInteraction(interaction);
     }
     return encoder.encodedSettlement({});
-  }
-
-  private tokenIndex(token: string): number {
-    // NOTE: Verify and normalize the address into a case-checksummed address.
-    // Not only does this ensure validity of the addresses early on, it also
-    // makes it so `0xff...f` and `0xFF..F` map to the same ID.
-    const tokenAddress = ethers.utils.getAddress(token);
-
-    let tokenIndex = this._tokenMap[tokenAddress];
-    if (tokenIndex === undefined) {
-      tokenIndex = this._tokens.length;
-      this._tokens.push(tokenAddress);
-      this._tokenMap[tokenAddress] = tokenIndex;
-    }
-
-    return tokenIndex;
   }
 }

--- a/src/ts/swap.ts
+++ b/src/ts/swap.ts
@@ -1,8 +1,43 @@
-import { BigNumberish, BytesLike } from "ethers";
+import { BigNumberish, BytesLike, Signer } from "ethers";
+
+import { Order } from "./order";
+import { TokenRegistry, Trade, encodeTrade } from "./settlement";
+import { EcdsaSigningScheme, Signature, signOrder } from "./sign";
+import { TypedDataDomain } from "./types/ethers";
 
 /**
- * A Balancer swap request used for settling a single order against Balancer
- * pools.
+ * A Balancer swap used for settling a single order against Balancer pools.
+ */
+export interface Swap {
+  /**
+   * The ID of the pool for the swap.
+   */
+  poolId: BytesLike;
+  /**
+   * The swap input token address.
+   */
+  tokenIn: string;
+  /**
+   * The swap output token address.
+   */
+  tokenOut: string;
+  /**
+   * The amount to swap. This will ether be a fixed input amount when swapping
+   * a sell order, or a fixed output amount when swapping a buy order.
+   */
+  amount: BigNumberish;
+  /**
+   * Optional additional pool user data required for the swap.
+   *
+   * This additional user data is pool implementation specific, and allows pools
+   * to extend the Vault pool interface.
+   */
+  userData?: BytesLike;
+}
+
+/**
+ * An encoded Balancer swap request that can be used as input to the settlement
+ * contract.
  */
 export interface SwapRequest {
   /**
@@ -21,15 +56,140 @@ export interface SwapRequest {
    */
   tokenOutIndex: number;
   /**
-   * The amount to swap. This will ether be a fixed input amount when swapping
-   * a sell order, or a fixed output amount when swapping a buy order.
+   * The amount to swap.
    */
   amount: BigNumberish;
   /**
    * Additional pool user data required for the swap.
-   *
-   * This additional user data is pool implementation specific, and allows pools
-   * to extend the Vault pool interface.
    */
   userData: BytesLike;
+}
+
+/**
+ * Encoded swap parameters.
+ */
+export type EncodedSwap = [
+  /** Swap requests. */
+  SwapRequest[],
+  /** Tokens. */
+  string[],
+  /** Encoded trade. */
+  Trade,
+];
+
+/**
+ * Encodes a swap as a {@link SwapRequest} to be used with the settlement
+ * contract.
+ */
+export function encodeSwapRequest(
+  tokens: TokenRegistry,
+  swap: Swap,
+): SwapRequest {
+  return {
+    poolId: swap.poolId,
+    tokenInIndex: tokens.index(swap.tokenIn),
+    tokenOutIndex: tokens.index(swap.tokenOut),
+    amount: swap.amount,
+    userData: swap.userData || "0x",
+  };
+}
+
+/**
+ * A class for building calldata for a swap.
+ *
+ * The encoder ensures that token addresses are kept track of and performs
+ * necessary computation in order to map each token addresses to IDs to
+ * properly encode swap requests and the trade.
+ */
+export class SwapEncoder {
+  private readonly _tokens = new TokenRegistry();
+  private readonly _swaps: SwapRequest[] = [];
+  private _trade: Trade | undefined = undefined;
+
+  /**
+   * Creates a new settlement encoder instance.
+   *
+   * @param domain Domain used for signing orders. See {@link signOrder} for
+   * more details.
+   */
+  public constructor(public readonly domain: TypedDataDomain) {}
+
+  /**
+   * Gets the array of token addresses used by the currently encoded swaps.
+   */
+  public get tokens(): string[] {
+    // NOTE: Make sure to slice the original array, so it cannot be modified
+    // outside of this class.
+    return this._tokens.addresses;
+  }
+
+  /**
+   * Gets the encoded swaps.
+   */
+  public get swaps(): SwapRequest[] {
+    return this._swaps.slice();
+  }
+
+  /**
+   * Encodes the swap as a swap request and appends it to the swaps encoded so
+   * far.
+   *
+   * @param swap The Balancer swap to encode.
+   */
+  public encodeSwapRequest(swap: Swap): void {
+    this._swaps.push(encodeSwapRequest(this._tokens, swap));
+  }
+
+  /**
+   * Returns the encoded swap parameters for the given order and signature.
+   */
+  public encodedSwap(order: Order, signature: Signature): EncodedSwap;
+
+  /**
+   * Signs an order and returns the encoded swap parameters for trading the
+   * signed order.
+   */
+  public async encodedSwap(
+    order: Order,
+    owner: Signer,
+    scheme: EcdsaSigningScheme,
+  ): Promise<EncodedSwap>;
+
+  public encodedSwap(
+    ...args: [Order, Signature] | [Order, Signer, EcdsaSigningScheme]
+  ): EncodedSwap | Promise<EncodedSwap> {
+    if (args.length === 2) {
+      const [order, signature] = args;
+      const trade = encodeTrade(this._tokens, order, signature, {
+        executedAmount: 0,
+      });
+      return [this.swaps, this.tokens, trade];
+    } else {
+      const [order, owner, scheme] = args;
+      return signOrder(this.domain, order, owner, scheme).then((signature) =>
+        this.encodedSwap(order, signature),
+      );
+    }
+  }
+}
+
+/**
+ * Utility method for encoding a direct swap between an order and Balancer
+ * pools.
+ *
+ * This method functions identically to using a {@link SwapEncoder} and is
+ * provided as a short-cut.
+ */
+export function encodeSwap(
+  domain: TypedDataDomain,
+  swaps: Swap[],
+  order: Order,
+  owner: Signer,
+  scheme: EcdsaSigningScheme,
+): Promise<EncodedSwap> {
+  const encoder = new SwapEncoder(domain);
+  for (const swap of swaps) {
+    encoder.encodeSwapRequest(swap);
+  }
+  return encoder.encodedSwap(order, owner, scheme);
 }

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -1,3 +1,4 @@
+import IERC20 from "@openzeppelin/contracts/build/contracts/IERC20.json";
 import { expect } from "chai";
 import { MockContract } from "ethereum-waffle";
 import { BigNumber, Contract, ContractReceipt, Event } from "ethers";
@@ -11,6 +12,7 @@ import {
   PRE_SIGNED,
   SettlementEncoder,
   SigningScheme,
+  SwapEncoder,
   TradeExecution,
   TypedDataDomain,
   computeOrderUid,
@@ -23,6 +25,10 @@ import {
   builtAndDeployedMetadataCoincide,
   readVaultRelayerImmutables,
 } from "./bytecode";
+
+function fillBytes(count: number, byte: number): string {
+  return ethers.utils.hexlify([...Array(count)].map(() => byte));
+}
 
 function toNumberLossy(value: BigNumber): number {
   // NOTE: BigNumber throws an exception when if is outside the range of
@@ -137,32 +143,62 @@ describe("GPv2Settlement", () => {
       );
     });
 
-    it("rejects reentrancy attempts via interactions", async () => {
-      await authenticator.connect(owner).addSolver(solver.address);
-      const encoder = new SettlementEncoder(testDomain);
-      encoder.encodeInteraction({
-        target: settlement.address,
-        callData: settlement.interface.encodeFunctionData("settle", empty),
-      });
+    describe("Reentrancy Protection", () => {
+      for (const { name, params } of [
+        {
+          name: "settle",
+          params: empty,
+        },
+        {
+          name: "swap",
+          params: SwapEncoder.encodeSwap(
+            [],
+            {
+              sellToken: ethers.constants.AddressZero,
+              buyToken: ethers.constants.AddressZero,
+              sellAmount: ethers.constants.Zero,
+              buyAmount: ethers.constants.Zero,
+              validTo: 0,
+              appData: 0,
+              feeAmount: ethers.constants.Zero,
+              kind: OrderKind.SELL,
+              partiallyFillable: false,
+            },
+            {
+              scheme: SigningScheme.EIP712,
+              data: `0x${"00".repeat(65)}`,
+            },
+          ),
+        },
+      ]) {
+        it(`rejects ${name} reentrancy attempts via interactions`, async () => {
+          await authenticator.connect(owner).addSolver(solver.address);
+          const encoder = new SettlementEncoder(testDomain);
+          encoder.encodeInteraction({
+            target: settlement.address,
+            callData: settlement.interface.encodeFunctionData(name, params),
+          });
 
-      await expect(
-        settlement.connect(solver).settle(...encoder.encodedSettlement({})),
-      ).to.be.revertedWith("ReentrancyGuard: reentrant call");
-    });
+          await expect(
+            settlement.connect(solver).settle(...encoder.encodedSettlement({})),
+          ).to.be.revertedWith("ReentrancyGuard: reentrant call");
+        });
 
-    it("rejects reentrancy attempt even if settlement contract is registered solver", async () => {
-      await authenticator.connect(owner).addSolver(solver.address);
-      // Add settlement contract address as registered solver
-      await authenticator.connect(owner).addSolver(settlement.address);
-      const encoder = new SettlementEncoder(testDomain);
-      encoder.encodeInteraction({
-        target: settlement.address,
-        callData: settlement.interface.encodeFunctionData("settle", empty),
-      });
+        it(`rejects ${name} reentrancy attempt even as a registered solver`, async () => {
+          await authenticator.connect(owner).addSolver(solver.address);
+          // Add settlement contract address as registered solver
+          await authenticator.connect(owner).addSolver(settlement.address);
+          const encoder = new SettlementEncoder(testDomain);
+          encoder.encodeInteraction({
+            target: settlement.address,
+            callData: settlement.interface.encodeFunctionData(name, params),
+          });
 
-      await expect(
-        settlement.connect(solver).settle(...encoder.encodedSettlement({})),
-      ).to.be.revertedWith("ReentrancyGuard: reentrant call");
+          await expect(
+            settlement.connect(solver).settle(...encoder.encodedSettlement({})),
+          ).to.be.revertedWith("ReentrancyGuard: reentrant call");
+        });
+      }
     });
 
     it("accepts transactions from solvers", async () => {
@@ -236,6 +272,364 @@ describe("GPv2Settlement", () => {
           .connect(solver)
           .settle([tokens, clearingPrices, trades, ["0x", "0x", "0x", "0x"]]),
       ).to.be.reverted;
+    });
+  });
+
+  describe("swap", () => {
+    const emptySwap = () =>
+      SwapEncoder.encodeSwap(
+        testDomain,
+        [],
+        {
+          sellToken: ethers.constants.AddressZero,
+          buyToken: ethers.constants.AddressZero.replace(/0$/, "1"),
+          sellAmount: ethers.constants.Zero,
+          buyAmount: ethers.constants.Zero,
+          validTo: 0,
+          appData: 0,
+          feeAmount: ethers.constants.Zero,
+          kind: OrderKind.SELL,
+          partiallyFillable: false,
+        },
+        traders[0],
+        SigningScheme.EIP712,
+      );
+
+    it("rejects transactions from non-solvers", async () => {
+      await expect(settlement.swap(...(await emptySwap()))).to.be.revertedWith(
+        "GPv2: not a solver",
+      );
+    });
+
+    it("executes swap and fee transfer with correct amounts", async () => {
+      const order = {
+        kind: OrderKind.BUY,
+        receiver: traders[1].address,
+        sellToken: fillBytes(20, 1),
+        buyToken: fillBytes(20, 4),
+        sellAmount: ethers.utils.parseEther("4.2"),
+        buyAmount: ethers.utils.parseEther("13.37"),
+        validTo: 0x01020304,
+        appData: 0,
+        feeAmount: ethers.utils.parseEther("1.0"),
+        partiallyFillable: false,
+        useInternalSellTokenBalance: true,
+        useInternalBuyTokenBalance: false,
+      };
+
+      const encoder = new SwapEncoder(testDomain);
+      encoder.encodeSwapRequest({
+        poolId: fillBytes(32, 0xff),
+        tokenIn: fillBytes(20, 1),
+        tokenOut: fillBytes(20, 2),
+        amount: ethers.utils.parseEther("42.0"),
+      });
+      encoder.encodeSwapRequest({
+        poolId: fillBytes(32, 0xfe),
+        tokenIn: fillBytes(20, 2),
+        tokenOut: fillBytes(20, 3),
+        amount: ethers.utils.parseEther("1337.0"),
+        userData: "0x010203",
+      });
+      encoder.encodeSwapRequest({
+        poolId: fillBytes(32, 0xfd),
+        tokenIn: fillBytes(20, 3),
+        tokenOut: fillBytes(20, 4),
+        amount: ethers.utils.parseEther("6.0"),
+      });
+      await encoder.signEncodeTrade(order, traders[0], SigningScheme.EIP712);
+
+      await vault.mock.batchSwapGivenOut
+        .withArgs(
+          encoder.swaps.map(({ amount, ...swap }) => ({
+            ...swap,
+            amountOut: amount,
+          })),
+          encoder.tokens,
+          {
+            sender: traders[0].address,
+            fromInternalBalance: true,
+            recipient: traders[1].address,
+            toInternalBalance: false,
+          },
+          [order.sellAmount, 0, 0, order.buyAmount.mul(-1)],
+          order.validTo,
+        )
+        .returns([order.sellAmount.div(2), 0, 0, order.buyAmount.mul(-1)]);
+      await vault.mock.transferInternalBalance
+        .withArgs([
+          {
+            token: order.sellToken,
+            amount: order.feeAmount,
+            sender: traders[0].address,
+            recipient: settlement.address,
+          },
+        ])
+        .returns();
+
+      await authenticator.connect(owner).addSolver(solver.address);
+      await expect(settlement.connect(solver).swap(...encoder.encodedSwap())).to
+        .not.be.reverted;
+    });
+
+    describe("Balances", () => {
+      for (const { name, ...flags } of [
+        {
+          name: "external to external",
+          useInternalSellTokenBalance: false,
+          useInternalBuyTokenBalance: false,
+        },
+        {
+          name: "external to internal",
+          useInternalSellTokenBalance: false,
+          useInternalBuyTokenBalance: true,
+        },
+        {
+          name: "internal to external",
+          useInternalSellTokenBalance: true,
+          useInternalBuyTokenBalance: false,
+        },
+        {
+          name: "internal to internal",
+          useInternalSellTokenBalance: true,
+          useInternalBuyTokenBalance: true,
+        },
+      ]) {
+        it(`performs an ${name} swap when specified`, async () => {
+          const sellToken = await waffle.deployMockContract(
+            deployer,
+            IERC20.abi,
+          );
+          const buyToken = `0x${"cc".repeat(20)}`;
+          const feeAmount = ethers.utils.parseEther("1.0");
+
+          const encoder = new SwapEncoder(testDomain);
+          await encoder.signEncodeTrade(
+            {
+              sellToken: sellToken.address,
+              buyToken,
+              receiver: traders[1].address,
+              sellAmount: ethers.constants.Zero,
+              buyAmount: ethers.constants.Zero,
+              validTo: 0,
+              appData: 0,
+              feeAmount,
+              kind: OrderKind.SELL,
+              partiallyFillable: false,
+              ...flags,
+            },
+            traders[0],
+            SigningScheme.EIP712,
+          );
+
+          await vault.mock.batchSwapGivenIn
+            .withArgs(
+              [],
+              encoder.tokens,
+              {
+                sender: traders[0].address,
+                fromInternalBalance: flags.useInternalSellTokenBalance,
+                recipient: traders[1].address,
+                toInternalBalance: flags.useInternalBuyTokenBalance,
+              },
+              [0, 0],
+              0,
+            )
+            .returns([0, 0]);
+          if (flags.useInternalSellTokenBalance) {
+            await vault.mock.transferInternalBalance
+              .withArgs([
+                {
+                  token: sellToken.address,
+                  amount: feeAmount,
+                  sender: traders[0].address,
+                  recipient: settlement.address,
+                },
+              ])
+              .returns();
+          } else {
+            await sellToken.mock.transferFrom
+              .withArgs(traders[0].address, settlement.address, feeAmount)
+              .returns(true);
+          }
+
+          await authenticator.connect(owner).addSolver(solver.address);
+          await settlement.connect(solver).swap(...encoder.encodedSwap());
+          await expect(
+            settlement.connect(solver).swap(...encoder.encodedSwap()),
+          ).to.not.be.reverted;
+        });
+      }
+    });
+
+    describe("Swap Variants", () => {
+      const sellAmount = ethers.utils.parseEther("4.2");
+      const buyAmount = ethers.utils.parseEther("13.37");
+
+      for (const { kind, swapFunction } of [
+        {
+          kind: OrderKind.SELL,
+          swapFunction: "batchSwapGivenIn",
+        },
+        {
+          kind: OrderKind.BUY,
+          swapFunction: "batchSwapGivenOut",
+        },
+      ]) {
+        const order = {
+          kind,
+          sellToken: fillBytes(20, 1),
+          buyToken: fillBytes(20, 2),
+          sellAmount,
+          buyAmount,
+          validTo: 0x01020304,
+          appData: 0,
+          feeAmount: ethers.utils.parseEther("1.0"),
+          useInternalSellTokenBalance: true,
+          partiallyFillable: true,
+        };
+        const orderUid = () =>
+          computeOrderUid(testDomain, order, traders[0].address);
+        const encodeSwap = () =>
+          SwapEncoder.encodeSwap(
+            testDomain,
+            [],
+            order,
+            traders[0],
+            SigningScheme.ETHSIGN,
+          );
+
+        it(`executes ${kind} order against swap given in`, async () => {
+          await vault.mock[swapFunction].returns([
+            sellAmount,
+            buyAmount.mul(-1),
+          ]);
+          await vault.mock.transferInternalBalance.returns();
+
+          await authenticator.connect(owner).addSolver(solver.address);
+          await expect(settlement.connect(solver).swap(...(await encodeSwap())))
+            .to.not.be.reverted;
+        });
+
+        it(`updates the filled amount to be the full ${kind} amount`, async () => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const filledAmount = (order as any)[`${kind}Amount`];
+
+          await vault.mock[swapFunction].returns([
+            sellAmount,
+            buyAmount.mul(-1),
+          ]);
+          await vault.mock.transferInternalBalance.returns();
+
+          await authenticator.connect(owner).addSolver(solver.address);
+          await settlement.connect(solver).swap(...(await encodeSwap()));
+
+          expect(await settlement.filledAmount(orderUid())).to.equal(
+            filledAmount,
+          );
+        });
+
+        it(`reverts for cancelled ${kind} orders`, async () => {
+          await vault.mock[swapFunction].returns([0, 0]);
+          await vault.mock.transferInternalBalance.returns();
+
+          await settlement.connect(traders[0]).invalidateOrder(orderUid());
+          await authenticator.connect(owner).addSolver(solver.address);
+          await expect(
+            settlement.connect(solver).swap(...(await encodeSwap())),
+          ).to.be.revertedWith("order filled");
+        });
+
+        it(`reverts for partially filled ${kind} orders`, async () => {
+          await vault.mock[swapFunction].returns([0, 0]);
+          await vault.mock.transferInternalBalance.returns();
+
+          await settlement.setFilledAmount(orderUid(), 1);
+          await authenticator.connect(owner).addSolver(solver.address);
+          await expect(
+            settlement.connect(solver).swap(...(await encodeSwap())),
+          ).to.be.revertedWith("order filled");
+        });
+
+        it(`reverts when not exactly trading ${kind} amount`, async () => {
+          await vault.mock[swapFunction].returns([
+            sellAmount.sub(1),
+            buyAmount.add(1).mul(-1),
+          ]);
+          await vault.mock.transferInternalBalance.returns();
+
+          await authenticator.connect(owner).addSolver(solver.address);
+          await expect(
+            settlement.connect(solver).swap(...(await encodeSwap())),
+          ).to.be.revertedWith(`${kind} amount not respected`);
+        });
+
+        it(`emits a ${kind} trade event`, async () => {
+          const [executedSellAmount, executedBuyAmount] =
+            kind == OrderKind.SELL
+              ? [order.sellAmount, order.buyAmount.mul(2)]
+              : [order.sellAmount.div(2), order.buyAmount];
+          await vault.mock[swapFunction].returns([
+            executedSellAmount,
+            executedBuyAmount.mul(-1),
+          ]);
+          await vault.mock.transferInternalBalance.returns();
+
+          await authenticator.connect(owner).addSolver(solver.address);
+          await expect(settlement.connect(solver).swap(...(await encodeSwap())))
+            .to.emit(settlement, "Trade")
+            .withArgs(
+              traders[0].address,
+              order.sellToken,
+              order.buyToken,
+              executedSellAmount,
+              executedBuyAmount,
+              order.feeAmount,
+              orderUid(),
+            );
+        });
+      }
+    });
+
+    it("should emit a settlement event", async () => {
+      await vault.mock.batchSwapGivenIn.returns([0, 0]);
+      await vault.mock.transferInternalBalance.returns();
+
+      await authenticator.connect(owner).addSolver(solver.address);
+      await expect(settlement.connect(solver).swap(...(await emptySwap())))
+        .to.emit(settlement, "Settlement")
+        .withArgs(solver.address);
+    });
+
+    it("reverts on negative sell amounts", async () => {
+      await vault.mock.batchSwapGivenIn.returns([-1, 0]);
+      await vault.mock.transferInternalBalance.returns();
+
+      await authenticator.connect(owner).addSolver(solver.address);
+      await expect(
+        settlement.connect(solver).swap(...(await emptySwap())),
+      ).to.be.revertedWith("SafeCast: value must be positive");
+    });
+
+    it("reverts on positive buy amounts", async () => {
+      await vault.mock.batchSwapGivenIn.returns([0, 1]);
+      await vault.mock.transferInternalBalance.returns();
+
+      await authenticator.connect(owner).addSolver(solver.address);
+      await expect(
+        settlement.connect(solver).swap(...(await emptySwap())),
+      ).to.be.revertedWith("SafeCast: value must be positive");
+    });
+
+    it("reverts on unary negation overflow for buy amounts", async () => {
+      const INT256_MIN = `-0x80${"00".repeat(31)}`;
+      await vault.mock.batchSwapGivenIn.returns([0, INT256_MIN]);
+      await vault.mock.transferInternalBalance.returns();
+
+      await authenticator.connect(owner).addSolver(solver.address);
+      await expect(
+        settlement.connect(solver).swap(...(await emptySwap())),
+      ).to.be.revertedWith("SafeCast: value must be positive");
     });
   });
 


### PR DESCRIPTION
Closes #491 

This PR implements the logic for a Balancer fast path. It is quite straight forward and will delegate most of the work to the Vault's swap interface. Specifically it configures swap limits and fund management parameters to match the signed order, preventing malicious solvers from swapping in a way that does not respect the user's limit price, or swapping for tokens that the user does not want.

Additionally, the fee transfer is specified with the swap in order to reduce the number of calls to the Vault relayer for gas efficiency.

### Test Plan

more than 400 lines of unit tests and 100% coverage :sunglasses:. Unfortunately testing this code is quite hard because of just how many variations there are of sell/buy order x internal/external sell balance x internal/external buy balance.

This test does not include an integration test, which is needed to verify:
- Order's limit price is respected
- Order's validity is respected.