### PR TITLE
Differentiate between direct ERC20 and external Vault sell balances

### DIFF
--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -27,4 +27,5 @@ export * from "./reader";
 export * from "./settlement";
 export * from "./sign";
 export * from "./swap";
+export * from "./vault";
 export * from "./types/ethers";

--- a/src/ts/vault.ts
+++ b/src/ts/vault.ts
@@ -1,0 +1,42 @@
+import { ethers, Contract } from "ethers";
+
+/**
+ * Balancer Vault partial ABI interface.
+ *
+ * This definition only contains the Vault methods that are used by GPv2 Vault
+ * relayer. It is copied here to avoid relying on build artifacts.
+ */
+export const VAULT_INTERFACE = new ethers.utils.Interface([
+  "function transferToExternalBalance((address, uint256, address, address)[])",
+  "function transferInternalBalance((address, uint256, address, address)[])",
+  "function withdrawFromInternalBalance((address, uint256, address, address)[])",
+  "function batchSwapGivenIn((bytes32, uint256, uint256, uint256, bytes)[], address[], (address, bool, address, bool), int256[], uint256)",
+  "function batchSwapGivenOut((bytes32, uint256, uint256, uint256, bytes)[], address[], (address, bool, address, bool), int256[], uint256)",
+]);
+
+/**
+ * Grants the required roles to the specified Vault relayer.
+ *
+ * This method is intended to be called by the Balancer Vault admin, and **not**
+ * traders. It is included in the exported TypeScript library for completeness
+ * and "documentation".
+ *
+ * @param authorizer The Vault authorizer contract that manages access.
+ * @param vaultAddress The address to the Vault.
+ * @param vaultRelayerAddress The address to the GPv2 Vault relayer contract.
+ */
+export async function grantRequiredRoles(
+  authorizer: Contract,
+  vaultAddress: string,
+  vaultRelayerAddress: string,
+): Promise<void> {
+  for (const name in VAULT_INTERFACE.functions) {
+    await authorizer.grantRole(
+      ethers.utils.solidityKeccak256(
+        ["address", "bytes4"],
+        [vaultAddress, VAULT_INTERFACE.getSighash(name)],
+      ),
+      vaultRelayerAddress,
+    );
+  }
+}

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -374,38 +374,20 @@ describe("GPv2Settlement", () => {
     });
 
     describe("Balances", () => {
-      for (const { name, ...flags } of [
-        {
-          name: "erc20 to erc20",
-          sellTokenBalance: OrderBalance.ERC20,
-          buyTokenBalance: OrderBalance.ERC20,
-        },
-        {
-          name: "erc20 to internal",
-          sellTokenBalance: OrderBalance.ERC20,
-          buyTokenBalance: OrderBalance.INTERNAL,
-        },
-        {
-          name: "external to erc20",
-          sellTokenBalance: OrderBalance.EXTERNAL,
-          buyTokenBalance: OrderBalance.ERC20,
-        },
-        {
-          name: "external to internal",
-          sellTokenBalance: OrderBalance.EXTERNAL,
-          buyTokenBalance: OrderBalance.INTERNAL,
-        },
-        {
-          name: "internal to erc20",
-          sellTokenBalance: OrderBalance.INTERNAL,
-          buyTokenBalance: OrderBalance.ERC20,
-        },
-        {
-          name: "internal to internal",
-          sellTokenBalance: OrderBalance.INTERNAL,
-          buyTokenBalance: OrderBalance.INTERNAL,
-        },
-      ]) {
+      const balanceVariants = [
+        OrderBalance.ERC20,
+        OrderBalance.EXTERNAL,
+        OrderBalance.INTERNAL,
+      ].flatMap((sellTokenBalance) =>
+        [OrderBalance.ERC20, OrderBalance.INTERNAL].map((buyTokenBalance) => {
+          return {
+            name: `${sellTokenBalance} to ${buyTokenBalance}`,
+            sellTokenBalance,
+            buyTokenBalance,
+          };
+        }),
+      );
+      for (const { name, ...flags } of balanceVariants) {
         it(`performs an ${name} swap when specified`, async () => {
           const sellToken = await waffle.deployMockContract(
             deployer,
@@ -449,21 +431,36 @@ describe("GPv2Settlement", () => {
               0,
             )
             .returns([0, 0]);
-          if (flags.sellTokenBalance == OrderBalance.INTERNAL) {
-            await vault.mock.transferInternalBalance
-              .withArgs([
-                {
-                  token: sellToken.address,
-                  amount: feeAmount,
-                  sender: traders[0].address,
-                  recipient: settlement.address,
-                },
-              ])
-              .returns();
-          } else {
-            await sellToken.mock.transferFrom
-              .withArgs(traders[0].address, settlement.address, feeAmount)
-              .returns(true);
+          switch (flags.sellTokenBalance) {
+            case OrderBalance.ERC20:
+              await sellToken.mock.transferFrom
+                .withArgs(traders[0].address, settlement.address, feeAmount)
+                .returns(true);
+              break;
+            case OrderBalance.EXTERNAL:
+              await vault.mock.transferToExternalBalance
+                .withArgs([
+                  {
+                    token: sellToken.address,
+                    amount: feeAmount,
+                    sender: traders[0].address,
+                    recipient: settlement.address,
+                  },
+                ])
+                .returns();
+              break;
+            case OrderBalance.INTERNAL:
+              await vault.mock.transferInternalBalance
+                .withArgs([
+                  {
+                    token: sellToken.address,
+                    amount: feeAmount,
+                    sender: traders[0].address,
+                    recipient: settlement.address,
+                  },
+                ])
+                .returns();
+              break;
           }
 
           await authenticator.connect(owner).addSolver(solver.address);

--- a/test/e2e/balancerSwap.test.ts
+++ b/test/e2e/balancerSwap.test.ts
@@ -11,6 +11,7 @@ import {
   SigningScheme,
   TypedDataDomain,
   domain,
+  grantRequiredRoles,
 } from "../../src/ts";
 
 import MockPool from "./balancer/MockPool.json";
@@ -47,23 +48,11 @@ describe("E2E: Direct Balancer swap", () => {
     } = deployment);
 
     const { vaultAuthorizer, authenticator, manager } = deployment;
-    for (const method of [
-      "batchSwapGivenIn",
-      "batchSwapGivenOut",
-      "transferInternalBalance",
-      "transferToExternalBalance",
-      "withdrawFromInternalBalance",
-    ]) {
-      await vaultAuthorizer
-        .connect(manager)
-        .grantRole(
-          ethers.utils.solidityKeccak256(
-            ["address", "bytes4"],
-            [vault.address, vault.interface.getSighash(method)],
-          ),
-          vaultRelayer.address,
-        );
-    }
+    await grantRequiredRoles(
+      vaultAuthorizer.connect(manager),
+      vault.address,
+      vaultRelayer.address,
+    );
     await authenticator.connect(manager).addSolver(solver.address);
 
     const { chainId } = await ethers.provider.getNetwork();


### PR DESCRIPTION
Closes #520, closes #535, supersedes #531 

This PR adds code to differentiate between direct ERC20 allowances to the Vault relayer and reusing Vault ERC20 allowances for settlements and the swap fast-path.

It actually turns out that having 3 sources of balances for the sell token made it easier to make these PRs slightly smaller and add incremental changes. One issue with the current implementation is that for the `swap` path with `ERC20` token balances, it currently requires **both** vault and vault relayer approvals (:vomiting_face:). This will be fixed as part of #534, and I didn't want to include it in this PR lest it gets too large.

### Test Plan

Updated unit and e2e tests to exercise new code path, coverage should be 100%.
