### PR TITLE
New configurations for balances

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -154,15 +154,17 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
         recoverOrderFromTrade(recoveredOrder, tokens, trade);
 
         IVault.SwapKind kind =
-            order.kind == GPv2Order.SELL
+            order.kind == GPv2Order.KIND_SELL
                 ? IVault.SwapKind.GIVEN_IN
                 : IVault.SwapKind.GIVEN_OUT;
 
         IVault.FundManagement memory funds;
         funds.sender = recoveredOrder.owner;
-        funds.fromInternalBalance = order.useInternalSellTokenBalance;
+        funds.fromInternalBalance =
+            order.sellTokenBalance == GPv2Order.BALANCE_INTERNAL;
         funds.recipient = recoveredOrder.receiver;
-        funds.toInternalBalance = order.useInternalBuyTokenBalance;
+        funds.toInternalBalance =
+            order.buyTokenBalance == GPv2Order.BALANCE_INTERNAL;
 
         int256[] memory limits = new int256[](tokens.length);
         // NOTE: Array allocation initializes elements to 0, so we only need to
@@ -175,7 +177,7 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
         feeTransfer.account = recoveredOrder.owner;
         feeTransfer.token = order.sellToken;
         feeTransfer.amount = order.feeAmount;
-        feeTransfer.useInternalBalance = order.useInternalSellTokenBalance;
+        feeTransfer.balance = order.sellTokenBalance;
 
         int256[] memory tokenDeltas =
             vaultRelayer.batchSwapWithFee(
@@ -201,7 +203,7 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
         // validity have already been verified when executing the swap through
         // the `limit` and `deadline` parameters.
         require(filledAmount[orderUid] == 0, "GPv2: order filled");
-        if (order.kind == GPv2Order.SELL) {
+        if (order.kind == GPv2Order.KIND_SELL) {
             require(
                 executedSellAmount == order.sellAmount,
                 "GPv2: sell amount not respected"
@@ -363,7 +365,7 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
         uint256 executedFeeAmount;
         uint256 currentFilledAmount;
 
-        if (order.kind == GPv2Order.SELL) {
+        if (order.kind == GPv2Order.KIND_SELL) {
             if (order.partiallyFillable) {
                 executedSellAmount = executedAmount;
                 executedFeeAmount = order.feeAmount.mul(executedSellAmount).div(
@@ -419,12 +421,12 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
         inTransfer.account = recoveredOrder.owner;
         inTransfer.token = order.sellToken;
         inTransfer.amount = executedSellAmount;
-        inTransfer.useInternalBalance = order.useInternalSellTokenBalance;
+        inTransfer.balance = order.sellTokenBalance;
 
         outTransfer.account = recoveredOrder.receiver;
         outTransfer.token = order.buyToken;
         outTransfer.amount = executedBuyAmount;
-        outTransfer.useInternalBalance = order.useInternalBuyTokenBalance;
+        outTransfer.balance = order.buyTokenBalance;
     }
 
     /// @dev Execute a list of arbitrary contract calls from this contract.

--- a/src/contracts/libraries/GPv2Order.sol
+++ b/src/contracts/libraries/GPv2Order.sol
@@ -19,8 +19,8 @@ library GPv2Order {
         uint256 feeAmount;
         bytes32 kind;
         bool partiallyFillable;
-        bool useInternalSellTokenBalance;
-        bool useInternalBuyTokenBalance;
+        bytes32 sellTokenBalance;
+        bytes32 buyTokenBalance;
     }
 
     /// @dev The order EIP-712 type hash for the [`GPv2Order.Data`] struct.
@@ -39,13 +39,13 @@ library GPv2Order {
     ///         "uint256 feeAmount," +
     ///         "string kind," +
     ///         "bool partiallyFillable" +
-    ///         "bool useInternalSellTokenBalance" +
-    ///         "bool useInternalBuyTokenBalance" +
+    ///         "string sellTokenBalance" +
+    ///         "string buyTokenBalance" +
     ///     ")"
     /// )
     /// ```
     bytes32 internal constant TYPE_HASH =
-        hex"e2dc073fc74b3a79b74490a80ce2541fc2191b237c79ab2b8a60f3be54432ce9";
+        hex"d5a25ba2e97094ad7d83dc28a6572da797d6b3e7fc6663bd93efb789fc17e489";
 
     /// @dev The marker value for a sell order for computing the order struct
     /// hash. This allows the EIP-712 compatible wallets to display a
@@ -55,7 +55,7 @@ library GPv2Order {
     /// ```
     /// keccak256("sell")
     /// ```
-    bytes32 internal constant SELL =
+    bytes32 internal constant KIND_SELL =
         hex"f3b277728b3fee749481eb3e0b3b48980dbbab78658fc419025cb16eee346775";
 
     /// @dev The OrderKind marker value for a buy order for computing the order
@@ -65,8 +65,39 @@ library GPv2Order {
     /// ```
     /// keccak256("buy")
     /// ```
-    bytes32 internal constant BUY =
+    bytes32 internal constant KIND_BUY =
         hex"6ed88e868af0a1983e3886d5f3e95a2fafbd6c3450bc229e27342283dc429ccc";
+
+    /// @dev The TokenBalance marker value for using direct ERC20 balances for
+    /// computing the order struct hash.
+    ///
+    /// This value is pre-computed from the following expression:
+    /// ```
+    /// keccak256("erc20")
+    /// ```
+    bytes32 internal constant BALANCE_ERC20 =
+        hex"5a28e9363bb942b639270062aa6bb295f434bcdfc42c97267bf003f272060dc9";
+
+    /// @dev The TokenBalance marker value for using Balancer Vault external
+    /// balances (in order to re-use Vault ERC20 approvals) for computing the
+    /// order struct hash.
+    ///
+    /// This value is pre-computed from the following expression:
+    /// ```
+    /// keccak256("external")
+    /// ```
+    bytes32 internal constant BALANCE_EXTERNAL =
+        hex"abee3b73373acd583a130924aad6dc38cfdc44ba0555ba94ce2ff63980ea0632";
+
+    /// @dev The TokenBalance marker value for using Balancer Vault internal
+    /// balances for computing the order struct hash.
+    ///
+    /// This value is pre-computed from the following expression:
+    /// ```
+    /// keccak256("internal")
+    /// ```
+    bytes32 internal constant BALANCE_INTERNAL =
+        hex"4ac99ace14ee0a5ef932dc609df0943ab7ac16b7583634612f8dc35a4289a6ce";
 
     /// @dev Marker address used to indicate that the receiver of the trade
     /// proceeds should the owner of the order.

--- a/src/contracts/libraries/GPv2Trade.sol
+++ b/src/contracts/libraries/GPv2Trade.sol
@@ -49,8 +49,8 @@ library GPv2Trade {
         (
             order.kind,
             order.partiallyFillable,
-            order.useInternalSellTokenBalance,
-            order.useInternalBuyTokenBalance,
+            order.sellTokenBalance,
+            order.buyTokenBalance,
             signingScheme
         ) = extractFlags(trade.flags);
     }
@@ -67,27 +67,30 @@ library GPv2Trade {
     /// order. The flags byte uses the following format:
     ///
     /// ```
-    /// bit | 31 ...   | 5 | 4 | 3 | 2 | 1 | 0 |
+    /// bit | 31 ...   | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
     /// ----+----------+---+---+-------+---+---+
-    ///     | reserved | *   * | * | * | * | * |
+    ///     | reserved | *   * | * | *   * | * | * |
+    ///                  |   |   |   |   |   |   |
+    ///                  |   |   |   |   |   |   +---- order kind bit, 0 for a sell order
+    ///                  |   |   |   |   |   |         and 1 for a buy order
     ///                  |   |   |   |   |   |
-    ///                  |   |   |   |   |   +---- order kind bit, 0 for a sell order
-    ///                  |   |   |   |   |         and 1 for a buy order
+    ///                  |   |   |   |   |   +-------- order fill bit, 0 for fill-or-kill
+    ///                  |   |   |   |   |             and 1 for a partially fillable order
     ///                  |   |   |   |   |
-    ///                  |   |   |   |   +-------- order fill bit, 0 for fill-or-kill
-    ///                  |   |   |   |             and 1 for a partially fillable order
-    ///                  |   |   |   |
-    ///                  |   |   |   +------------ use internal sell token balance bit:
-    ///                  |   |   |                 0: external ERC20 token balance
-    ///                  |   |   |                 1: internal Balancer vault balance
+    ///                  |   |   |   +---+------------ use internal sell token balance bit:
+    ///                  |   |   |                     0x: ERC20 token balance
+    ///                  |   |   |                     10: external Balancer Vault balance
+    ///                  |   |   |                     11: internal Balancer Vault balance
     ///                  |   |   |
-    ///                  |   |   +---------------- use internal buy token balance bit
+    ///                  |   |   +-------------------- use buy token balance bit
+    ///                  |   |                         0: ERC20 token balance
+    ///                  |   |                         1: internal Balancer Vault balance
     ///                  |   |
-    ///                  +---+-------------------- signature scheme bits:
-    ///                                            00: EIP-712
-    ///                                            01: eth_sign
-    ///                                            10: EIP-1271
-    ///                                            11: pre_sign
+    ///                  +---+------------------------ signature scheme bits:
+    ///                                                00: EIP-712
+    ///                                                01: eth_sign
+    ///                                                10: EIP-1271
+    ///                                                11: pre_sign
     /// ```
     function extractFlags(uint256 flags)
         internal
@@ -95,23 +98,33 @@ library GPv2Trade {
         returns (
             bytes32 kind,
             bool partiallyFillable,
-            bool useInternalSellTokenBalance,
-            bool useInternalBuyTokenBalance,
+            bytes32 sellTokenBalance,
+            bytes32 buyTokenBalance,
             GPv2Signing.Scheme signingScheme
         )
     {
         if (flags & 0x01 == 0) {
-            kind = GPv2Order.SELL;
+            kind = GPv2Order.KIND_SELL;
         } else {
-            kind = GPv2Order.BUY;
+            kind = GPv2Order.KIND_BUY;
         }
         partiallyFillable = flags & 0x02 != 0;
-        useInternalSellTokenBalance = flags & 0x04 != 0;
-        useInternalBuyTokenBalance = flags & 0x08 != 0;
+        if (flags & 0x08 == 0) {
+            sellTokenBalance = GPv2Order.BALANCE_ERC20;
+        } else if (flags & 0x04 == 0) {
+            sellTokenBalance = GPv2Order.BALANCE_EXTERNAL;
+        } else {
+            sellTokenBalance = GPv2Order.BALANCE_INTERNAL;
+        }
+        if (flags & 0x10 == 0) {
+            buyTokenBalance = GPv2Order.BALANCE_ERC20;
+        } else {
+            buyTokenBalance = GPv2Order.BALANCE_INTERNAL;
+        }
 
         // NOTE: Take advantage of the fact that Solidity will revert if the
         // following expression does not produce a valid enum value. This means
         // we check here that the leading reserved bits must be 0.
-        signingScheme = GPv2Signing.Scheme(flags >> 4);
+        signingScheme = GPv2Signing.Scheme(flags >> 5);
     }
 }

--- a/src/contracts/libraries/GPv2Transfer.sol
+++ b/src/contracts/libraries/GPv2Transfer.sol
@@ -4,6 +4,7 @@ pragma abicoder v2;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "../interfaces/IVault.sol";
+import "./GPv2Order.sol";
 import "./GPv2SafeERC20.sol";
 
 /// @title Gnosis Protocol v2 Transfers
@@ -16,7 +17,7 @@ library GPv2Transfer {
         address account;
         IERC20 token;
         uint256 amount;
-        bool useInternalBalance;
+        bytes32 balance;
     }
 
     /// @dev Ether marker address used to indicate an Ether transfer.
@@ -44,7 +45,7 @@ library GPv2Transfer {
             "GPv2: cannot transfer native ETH"
         );
 
-        if (transfer.useInternalBalance) {
+        if (transfer.balance == GPv2Order.BALANCE_INTERNAL) {
             IVault.BalanceTransfer[] memory vaultTransfers =
                 new IVault.BalanceTransfer[](1);
 
@@ -95,7 +96,7 @@ library GPv2Transfer {
                 "GPv2: cannot transfer native ETH"
             );
 
-            if (transfer.useInternalBalance) {
+            if (transfer.balance == GPv2Order.BALANCE_INTERNAL) {
                 IVault.BalanceTransfer memory vaultTransfer =
                     vaultTransfers[vaultTransferCount++];
                 vaultTransfer.token = transfer.token;
@@ -136,11 +137,11 @@ library GPv2Transfer {
 
             if (address(transfer.token) == BUY_ETH_ADDRESS) {
                 require(
-                    !transfer.useInternalBalance,
+                    transfer.balance != GPv2Order.BALANCE_INTERNAL,
                     "GPv2: unsupported internal ETH"
                 );
                 payable(transfer.account).transfer(transfer.amount);
-            } else if (transfer.useInternalBalance) {
+            } else if (transfer.balance == GPv2Order.BALANCE_INTERNAL) {
                 IVault.BalanceTransfer memory vaultTransfer =
                     vaultTransfers[vaultTransferCount++];
                 vaultTransfer.token = transfer.token;

--- a/src/contracts/test/GPv2TradeTestInterface.sol
+++ b/src/contracts/test/GPv2TradeTestInterface.sol
@@ -19,8 +19,8 @@ contract GPv2TradeTestInterface {
         returns (
             bytes32 kind,
             bool partiallyFillable,
-            bool useInternalSellTokenBalance,
-            bool useInternalBuyTokenBalance,
+            bytes32 sellTokenBalance,
+            bytes32 buyTokenBalance,
             GPv2Signing.Scheme signingScheme
         )
     {

--- a/src/deploy/002_settlement.ts
+++ b/src/deploy/002_settlement.ts
@@ -39,7 +39,7 @@ const deploySettlement: DeployFunction = async function ({
 
   await deploy(settlement, {
     from: deployer,
-    gasLimit: 4.5e6,
+    gasLimit: 5e6,
     args: [authenticatorAddress, vaultAddress],
     deterministicDeployment: SALT,
     log: true,

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -7,6 +7,7 @@ import { artifacts, ethers, waffle } from "hardhat";
 import {
   Interaction,
   InteractionStage,
+  OrderBalance,
   OrderFlags,
   OrderKind,
   PRE_SIGNED,
@@ -313,8 +314,8 @@ describe("GPv2Settlement", () => {
         appData: 0,
         feeAmount: ethers.utils.parseEther("1.0"),
         partiallyFillable: false,
-        useInternalSellTokenBalance: true,
-        useInternalBuyTokenBalance: false,
+        sellTokenBalance: OrderBalance.INTERNAL,
+        buyTokenBalance: OrderBalance.ERC20,
       };
 
       const encoder = new SwapEncoder(testDomain);
@@ -375,24 +376,34 @@ describe("GPv2Settlement", () => {
     describe("Balances", () => {
       for (const { name, ...flags } of [
         {
-          name: "external to external",
-          useInternalSellTokenBalance: false,
-          useInternalBuyTokenBalance: false,
+          name: "erc20 to erc20",
+          sellTokenBalance: OrderBalance.ERC20,
+          buyTokenBalance: OrderBalance.ERC20,
+        },
+        {
+          name: "erc20 to internal",
+          sellTokenBalance: OrderBalance.ERC20,
+          buyTokenBalance: OrderBalance.INTERNAL,
+        },
+        {
+          name: "external to erc20",
+          sellTokenBalance: OrderBalance.EXTERNAL,
+          buyTokenBalance: OrderBalance.ERC20,
         },
         {
           name: "external to internal",
-          useInternalSellTokenBalance: false,
-          useInternalBuyTokenBalance: true,
+          sellTokenBalance: OrderBalance.EXTERNAL,
+          buyTokenBalance: OrderBalance.INTERNAL,
         },
         {
-          name: "internal to external",
-          useInternalSellTokenBalance: true,
-          useInternalBuyTokenBalance: false,
+          name: "internal to erc20",
+          sellTokenBalance: OrderBalance.INTERNAL,
+          buyTokenBalance: OrderBalance.ERC20,
         },
         {
           name: "internal to internal",
-          useInternalSellTokenBalance: true,
-          useInternalBuyTokenBalance: true,
+          sellTokenBalance: OrderBalance.INTERNAL,
+          buyTokenBalance: OrderBalance.INTERNAL,
         },
       ]) {
         it(`performs an ${name} swap when specified`, async () => {
@@ -428,15 +439,17 @@ describe("GPv2Settlement", () => {
               encoder.tokens,
               {
                 sender: traders[0].address,
-                fromInternalBalance: flags.useInternalSellTokenBalance,
+                fromInternalBalance:
+                  flags.sellTokenBalance == OrderBalance.INTERNAL,
                 recipient: traders[1].address,
-                toInternalBalance: flags.useInternalBuyTokenBalance,
+                toInternalBalance:
+                  flags.buyTokenBalance == OrderBalance.INTERNAL,
               },
               [0, 0],
               0,
             )
             .returns([0, 0]);
-          if (flags.useInternalSellTokenBalance) {
+          if (flags.sellTokenBalance == OrderBalance.INTERNAL) {
             await vault.mock.transferInternalBalance
               .withArgs([
                 {
@@ -485,7 +498,7 @@ describe("GPv2Settlement", () => {
           validTo: 0x01020304,
           appData: 0,
           feeAmount: ethers.utils.parseEther("1.0"),
-          useInternalSellTokenBalance: true,
+          sellTokenBalance: OrderBalance.INTERNAL,
           partiallyFillable: true,
         };
         const orderUid = () =>

--- a/test/GPv2Signing.test.ts
+++ b/test/GPv2Signing.test.ts
@@ -4,6 +4,7 @@ import { artifacts, ethers, waffle } from "hardhat";
 
 import {
   EIP1271_MAGICVALUE,
+  OrderBalance,
   OrderKind,
   PRE_SIGNED,
   SettlementEncoder,
@@ -137,8 +138,8 @@ describe("GPv2Signing", () => {
         feeAmount: fillUint(256, 0x08),
         kind: OrderKind.BUY,
         partiallyFillable: true,
-        useInternalSellTokenBalance: true,
-        useInternalBuyTokenBalance: true,
+        sellTokenBalance: OrderBalance.EXTERNAL,
+        buyTokenBalance: OrderBalance.INTERNAL,
       };
       const tradeExecution = {
         executedAmount: fillUint(256, 0x09),

--- a/test/GPv2Trade.test.ts
+++ b/test/GPv2Trade.test.ts
@@ -3,6 +3,7 @@ import { Contract, BigNumber } from "ethers";
 import { ethers, waffle } from "hardhat";
 
 import {
+  OrderBalance,
   OrderKind,
   SettlementEncoder,
   SigningScheme,
@@ -10,7 +11,12 @@ import {
   encodeSigningScheme,
 } from "../src/ts";
 
-import { decodeOrderKind, decodeOrder } from "./encoding";
+import {
+  OrderBalanceId,
+  decodeOrderKind,
+  decodeOrderBalance,
+  decodeOrder,
+} from "./encoding";
 
 function fillBytes(count: number, byte: number): string {
   return ethers.utils.hexlify([...Array(count)].map(() => byte));
@@ -61,8 +67,8 @@ describe("GPv2Trade", () => {
         feeAmount: fillUint(256, 0x08),
         kind: OrderKind.BUY,
         partiallyFillable: true,
-        useInternalSellTokenBalance: true,
-        useInternalBuyTokenBalance: true,
+        sellTokenBalance: OrderBalance.EXTERNAL,
+        buyTokenBalance: OrderBalance.INTERNAL,
       };
       const tradeExecution = {
         executedAmount: fillUint(256, 0x09),
@@ -116,44 +122,47 @@ describe("GPv2Trade", () => {
 
   describe("extractFlags", () => {
     it("should extract all supported order flags", async () => {
-      for (const flags of [
-        {
-          kind: OrderKind.SELL,
-          partiallyFillable: false,
-          useInternalSellTokenBalance: true,
-          useInternalBuyTokenBalance: true,
-        },
-        {
-          kind: OrderKind.BUY,
-          partiallyFillable: false,
-          useInternalSellTokenBalance: false,
-          useInternalBuyTokenBalance: true,
-        },
-        {
-          kind: OrderKind.SELL,
-          partiallyFillable: true,
-          useInternalSellTokenBalance: true,
-          useInternalBuyTokenBalance: false,
-        },
-        {
-          kind: OrderKind.BUY,
-          partiallyFillable: true,
-          useInternalSellTokenBalance: false,
-          useInternalBuyTokenBalance: false,
-        },
-      ]) {
+      const flagVariants = [OrderKind.SELL, OrderKind.BUY].flatMap((kind) =>
+        [false, true].flatMap((partiallyFillable) =>
+          [
+            OrderBalance.ERC20,
+            OrderBalance.EXTERNAL,
+            OrderBalance.INTERNAL,
+          ].flatMap((sellTokenBalance) =>
+            [OrderBalance.ERC20, OrderBalance.INTERNAL].map(
+              (buyTokenBalance) => ({
+                kind,
+                partiallyFillable,
+                sellTokenBalance,
+                buyTokenBalance,
+              }),
+            ),
+          ),
+        ),
+      );
+
+      for (const flags of flagVariants) {
         const {
           kind: encodedKind,
           partiallyFillable,
-          useInternalSellTokenBalance,
-          useInternalBuyTokenBalance,
+          sellTokenBalance: encodedSellTokenBalance,
+          buyTokenBalance: encodedBuyTokenBalance,
         } = await tradeLib.extractFlagsTest(encodeOrderFlags(flags));
         expect({
           kind: decodeOrderKind(encodedKind),
           partiallyFillable,
-          useInternalSellTokenBalance,
-          useInternalBuyTokenBalance,
+          sellTokenBalance: decodeOrderBalance(encodedSellTokenBalance),
+          buyTokenBalance: decodeOrderBalance(encodedBuyTokenBalance),
         }).to.deep.equal(flags);
+      }
+    });
+
+    it("should accept 0b00 and 0b01 for ERC20 sell token balance flag", async () => {
+      for (const encodedFlags of [0b00000, 0b00100]) {
+        const { sellTokenBalance } = await tradeLib.extractFlagsTest(
+          encodedFlags,
+        );
+        expect(sellTokenBalance).to.equal(OrderBalanceId.ERC20);
       }
     });
 
@@ -172,7 +181,7 @@ describe("GPv2Trade", () => {
     });
 
     it("should revert when encoding invalid flags", async () => {
-      await expect(tradeLib.extractFlagsTest(0b1000000)).to.be.reverted;
+      await expect(tradeLib.extractFlagsTest(0b10000000)).to.be.reverted;
     });
   });
 });

--- a/test/GPv2Transfer.test.ts
+++ b/test/GPv2Transfer.test.ts
@@ -6,6 +6,8 @@ import { artifacts, ethers, waffle } from "hardhat";
 
 import { BUY_ETH_ADDRESS } from "../src/ts";
 
+import { OrderBalanceId } from "./encoding";
+
 describe("GPv2Transfer", () => {
   const [
     deployer,
@@ -43,7 +45,7 @@ describe("GPv2Transfer", () => {
             account: traders[0].address,
             token: token.address,
             amount,
-            useInternalBalance: false,
+            balance: OrderBalanceId.ERC20,
           },
           recipient.address,
         ),
@@ -68,7 +70,7 @@ describe("GPv2Transfer", () => {
             account: traders[0].address,
             token: token.address,
             amount,
-            useInternalBalance: true,
+            balance: OrderBalanceId.INTERNAL,
           },
           recipient.address,
         ),
@@ -76,7 +78,11 @@ describe("GPv2Transfer", () => {
     });
 
     it("reverts when mistakenly trying to transfer Ether", async () => {
-      for (const useInternalBalance of [false, true]) {
+      for (const balance of [
+        OrderBalanceId.ERC20,
+        OrderBalanceId.EXTERNAL,
+        OrderBalanceId.INTERNAL,
+      ]) {
         await expect(
           transfer.transferFromAccountTest(
             vault.address,
@@ -84,7 +90,7 @@ describe("GPv2Transfer", () => {
               account: traders[0].address,
               token: BUY_ETH_ADDRESS,
               amount,
-              useInternalBalance,
+              balance,
             },
             recipient.address,
           ),
@@ -104,7 +110,7 @@ describe("GPv2Transfer", () => {
             account: traders[0].address,
             token: token.address,
             amount,
-            useInternalBalance: false,
+            balance: OrderBalanceId.ERC20,
           },
           recipient.address,
         ),
@@ -130,7 +136,7 @@ describe("GPv2Transfer", () => {
             account: traders[0].address,
             token: token.address,
             amount,
-            useInternalBalance: true,
+            balance: OrderBalanceId.INTERNAL,
           },
           recipient.address,
         ),
@@ -151,7 +157,7 @@ describe("GPv2Transfer", () => {
               account: traders[0].address,
               token: token.address,
               amount,
-              useInternalBalance: false,
+              balance: OrderBalanceId.ERC20,
             },
           ],
           recipient.address,
@@ -178,7 +184,7 @@ describe("GPv2Transfer", () => {
               account: traders[0].address,
               token: token.address,
               amount,
-              useInternalBalance: true,
+              balance: OrderBalanceId.INTERNAL,
             },
           ],
           recipient.address,
@@ -230,7 +236,11 @@ describe("GPv2Transfer", () => {
     });
 
     it("reverts when mistakenly trying to transfer Ether", async () => {
-      for (const useInternalBalance of [false, true]) {
+      for (const balance of [
+        OrderBalanceId.ERC20,
+        OrderBalanceId.EXTERNAL,
+        OrderBalanceId.INTERNAL,
+      ]) {
         await expect(
           transfer.transferFromAccountsTest(
             vault.address,
@@ -239,7 +249,7 @@ describe("GPv2Transfer", () => {
                 account: traders[0].address,
                 token: BUY_ETH_ADDRESS,
                 amount,
-                useInternalBalance,
+                balance,
               },
             ],
             recipient.address,
@@ -261,7 +271,7 @@ describe("GPv2Transfer", () => {
               account: traders[0].address,
               token: token.address,
               amount,
-              useInternalBalance: false,
+              balance: OrderBalanceId.ERC20,
             },
           ],
           recipient.address,
@@ -289,7 +299,7 @@ describe("GPv2Transfer", () => {
               account: traders[0].address,
               token: token.address,
               amount,
-              useInternalBalance: true,
+              balance: OrderBalanceId.INTERNAL,
             },
           ],
           recipient.address,
@@ -309,7 +319,7 @@ describe("GPv2Transfer", () => {
             account: traders[0].address,
             token: token.address,
             amount,
-            useInternalBalance: false,
+            balance: OrderBalanceId.ERC20,
           },
         ]),
       ).to.not.be.reverted;
@@ -332,7 +342,7 @@ describe("GPv2Transfer", () => {
             account: traders[0].address,
             token: token.address,
             amount,
-            useInternalBalance: true,
+            balance: OrderBalanceId.INTERNAL,
           },
         ]),
       ).to.not.be.reverted;
@@ -350,7 +360,7 @@ describe("GPv2Transfer", () => {
           account: traders[0].address,
           token: BUY_ETH_ADDRESS,
           amount,
-          useInternalBalance: false,
+          balance: OrderBalanceId.ERC20,
         },
       ]);
 
@@ -374,7 +384,7 @@ describe("GPv2Transfer", () => {
               account: trader.address,
               token: token.address,
               amount,
-              useInternalBalance: false,
+              balance: OrderBalanceId.ERC20,
             });
             break;
           case 1:
@@ -382,7 +392,7 @@ describe("GPv2Transfer", () => {
               account: trader.address,
               token: token.address,
               amount,
-              useInternalBalance: true,
+              balance: OrderBalanceId.INTERNAL,
             });
             break;
           case 2:
@@ -390,7 +400,7 @@ describe("GPv2Transfer", () => {
               account: trader.address,
               token: BUY_ETH_ADDRESS,
               amount,
-              useInternalBalance: false,
+              balance: OrderBalanceId.ERC20,
             });
             break;
         }
@@ -444,7 +454,7 @@ describe("GPv2Transfer", () => {
             account: traders[0].address,
             token: token.address,
             amount,
-            useInternalBalance: false,
+            balance: OrderBalanceId.ERC20,
           },
         ]),
       ).to.be.revertedWith("test error");
@@ -468,7 +478,7 @@ describe("GPv2Transfer", () => {
             account: traders[0].address,
             token: token.address,
             amount,
-            useInternalBalance: true,
+            balance: OrderBalanceId.INTERNAL,
           },
         ]),
       ).to.be.revertedWith("test error");
@@ -481,7 +491,7 @@ describe("GPv2Transfer", () => {
             account: traders[0].address,
             token: BUY_ETH_ADDRESS,
             amount,
-            useInternalBalance: true,
+            balance: OrderBalanceId.INTERNAL,
           },
         ]),
       ).to.be.revertedWith("unsupported internal ETH");

--- a/test/GPv2VaultRelayer.test.ts
+++ b/test/GPv2VaultRelayer.test.ts
@@ -6,6 +6,8 @@ import { artifacts, ethers, waffle } from "hardhat";
 
 import { SwapRequest } from "../src/ts";
 
+import { OrderBalanceId } from "./encoding";
+
 const GIVEN_IN = 0;
 const GIVEN_OUT = 1;
 
@@ -65,13 +67,13 @@ describe("GPv2VaultRelayer", () => {
             account: traders[0].address,
             token: tokens[0].address,
             amount,
-            useInternalBalance: false,
+            balance: OrderBalanceId.ERC20,
           },
           {
             account: traders[1].address,
             token: tokens[1].address,
             amount,
-            useInternalBalance: true,
+            balance: OrderBalanceId.INTERNAL,
           },
         ]),
       ).to.not.be.reverted;
@@ -91,7 +93,7 @@ describe("GPv2VaultRelayer", () => {
             account: traders[0].address,
             token: token.address,
             amount,
-            useInternalBalance: false,
+            balance: OrderBalanceId.ERC20,
           },
         ]),
       ).to.be.revertedWith("test error");
@@ -118,7 +120,7 @@ describe("GPv2VaultRelayer", () => {
             account: traders[0].address,
             token: token.address,
             amount,
-            useInternalBalance: true,
+            balance: OrderBalanceId.INTERNAL,
           },
         ]),
       ).to.be.revertedWith("test error");
@@ -142,7 +144,7 @@ describe("GPv2VaultRelayer", () => {
         account: string;
         token: string;
         amount: BigNumberish;
-        useInternalBalance: boolean;
+        balance: string;
       };
     }
 
@@ -163,7 +165,7 @@ describe("GPv2VaultRelayer", () => {
           account: ethers.constants.AddressZero,
           token: ethers.constants.AddressZero,
           amount: ethers.constants.Zero,
-          useInternalBalance: false,
+          balance: OrderBalanceId.ERC20,
         },
       ];
     };
@@ -218,7 +220,7 @@ describe("GPv2VaultRelayer", () => {
             account: traders[0].address,
             token: tokens[0].address,
             amount: ethers.utils.parseEther("1.0"),
-            useInternalBalance: false,
+            balance: OrderBalanceId.ERC20,
           };
 
           await vault.mock[`batchSwapGiven${name}`]
@@ -260,7 +262,7 @@ describe("GPv2VaultRelayer", () => {
             account: traders[0].address,
             token: token.address,
             amount: ethers.utils.parseEther("1.0"),
-            useInternalBalance: false,
+            balance: OrderBalanceId.ERC20,
           };
 
           await vault.mock[`batchSwapGiven${name}`].returns(deltas);
@@ -305,7 +307,7 @@ describe("GPv2VaultRelayer", () => {
                 account: traders[0].address,
                 token: token.address,
                 amount,
-                useInternalBalance: false,
+                balance: OrderBalanceId.ERC20,
               },
             }),
           ),
@@ -335,7 +337,7 @@ describe("GPv2VaultRelayer", () => {
                 account: traders[0].address,
                 token: token.address,
                 amount,
-                useInternalBalance: true,
+                balance: OrderBalanceId.INTERNAL,
               },
             }),
           ),
@@ -358,7 +360,7 @@ describe("GPv2VaultRelayer", () => {
                 account: traders[0].address,
                 token: token.address,
                 amount,
-                useInternalBalance: false,
+                balance: OrderBalanceId.ERC20,
               },
             }),
           ),
@@ -388,7 +390,7 @@ describe("GPv2VaultRelayer", () => {
                 account: traders[0].address,
                 token: token.address,
                 amount,
-                useInternalBalance: true,
+                balance: OrderBalanceId.INTERNAL,
               },
             }),
           ),

--- a/test/e2e/internalBalances.test.ts
+++ b/test/e2e/internalBalances.test.ts
@@ -4,6 +4,7 @@ import { Contract, Wallet } from "ethers";
 import { ethers, waffle } from "hardhat";
 
 import {
+  OrderBalance,
   OrderKind,
   SettlementEncoder,
   SigningScheme,
@@ -121,7 +122,7 @@ describe("E2E: Should allow trading with Vault internal balances", () => {
         feeAmount: ethers.utils.parseEther("0.3"),
         validTo: 0xffffffff,
         appData: 2,
-        useInternalSellTokenBalance: true,
+        sellTokenBalance: OrderBalance.INTERNAL,
       },
       traders[1],
       SigningScheme.EIP712,
@@ -142,7 +143,7 @@ describe("E2E: Should allow trading with Vault internal balances", () => {
         feeAmount: ethers.utils.parseEther("0.002"),
         validTo: 0xffffffff,
         appData: 2,
-        useInternalBuyTokenBalance: true,
+        buyTokenBalance: OrderBalance.INTERNAL,
       },
       traders[2],
       SigningScheme.EIP712,
@@ -174,8 +175,8 @@ describe("E2E: Should allow trading with Vault internal balances", () => {
         feeAmount: ethers.utils.parseEther("1.5"),
         validTo: 0xffffffff,
         appData: 2,
-        useInternalSellTokenBalance: true,
-        useInternalBuyTokenBalance: true,
+        sellTokenBalance: OrderBalance.INTERNAL,
+        buyTokenBalance: OrderBalance.INTERNAL,
       },
       traders[3],
       SigningScheme.EIP712,

--- a/test/encoding.ts
+++ b/test/encoding.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from "ethers";
 import { ethers } from "hardhat";
 
-import { Order, OrderKind, normalizeOrder } from "../src/ts";
+import { Order, OrderBalance, OrderKind, normalizeOrder } from "../src/ts";
 
 export type AbiOrder = [
   string,
@@ -14,8 +14,8 @@ export type AbiOrder = [
   BigNumber,
   string,
   boolean,
-  boolean,
-  boolean,
+  string,
+  string,
 ];
 
 export function encodeOrder(order: Order): AbiOrder {
@@ -31,18 +31,30 @@ export function encodeOrder(order: Order): AbiOrder {
     BigNumber.from(o.feeAmount),
     ethers.utils.id(o.kind),
     o.partiallyFillable,
-    o.useInternalSellTokenBalance,
-    o.useInternalBuyTokenBalance,
+    ethers.utils.id(o.sellTokenBalance),
+    ethers.utils.id(o.buyTokenBalance),
   ];
 }
 
-export function decodeOrderKind(kindHash: string): OrderKind {
-  for (const kind of [OrderKind.SELL, OrderKind.BUY]) {
-    if (kindHash == ethers.utils.id(kind)) {
-      return kind;
+function decodeEnum<T>(hash: string, values: T[]): T {
+  for (const value of values) {
+    if (hash == ethers.utils.id(`${value}`)) {
+      return value;
     }
   }
-  throw new Error(`invalid order kind hash '${kindHash}'`);
+  throw new Error(`invalid enum hash '${hash}'`);
+}
+
+export function decodeOrderKind(kindHash: string): OrderKind {
+  return decodeEnum(kindHash, [OrderKind.SELL, OrderKind.BUY]);
+}
+
+export function decodeOrderBalance(balanceHash: string): OrderBalance {
+  return decodeEnum(balanceHash, [
+    OrderBalance.ERC20,
+    OrderBalance.EXTERNAL,
+    OrderBalance.INTERNAL,
+  ]);
 }
 
 export function decodeOrder(order: AbiOrder): Order {
@@ -57,7 +69,13 @@ export function decodeOrder(order: AbiOrder): Order {
     feeAmount: order[7],
     kind: decodeOrderKind(order[8]),
     partiallyFillable: order[9],
-    useInternalSellTokenBalance: order[10],
-    useInternalBuyTokenBalance: order[11],
+    sellTokenBalance: decodeOrderBalance(order[10]),
+    buyTokenBalance: decodeOrderBalance(order[11]),
   };
 }
+
+export const OrderBalanceId = {
+  ERC20: ethers.utils.id(OrderBalance.ERC20),
+  EXTERNAL: ethers.utils.id(OrderBalance.EXTERNAL),
+  INTERNAL: ethers.utils.id(OrderBalance.INTERNAL),
+};


### PR DESCRIPTION
This PR adds a new "enum" for configuring buy and sell token balances. This allows an additional value for differentiating between using ERC20 token allowance directly on the Vault relayer and external Vault balances to reuse ERC20 allowances made to the Vault using a relayer approval.

Note, that currently the SC treat `ERC20` and `EXTERNAL` the same for now, the actual differentiation will come in a follow up PR.

One thing that we should discuss is the string values for the `OrderBalance` enum, as this is what will be displayed to the user when signing the order. Looping in @anxolin 

### Test Plan

Adjusted tests to use new enum.
