### PR TITLE
Remove hardhat/console.sol dependency in test contract

### DIFF
--- a/src/contracts/test/NonStandardERC20.sol
+++ b/src/contracts/test/NonStandardERC20.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.7.6;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
-import "hardhat/console.sol";
 
 abstract contract NonStandardERC20 {
     using SafeMath for uint256;


### PR DESCRIPTION
It looks like a dependency on `hardhat/console.sol` accidentally slipped into the code but shouldn't be there. This PR removes it.
