### PR TITLE
Add method for single transfer for swap fees

### DIFF
--- a/src/contracts/libraries/GPv2Transfer.sol
+++ b/src/contracts/libraries/GPv2Transfer.sol
@@ -24,7 +24,9 @@ library GPv2Transfer {
         0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
     /// @dev Execute the specified transfer from the specified account to a
-    /// recipient.
+    /// recipient. The recipient will either receive internal Vault balances or
+    /// ERC20 token balances depending on whether the account is using internal
+    /// balances or not.
     ///
     /// This method is used for transferring fees to the settlement contract
     /// when settling a single order directly with Balancer.
@@ -52,7 +54,7 @@ library GPv2Transfer {
             vaultTransfer.sender = transfer.account;
             vaultTransfer.recipient = recipient;
 
-            vault.withdrawFromInternalBalance(vaultTransfers);
+            vault.transferInternalBalance(vaultTransfers);
         } else {
             transfer.token.safeTransferFrom(
                 transfer.account,
@@ -63,7 +65,9 @@ library GPv2Transfer {
     }
 
     /// @dev Execute the specified transfers from the specified accounts to a
-    /// single recipient.
+    /// single recipient. The recipient will receive all transfers as ERC20
+    /// token balances, regardless of whether or not the accounts are using
+    /// internal Vault balances.
     ///
     /// This method is used for accumulating user balances into the settlement
     /// contract.

--- a/src/contracts/libraries/GPv2Transfer.sol
+++ b/src/contracts/libraries/GPv2Transfer.sol
@@ -23,6 +23,45 @@ library GPv2Transfer {
     address internal constant BUY_ETH_ADDRESS =
         0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
+    /// @dev Execute the specified transfer from the specified account to a
+    /// recipient.
+    ///
+    /// This method is used for transferring fees to the settlement contract
+    /// when settling a single order directly with Balancer.
+    ///
+    /// @param vault The Balancer vault to use.
+    /// @param recipient The recipient for the transfer.
+    /// @param transfer The transfer to perform.
+    function transferFromAccount(
+        IVault vault,
+        address recipient,
+        Data calldata transfer
+    ) internal {
+        require(
+            address(transfer.token) != BUY_ETH_ADDRESS,
+            "GPv2: cannot transfer native ETH"
+        );
+
+        if (transfer.useInternalBalance) {
+            IVault.BalanceTransfer[] memory vaultTransfers =
+                new IVault.BalanceTransfer[](1);
+
+            IVault.BalanceTransfer memory vaultTransfer = vaultTransfers[0];
+            vaultTransfer.token = transfer.token;
+            vaultTransfer.amount = transfer.amount;
+            vaultTransfer.sender = transfer.account;
+            vaultTransfer.recipient = recipient;
+
+            vault.withdrawFromInternalBalance(vaultTransfers);
+        } else {
+            transfer.token.safeTransferFrom(
+                transfer.account,
+                recipient,
+                transfer.amount
+            );
+        }
+    }
+
     /// @dev Execute the specified transfers from the specified accounts to a
     /// single recipient.
     ///

--- a/src/contracts/test/GPv2TransferTestInterface.sol
+++ b/src/contracts/test/GPv2TransferTestInterface.sol
@@ -5,6 +5,14 @@ pragma abicoder v2;
 import "../libraries/GPv2Transfer.sol";
 
 contract GPv2TransferTestInterface {
+    function transferFromAccountTest(
+        IVault vault,
+        address recipient,
+        GPv2Transfer.Data calldata transfer
+    ) external {
+        GPv2Transfer.transferFromAccount(vault, recipient, transfer);
+    }
+
     function transferFromAccountsTest(
         IVault vault,
         address recipient,

--- a/test/GPv2Transfer.test.ts
+++ b/test/GPv2Transfer.test.ts
@@ -47,7 +47,7 @@ describe("GPv2Transfer", () => {
     });
 
     it("should transfer internal amount to recipient", async () => {
-      await vault.mock.withdrawFromInternalBalance
+      await vault.mock.transferInternalBalance
         .withArgs([
           {
             token: token.address,
@@ -95,8 +95,8 @@ describe("GPv2Transfer", () => {
       ).to.be.revertedWith("test error");
     });
 
-    it("should revert on failed Vault withdrawal", async () => {
-      await vault.mock.withdrawFromInternalBalance
+    it("should revert on failed Vault transfer", async () => {
+      await vault.mock.transferInternalBalance
         .withArgs([
           {
             token: token.address,

--- a/test/GPv2Transfer.test.ts
+++ b/test/GPv2Transfer.test.ts
@@ -31,6 +31,93 @@ describe("GPv2Transfer", () => {
 
   const amount = ethers.utils.parseEther("0.1337");
 
+  describe("transferFromAccount", () => {
+    it("should transfer external amount to recipient", async () => {
+      await token.mock.transferFrom
+        .withArgs(traders[0].address, recipient.address, amount)
+        .returns(true);
+      await expect(
+        transfer.transferFromAccountTest(vault.address, recipient.address, {
+          account: traders[0].address,
+          token: token.address,
+          amount,
+          useInternalBalance: false,
+        }),
+      ).to.not.be.reverted;
+    });
+
+    it("should transfer internal amount to recipient", async () => {
+      await vault.mock.withdrawFromInternalBalance
+        .withArgs([
+          {
+            token: token.address,
+            amount,
+            sender: traders[0].address,
+            recipient: recipient.address,
+          },
+        ])
+        .returns();
+      await expect(
+        transfer.transferFromAccountTest(vault.address, recipient.address, {
+          account: traders[0].address,
+          token: token.address,
+          amount,
+          useInternalBalance: true,
+        }),
+      ).to.not.be.reverted;
+    });
+
+    it("reverts when mistakenly trying to transfer Ether", async () => {
+      for (const useInternalBalance of [false, true]) {
+        await expect(
+          transfer.transferFromAccountTest(vault.address, recipient.address, {
+            account: traders[0].address,
+            token: BUY_ETH_ADDRESS,
+            amount,
+            useInternalBalance,
+          }),
+        ).to.be.revertedWith("GPv2: cannot transfer native ETH");
+      }
+    });
+
+    it("should revert on failed ERC20 transfers", async () => {
+      await token.mock.transferFrom
+        .withArgs(traders[0].address, recipient.address, amount)
+        .revertsWithReason("test error");
+
+      await expect(
+        transfer.transferFromAccountTest(vault.address, recipient.address, {
+          account: traders[0].address,
+          token: token.address,
+          amount,
+          useInternalBalance: false,
+        }),
+      ).to.be.revertedWith("test error");
+    });
+
+    it("should revert on failed Vault withdrawal", async () => {
+      await vault.mock.withdrawFromInternalBalance
+        .withArgs([
+          {
+            token: token.address,
+            amount,
+            sender: traders[0].address,
+            recipient: recipient.address,
+          },
+        ])
+        .revertsWithReason("test error");
+
+      await expect(
+        transfer.transferFromAccountTest(vault.address, recipient.address, {
+          account: traders[0].address,
+          token: token.address,
+          amount,
+          useInternalBalance: true,
+        }),
+      ).to.be.revertedWith("test error");
+    });
+  });
+
   describe("transferFromAccounts", () => {
     it("should transfer external amount to recipient", async () => {
       await token.mock.transferFrom


### PR DESCRIPTION
This PR adds a new method for executing a single `GPv2Transfer.Data` transfer from an account. This will be used for transferring a fees from a user to the settlement contract when performing a swap directly against Balancer. This is a specialization of the existing `transferFromAccounts` method with slightly different semantics for internal balances.

### Test Plan

Added new unit tests to verify the library method implementation.
