### PR TITLE
Add vault relayer method for direct Balancer swaps

### DIFF
--- a/src/contracts/GPv2VaultRelayer.sol
+++ b/src/contracts/GPv2VaultRelayer.sol
@@ -44,4 +44,91 @@ contract GPv2VaultRelayer {
     {
         vault.transferFromAccounts(msg.sender, transfers);
     }
+
+    /// @dev Performs a Balancer batched swap on behalf of a user and sends a
+    /// fee to the caller.
+    ///
+    /// This function reverts if:
+    /// - The caller is not the creator of the vault relayer
+    /// - The swap fails
+    /// - The fee transfer fails
+    ///
+    /// @param kind The Balancer swap kind, this can either be `GIVEN_IN` for
+    /// sell orders or `GIVEN_OUT` for buy orders.
+    /// @param swaps The swaps to perform.
+    /// @param tokens The tokens for the swaps. Swaps encode to and from tokens
+    /// as indices into this array.
+    /// @param funds The fund management settings, specifying the user the swap
+    /// is being performed for as well as the recipient of the proceeds.
+    /// @param limits Swap limits for encoding limit prices.
+    /// @param deadline The deadline for the swap.
+    /// @param feeTransfer The transfer data for the caller fee.
+    /// @return tokenDeltas The executed swap amounts.
+    function batchSwapWithFee(
+        IVault.SwapKind kind,
+        IVault.SwapRequest[] calldata swaps,
+        IERC20[] memory tokens,
+        IVault.FundManagement memory funds,
+        int256[] memory limits,
+        uint256 deadline,
+        GPv2Transfer.Data calldata feeTransfer
+    ) external onlyCreator returns (int256[] memory tokenDeltas) {
+        if (kind == IVault.SwapKind.GIVEN_IN) {
+            tokenDeltas = vault.batchSwapGivenIn(
+                swapRequestToIn(swaps),
+                tokens,
+                funds,
+                limits,
+                deadline
+            );
+        } else {
+            tokenDeltas = vault.batchSwapGivenOut(
+                swapRequestToOut(swaps),
+                tokens,
+                funds,
+                limits,
+                deadline
+            );
+        }
+
+        vault.transferFromAccount(msg.sender, feeTransfer);
+    }
+
+    /// @dev Converts an array of Vault `SwapRequest`s into `SwapIn`s.
+    ///
+    /// This method leverages the fact that both structs have identical memory
+    /// representations. For more information, consult conversion methods from:
+    /// <https://github.com/balancer-labs/balancer-core-v2/blob/master/contracts/vault/Swaps.sol>
+    ///
+    /// @param swaps The swap requests.
+    /// @return swapIns The swap ins.
+    function swapRequestToIn(IVault.SwapRequest[] calldata swaps)
+        private
+        pure
+        returns (IVault.SwapIn[] calldata swapIns)
+    {
+        // NOTE: Use assembly to cast the swap requests.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            swapIns.offset := swaps.offset
+            swapIns.length := swaps.length
+        }
+    }
+
+    /// @dev Converts an array of Vault `SwapRequest`s into `SwapOut`s.
+    ///
+    /// @param swaps The swap requests.
+    /// @return swapOuts The swap outs.
+    function swapRequestToOut(IVault.SwapRequest[] calldata swaps)
+        private
+        pure
+        returns (IVault.SwapOut[] calldata swapOuts)
+    {
+        // NOTE: Use assembly to cast the swap requests.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            swapOuts.offset := swaps.offset
+            swapOuts.length := swaps.length
+        }
+    }
 }

--- a/src/contracts/GPv2VaultRelayer.sol
+++ b/src/contracts/GPv2VaultRelayer.sol
@@ -42,7 +42,7 @@ contract GPv2VaultRelayer {
         external
         onlyCreator
     {
-        vault.transferFromAccounts(msg.sender, transfers);
+        vault.transferFromAccounts(transfers, msg.sender);
     }
 
     /// @dev Performs a Balancer batched swap on behalf of a user and sends a
@@ -91,7 +91,7 @@ contract GPv2VaultRelayer {
             );
         }
 
-        vault.transferFromAccount(msg.sender, feeTransfer);
+        vault.transferFromAccount(feeTransfer, msg.sender);
     }
 
     /// @dev Converts an array of Vault `SwapRequest`s into `SwapIn`s.

--- a/src/contracts/interfaces/IVault.sol
+++ b/src/contracts/interfaces/IVault.sol
@@ -12,13 +12,6 @@ interface IVault {
         address recipient;
     }
 
-    struct FundManagement {
-        address sender;
-        bool fromInternalBalance;
-        address recipient;
-        bool toInternalBalance;
-    }
-
     struct SwapIn {
         bytes32 poolId;
         uint256 tokenInIndex;
@@ -32,6 +25,23 @@ interface IVault {
         uint256 tokenInIndex;
         uint256 tokenOutIndex;
         uint256 amountOut;
+        bytes userData;
+    }
+
+    struct FundManagement {
+        address sender;
+        bool fromInternalBalance;
+        address recipient;
+        bool toInternalBalance;
+    }
+
+    enum SwapKind {GIVEN_IN, GIVEN_OUT}
+
+    struct SwapRequest {
+        bytes32 poolId;
+        uint256 tokenInIndex;
+        uint256 tokenOutIndex;
+        uint256 amount;
         bytes userData;
     }
 

--- a/src/contracts/libraries/GPv2Transfer.sol
+++ b/src/contracts/libraries/GPv2Transfer.sol
@@ -32,12 +32,12 @@ library GPv2Transfer {
     /// when settling a single order directly with Balancer.
     ///
     /// @param vault The Balancer vault to use.
+    /// @param transfer The transfer to perform specifying the sender account.
     /// @param recipient The recipient for the transfer.
-    /// @param transfer The transfer to perform.
     function transferFromAccount(
         IVault vault,
-        address recipient,
-        Data calldata transfer
+        Data calldata transfer,
+        address recipient
     ) internal {
         require(
             address(transfer.token) != BUY_ETH_ADDRESS,
@@ -73,12 +73,13 @@ library GPv2Transfer {
     /// contract.
     ///
     /// @param vault The Balancer vault to use.
+    /// @param transfers The batched transfers to perform specifying the
+    /// sender accounts.
     /// @param recipient The single recipient for all the transfers.
-    /// @param transfers The batched transfers to perform.
     function transferFromAccounts(
         IVault vault,
-        address recipient,
-        Data[] calldata transfers
+        Data[] calldata transfers,
+        address recipient
     ) internal {
         // NOTE: Pre-allocate an array of vault balance tranfers large enough to
         // hold all transfers. This allows us to efficiently batch internal

--- a/src/contracts/test/GPv2TransferTestInterface.sol
+++ b/src/contracts/test/GPv2TransferTestInterface.sol
@@ -7,18 +7,18 @@ import "../libraries/GPv2Transfer.sol";
 contract GPv2TransferTestInterface {
     function transferFromAccountTest(
         IVault vault,
-        address recipient,
-        GPv2Transfer.Data calldata transfer
+        GPv2Transfer.Data calldata transfer,
+        address recipient
     ) external {
-        GPv2Transfer.transferFromAccount(vault, recipient, transfer);
+        GPv2Transfer.transferFromAccount(vault, transfer, recipient);
     }
 
     function transferFromAccountsTest(
         IVault vault,
-        address recipient,
-        GPv2Transfer.Data[] calldata transfers
+        GPv2Transfer.Data[] calldata transfers,
+        address recipient
     ) external {
-        GPv2Transfer.transferFromAccounts(vault, recipient, transfers);
+        GPv2Transfer.transferFromAccounts(vault, transfers, recipient);
     }
 
     function transferToAccountsTest(

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -19,11 +19,12 @@ export function domain(
   };
 }
 
-export * from "./order";
-export * from "./interaction";
-export * from "./settlement";
-export * from "./reader";
 export * from "./deploy";
-export * from "./sign";
+export * from "./interaction";
+export * from "./order";
 export * from "./proxy";
+export * from "./reader";
+export * from "./settlement";
+export * from "./sign";
+export * from "./swap";
 export * from "./types/ethers";

--- a/src/ts/swap.ts
+++ b/src/ts/swap.ts
@@ -1,0 +1,35 @@
+import { BigNumberish, BytesLike } from "ethers";
+
+/**
+ * A Balancer swap request used for settling a single order against Balancer
+ * pools.
+ */
+export interface SwapRequest {
+  /**
+   * The ID of the pool for the swap.
+   */
+  poolId: BytesLike;
+  /**
+   * The index of the input token.
+   *
+   * Settlement swap calls encode tokens as an array, this number represents an
+   * index into that array.
+   */
+  tokenInIndex: number;
+  /**
+   * The index of the output token.
+   */
+  tokenOutIndex: number;
+  /**
+   * The amount to swap. This will ether be a fixed input amount when swapping
+   * a sell order, or a fixed output amount when swapping a buy order.
+   */
+  amount: BigNumberish;
+  /**
+   * Additional pool user data required for the swap.
+   *
+   * This additional user data is pool implementation specific, and allows pools
+   * to extend the Vault pool interface.
+   */
+  userData: BytesLike;
+}

--- a/test/GPv2Transfer.test.ts
+++ b/test/GPv2Transfer.test.ts
@@ -37,12 +37,16 @@ describe("GPv2Transfer", () => {
         .withArgs(traders[0].address, recipient.address, amount)
         .returns(true);
       await expect(
-        transfer.transferFromAccountTest(vault.address, recipient.address, {
-          account: traders[0].address,
-          token: token.address,
-          amount,
-          useInternalBalance: false,
-        }),
+        transfer.transferFromAccountTest(
+          vault.address,
+          {
+            account: traders[0].address,
+            token: token.address,
+            amount,
+            useInternalBalance: false,
+          },
+          recipient.address,
+        ),
       ).to.not.be.reverted;
     });
 
@@ -58,24 +62,32 @@ describe("GPv2Transfer", () => {
         ])
         .returns();
       await expect(
-        transfer.transferFromAccountTest(vault.address, recipient.address, {
-          account: traders[0].address,
-          token: token.address,
-          amount,
-          useInternalBalance: true,
-        }),
+        transfer.transferFromAccountTest(
+          vault.address,
+          {
+            account: traders[0].address,
+            token: token.address,
+            amount,
+            useInternalBalance: true,
+          },
+          recipient.address,
+        ),
       ).to.not.be.reverted;
     });
 
     it("reverts when mistakenly trying to transfer Ether", async () => {
       for (const useInternalBalance of [false, true]) {
         await expect(
-          transfer.transferFromAccountTest(vault.address, recipient.address, {
-            account: traders[0].address,
-            token: BUY_ETH_ADDRESS,
-            amount,
-            useInternalBalance,
-          }),
+          transfer.transferFromAccountTest(
+            vault.address,
+            {
+              account: traders[0].address,
+              token: BUY_ETH_ADDRESS,
+              amount,
+              useInternalBalance,
+            },
+            recipient.address,
+          ),
         ).to.be.revertedWith("GPv2: cannot transfer native ETH");
       }
     });
@@ -86,12 +98,16 @@ describe("GPv2Transfer", () => {
         .revertsWithReason("test error");
 
       await expect(
-        transfer.transferFromAccountTest(vault.address, recipient.address, {
-          account: traders[0].address,
-          token: token.address,
-          amount,
-          useInternalBalance: false,
-        }),
+        transfer.transferFromAccountTest(
+          vault.address,
+          {
+            account: traders[0].address,
+            token: token.address,
+            amount,
+            useInternalBalance: false,
+          },
+          recipient.address,
+        ),
       ).to.be.revertedWith("test error");
     });
 
@@ -108,12 +124,16 @@ describe("GPv2Transfer", () => {
         .revertsWithReason("test error");
 
       await expect(
-        transfer.transferFromAccountTest(vault.address, recipient.address, {
-          account: traders[0].address,
-          token: token.address,
-          amount,
-          useInternalBalance: true,
-        }),
+        transfer.transferFromAccountTest(
+          vault.address,
+          {
+            account: traders[0].address,
+            token: token.address,
+            amount,
+            useInternalBalance: true,
+          },
+          recipient.address,
+        ),
       ).to.be.revertedWith("test error");
     });
   });
@@ -124,14 +144,18 @@ describe("GPv2Transfer", () => {
         .withArgs(traders[0].address, recipient.address, amount)
         .returns(true);
       await expect(
-        transfer.transferFromAccountsTest(vault.address, recipient.address, [
-          {
-            account: traders[0].address,
-            token: token.address,
-            amount,
-            useInternalBalance: false,
-          },
-        ]),
+        transfer.transferFromAccountsTest(
+          vault.address,
+          [
+            {
+              account: traders[0].address,
+              token: token.address,
+              amount,
+              useInternalBalance: false,
+            },
+          ],
+          recipient.address,
+        ),
       ).to.not.be.reverted;
     });
 
@@ -147,14 +171,18 @@ describe("GPv2Transfer", () => {
         ])
         .returns();
       await expect(
-        transfer.transferFromAccountsTest(vault.address, recipient.address, [
-          {
-            account: traders[0].address,
-            token: token.address,
-            amount,
-            useInternalBalance: true,
-          },
-        ]),
+        transfer.transferFromAccountsTest(
+          vault.address,
+          [
+            {
+              account: traders[0].address,
+              token: token.address,
+              amount,
+              useInternalBalance: true,
+            },
+          ],
+          recipient.address,
+        ),
       ).to.not.be.reverted;
     });
 
@@ -195,8 +223,8 @@ describe("GPv2Transfer", () => {
       await expect(
         transfer.transferFromAccountsTest(
           vault.address,
-          recipient.address,
           transfers,
+          recipient.address,
         ),
       ).to.not.be.reverted;
     });
@@ -204,14 +232,18 @@ describe("GPv2Transfer", () => {
     it("reverts when mistakenly trying to transfer Ether", async () => {
       for (const useInternalBalance of [false, true]) {
         await expect(
-          transfer.transferFromAccountsTest(vault.address, recipient.address, [
-            {
-              account: traders[0].address,
-              token: BUY_ETH_ADDRESS,
-              amount,
-              useInternalBalance,
-            },
-          ]),
+          transfer.transferFromAccountsTest(
+            vault.address,
+            [
+              {
+                account: traders[0].address,
+                token: BUY_ETH_ADDRESS,
+                amount,
+                useInternalBalance,
+              },
+            ],
+            recipient.address,
+          ),
         ).to.be.revertedWith("GPv2: cannot transfer native ETH");
       }
     });
@@ -222,14 +254,18 @@ describe("GPv2Transfer", () => {
         .revertsWithReason("test error");
 
       await expect(
-        transfer.transferFromAccountsTest(vault.address, recipient.address, [
-          {
-            account: traders[0].address,
-            token: token.address,
-            amount,
-            useInternalBalance: false,
-          },
-        ]),
+        transfer.transferFromAccountsTest(
+          vault.address,
+          [
+            {
+              account: traders[0].address,
+              token: token.address,
+              amount,
+              useInternalBalance: false,
+            },
+          ],
+          recipient.address,
+        ),
       ).to.be.revertedWith("test error");
     });
 
@@ -246,14 +282,18 @@ describe("GPv2Transfer", () => {
         .revertsWithReason("test error");
 
       await expect(
-        transfer.transferFromAccountsTest(vault.address, recipient.address, [
-          {
-            account: traders[0].address,
-            token: token.address,
-            amount,
-            useInternalBalance: true,
-          },
-        ]),
+        transfer.transferFromAccountsTest(
+          vault.address,
+          [
+            {
+              account: traders[0].address,
+              token: token.address,
+              amount,
+              useInternalBalance: true,
+            },
+          ],
+          recipient.address,
+        ),
       ).to.be.revertedWith("test error");
     });
   });

--- a/test/GPv2VaultRelayer.test.ts
+++ b/test/GPv2VaultRelayer.test.ts
@@ -1,8 +1,13 @@
 import IERC20 from "@openzeppelin/contracts/build/contracts/IERC20.json";
 import { expect } from "chai";
 import { MockContract } from "ethereum-waffle";
-import { Contract } from "ethers";
+import { BigNumberish, Contract } from "ethers";
 import { artifacts, ethers, waffle } from "hardhat";
+
+import { SwapRequest } from "../src/ts";
+
+const GIVEN_IN = 0;
+const GIVEN_OUT = 1;
 
 describe("GPv2VaultRelayer", () => {
   const [
@@ -117,6 +122,278 @@ describe("GPv2VaultRelayer", () => {
           },
         ]),
       ).to.be.revertedWith("test error");
+    });
+  });
+
+  describe("batchSwapWithFee", () => {
+    interface BatchSwapWithFee {
+      kind: typeof GIVEN_IN | typeof GIVEN_OUT;
+      swaps: SwapRequest[];
+      tokens: string[];
+      funds: {
+        sender: string;
+        fromInternalBalance: boolean;
+        recipient: string;
+        toInternalBalance: boolean;
+      };
+      limits: BigNumberish[];
+      deadline: number;
+      feeTransfer: {
+        account: string;
+        token: string;
+        amount: BigNumberish;
+        useInternalBalance: boolean;
+      };
+    }
+
+    const encodeSwapParams = (p: Partial<BatchSwapWithFee>) => {
+      return [
+        p.kind ?? GIVEN_IN,
+        p.swaps ?? [],
+        p.tokens ?? [],
+        p.funds ?? {
+          sender: ethers.constants.AddressZero,
+          fromInternalBalance: true,
+          recipient: ethers.constants.AddressZero,
+          toInternalBalance: true,
+        },
+        p.limits ?? [],
+        p.deadline ?? 0,
+        p.feeTransfer ?? {
+          account: ethers.constants.AddressZero,
+          token: ethers.constants.AddressZero,
+          amount: ethers.constants.Zero,
+          useInternalBalance: false,
+        },
+      ];
+    };
+    const emptySwap = encodeSwapParams({});
+
+    it("should revert if not called by the creator", async () => {
+      await expect(
+        vaultRelayer.connect(nonCreator).batchSwapWithFee(...emptySwap),
+      ).to.be.revertedWith("not creator");
+    });
+
+    for (const [name, kind] of Object.entries({
+      In: GIVEN_IN,
+      Out: GIVEN_OUT,
+    } as const)) {
+      describe(`Swap Given ${name}`, () => {
+        it(`performs swaps given ${name.toLowerCase()}`, async () => {
+          const swaps = [
+            {
+              poolId: `0x${"01".repeat(32)}`,
+              tokenInIndex: 0,
+              tokenOutIndex: 1,
+              amount: ethers.utils.parseEther("42.0"),
+              userData: "0x010203",
+            },
+            {
+              poolId: `0x${"02".repeat(32)}`,
+              tokenInIndex: 1,
+              tokenOutIndex: 2,
+              amount: ethers.utils.parseEther("1337.0"),
+              userData: "0xabcd",
+            },
+          ];
+          const tokens = [
+            await waffle.deployMockContract(deployer, IERC20.abi),
+            await waffle.deployMockContract(deployer, IERC20.abi),
+            await waffle.deployMockContract(deployer, IERC20.abi),
+          ];
+          const funds = {
+            sender: traders[0].address,
+            fromInternalBalance: false,
+            recipient: traders[1].address,
+            toInternalBalance: true,
+          };
+          const limits = [
+            ethers.utils.parseEther("42.0"),
+            ethers.constants.Zero,
+            ethers.utils.parseEther("1337.0").mul(-1),
+          ];
+          const deadline = 0x01020304;
+          const feeTransfer = {
+            account: traders[0].address,
+            token: tokens[0].address,
+            amount: ethers.utils.parseEther("1.0"),
+            useInternalBalance: false,
+          };
+
+          await vault.mock[`batchSwapGiven${name}`]
+            .withArgs(
+              swaps.map(({ amount, ...swap }) => ({
+                ...swap,
+                [`amount${name}`]: amount,
+              })),
+              tokens.map(({ address }) => address),
+              funds,
+              limits,
+              deadline,
+            )
+            .returns([]);
+          await tokens[0].mock.transferFrom.returns(true);
+
+          await expect(
+            vaultRelayer.batchSwapWithFee(
+              kind,
+              swaps,
+              tokens.map(({ address }) => address),
+              funds,
+              limits,
+              deadline,
+              feeTransfer,
+            ),
+          ).to.not.be.reverted;
+        });
+
+        it("returns the Vault swap token deltas", async () => {
+          const deltas = [
+            ethers.utils.parseEther("42.0"),
+            ethers.constants.Zero,
+            ethers.utils.parseEther("1337.0").mul(-1),
+          ];
+
+          const token = await waffle.deployMockContract(deployer, IERC20.abi);
+          const feeTransfer = {
+            account: traders[0].address,
+            token: token.address,
+            amount: ethers.utils.parseEther("1.0"),
+            useInternalBalance: false,
+          };
+
+          await vault.mock[`batchSwapGiven${name}`].returns(deltas);
+          await token.mock.transferFrom.returns(true);
+
+          expect(
+            await vaultRelayer.callStatic.batchSwapWithFee(
+              ...encodeSwapParams({
+                kind,
+                feeTransfer,
+              }),
+            ),
+          ).to.deep.equal(deltas);
+        });
+
+        it("reverts on failed Vault swap", async () => {
+          await vault.mock[`batchSwapGiven${name}`].revertsWithReason(
+            "test error",
+          );
+
+          await expect(
+            vaultRelayer.batchSwapWithFee(...encodeSwapParams({ kind })),
+          ).to.be.revertedWith("test error");
+        });
+      });
+    }
+
+    describe("Fee Transfer", () => {
+      it("should perform ERC20 transfer when not using internal balance", async () => {
+        const token = await waffle.deployMockContract(deployer, IERC20.abi);
+        const amount = ethers.utils.parseEther("4.2");
+
+        await vault.mock.batchSwapGivenIn.returns([]);
+        await token.mock.transferFrom
+          .withArgs(traders[0].address, creator.address, amount)
+          .returns(true);
+
+        await expect(
+          vaultRelayer.batchSwapWithFee(
+            ...encodeSwapParams({
+              feeTransfer: {
+                account: traders[0].address,
+                token: token.address,
+                amount,
+                useInternalBalance: false,
+              },
+            }),
+          ),
+        ).to.not.be.reverted;
+      });
+
+      it("should perform Vault internal balance transfer when specified", async () => {
+        const token = await waffle.deployMockContract(deployer, IERC20.abi);
+        const amount = ethers.utils.parseEther("4.2");
+
+        await vault.mock.batchSwapGivenIn.returns([]);
+        await vault.mock.transferInternalBalance
+          .withArgs([
+            {
+              token: token.address,
+              amount,
+              sender: traders[0].address,
+              recipient: creator.address,
+            },
+          ])
+          .returns();
+
+        await expect(
+          vaultRelayer.batchSwapWithFee(
+            ...encodeSwapParams({
+              feeTransfer: {
+                account: traders[0].address,
+                token: token.address,
+                amount,
+                useInternalBalance: true,
+              },
+            }),
+          ),
+        ).to.not.be.reverted;
+      });
+
+      it("should revert on failed ERC20 transfer", async () => {
+        const token = await waffle.deployMockContract(deployer, IERC20.abi);
+        const amount = ethers.utils.parseEther("4.2");
+
+        await vault.mock.batchSwapGivenIn.returns([]);
+        await token.mock.transferFrom
+          .withArgs(traders[0].address, creator.address, amount)
+          .revertsWithReason("test error");
+
+        await expect(
+          vaultRelayer.batchSwapWithFee(
+            ...encodeSwapParams({
+              feeTransfer: {
+                account: traders[0].address,
+                token: token.address,
+                amount,
+                useInternalBalance: false,
+              },
+            }),
+          ),
+        ).to.be.revertedWith("test error");
+      });
+
+      it("should revert on failed Vault transfer", async () => {
+        const token = await waffle.deployMockContract(deployer, IERC20.abi);
+        const amount = ethers.utils.parseEther("4.2");
+
+        await vault.mock.batchSwapGivenIn.returns([]);
+        await vault.mock.transferInternalBalance
+          .withArgs([
+            {
+              token: token.address,
+              amount,
+              sender: traders[0].address,
+              recipient: creator.address,
+            },
+          ])
+          .revertsWithReason("test error");
+
+        await expect(
+          vaultRelayer.batchSwapWithFee(
+            ...encodeSwapParams({
+              feeTransfer: {
+                account: traders[0].address,
+                token: token.address,
+                amount,
+                useInternalBalance: true,
+              },
+            }),
+          ),
+        ).to.be.revertedWith("test error");
+      });
     });
   });
 });


### PR DESCRIPTION
This PR adds a new vault relayer method to enable the settlement contract to perform Balancer swaps on behalf of users. This will be used in the Balancer V2 "fast-path" when settling an order directly with Balancer pools.

### Test Plan

Added many unit tests, coverage should stay at 100% :smile: 
