### PR TITLE
Revert OpenZepplin version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@gnosis.pm/util-contracts": "=3.1.0-solc-7",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
-    "@openzeppelin/contracts": "=3.4.1-solc-0.7-2",
+    "@openzeppelin/contracts": "=3.4.0-solc-0.7",
     "@tenderly/hardhat-tenderly": "^1.0.11",
     "@types/chai": "^4.2.15",
     "@types/debug": "^4.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -581,10 +581,10 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@=3.4.1-solc-0.7-2":
-  version "3.4.1-solc-0.7-2"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1-solc-0.7-2.tgz#371c67ebffe50f551c3146a9eec5fe6ffe862e92"
-  integrity sha512-tAG9LWg8+M2CMu7hIsqHPaTyG4uDzjr6mhvH96LvOpLZZj6tgzTluBt+LsCf1/QaYrlis6pITvpIaIhE+iZB+Q==
+"@openzeppelin/contracts@=3.4.0-solc-0.7":
+  version "3.4.0-solc-0.7"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.0-solc-0.7.tgz#c4fbd1b761714745c4bce6fc97e8b44d4c29d5b9"
+  integrity sha512-bJz1YgmeKRYVnYZedYSiy5/YmaYTxOhb76ftCseN1z2r4DK7PwCGvRCF2fRavTxAmGkIC/Q5zSy/Dr3OerPw0w==
 
 "@redux-saga/core@^1.0.0":
   version "1.1.3"


### PR DESCRIPTION
This PR partially reverts #525 

This PR reverts the OZ contracts version from `v3.4.1-solc-0.7-2` back to `v3.4.0-solc-0.7` for a couple of reasons:
- It looks like `v3.4.1-solc-0.7-2` is "unofficial" as there is no corresponding commit or tag in the repo as of the creation of this PR
- `v3.4.0-solc-0.7` already contained the required fixes to the `SafeMath` contract that we needed (hence those changes are not reverted).

### Test Plan

CI still passes.
