### PR TITLE
Revert ERC20 transfers on non-contracts

### DIFF
--- a/src/contracts/libraries/GPv2SafeERC20.sol
+++ b/src/contracts/libraries/GPv2SafeERC20.sol
@@ -33,7 +33,7 @@ library GPv2SafeERC20 {
             }
         }
 
-        require(getLastTansferResult(), "GPv2: failed transfer");
+        require(getLastTansferResult(token), "GPv2: failed transfer");
     }
 
     /// @dev Wrapper around a call to the ERC20 function `transferFrom` that
@@ -66,15 +66,13 @@ library GPv2SafeERC20 {
             }
         }
 
-        require(getLastTansferResult(), "GPv2: failed transferFrom");
+        require(getLastTansferResult(token), "GPv2: failed transferFrom");
     }
 
     /// @dev Verifies that the last return was a successful `transfer*` call.
     /// This is done by checking that the return data is either empty, or
     /// is a valid ABI encoded boolean.
-    function getLastTansferResult() private pure returns (bool success) {
-        bool badReturnSize;
-
+    function getLastTansferResult(IERC20 token) private view returns (bool success) {
         // NOTE: Inspecting previous return data requires assembly. Note that
         // we write the return data to memory 0 in the case where the return
         // data size is 32, this is OK since the first 64 bytes of memory are
@@ -83,9 +81,37 @@ library GPv2SafeERC20 {
         // <https://docs.soliditylang.org/en/v0.7.6/internals/layout_in_memory.html>
         // solhint-disable-next-line no-inline-assembly
         assembly {
+            /// @dev Revert with an ABI encoded Solidity error with a message
+            /// that fits into 32-bytes.
+            ///
+            /// An ABI encoded Solidity error has the following memory layout:
+            ///
+            /// ------------+----------------------------------
+            ///  byte range | value
+            /// ------------+----------------------------------
+            ///  0x00..0x04 |        selector("Error(string)")
+            ///  0x04..0x24 |      string offset (always 0x20)
+            ///  0x24..0x44 |                    string length
+            ///  0x44..0x64 | string value, padded to 32-bytes
+            function revertWithMessage(length, message) {
+                mstore(0x00, "\x08\xc3\x79\xa0")
+                mstore(0x04, 0x20)
+                mstore(0x24, length)
+                mstore(0x44, message)
+                revert(0x00, 0x64)
+            }
+
             switch returndatasize()
                 // Non-standard ERC20 transfer without return.
                 case 0 {
+                    // NOTE: When the return data size is 0, verify that there
+                    // is code at the address. This is done in order to maintain
+                    // compatibility with Solidity calling conventions.
+                    // <https://docs.soliditylang.org/en/v0.7.6/control-structures.html#external-function-calls>
+                    if iszero(extcodesize(token)) {
+                        revertWithMessage(20, "GPv2: not a contract")
+                    }
+
                     success := 1
                 }
                 // Standard ERC20 transfer returning boolean success value.
@@ -101,10 +127,8 @@ library GPv2SafeERC20 {
                     success := iszero(iszero(mload(0)))
                 }
                 default {
-                    badReturnSize := 1
+                    revertWithMessage(31, "GPv2: malformed transfer result")
                 }
         }
-
-        require(!badReturnSize, "GPv2: malformed transfer result");
     }
 }

--- a/src/contracts/libraries/GPv2SafeERC20.sol
+++ b/src/contracts/libraries/GPv2SafeERC20.sol
@@ -72,7 +72,11 @@ library GPv2SafeERC20 {
     /// @dev Verifies that the last return was a successful `transfer*` call.
     /// This is done by checking that the return data is either empty, or
     /// is a valid ABI encoded boolean.
-    function getLastTansferResult(IERC20 token) private view returns (bool success) {
+    function getLastTansferResult(IERC20 token)
+        private
+        view
+        returns (bool success)
+    {
         // NOTE: Inspecting previous return data requires assembly. Note that
         // we write the return data to memory 0 in the case where the return
         // data size is 32, this is OK since the first 64 bytes of memory are

--- a/test/GPv2SafeERC20.test.ts
+++ b/test/GPv2SafeERC20.test.ts
@@ -111,12 +111,12 @@ describe("GPv2SafeERC20.sol", () => {
       });
     });
 
-    it("does not revert when calling a non-contract", async () => {
+    it("reverts when calling a non-contract", async () => {
       const amount = ethers.utils.parseEther("4.2");
 
       await expect(
         executor.transfer(traders[1].address, recipient.address, amount),
-      ).not.to.be.reverted;
+      ).to.be.revertedWith("not a contract");
     });
   });
 
@@ -239,7 +239,7 @@ describe("GPv2SafeERC20.sol", () => {
       });
     });
 
-    it("does not revert when calling a non-contract", async () => {
+    it("reverts when calling a non-contract", async () => {
       const amount = ethers.utils.parseEther("4.2");
 
       await expect(
@@ -249,7 +249,7 @@ describe("GPv2SafeERC20.sol", () => {
           recipient.address,
           amount,
         ),
-      ).not.to.be.reverted;
+      ).to.be.revertedWith("not a contract");
     });
   });
 });

--- a/test/GPv2TradeExecution.test.ts
+++ b/test/GPv2TradeExecution.test.ts
@@ -68,7 +68,7 @@ describe("GPv2TradeExecution", () => {
       ).to.be.revertedWith("test error");
     });
 
-    it("does not revert when transfering a token with no contract at its address", async () => {
+    it("reverts when transfering a token with no contract at its address", async () => {
       await expect(
         tradeExecution.transferSellAmountToRecipientTest(
           {
@@ -79,7 +79,7 @@ describe("GPv2TradeExecution", () => {
           },
           recipient.address,
         ),
-      ).not.to.be.reverted;
+      ).to.be.revertedWith("not a contract");
     });
 
     it("reverts when mistakenly trying to sell ETH using the marker buy Ether address", async () => {
@@ -162,7 +162,7 @@ describe("GPv2TradeExecution", () => {
       ).to.be.revertedWith("test error");
     });
 
-    it("should not revert when transfering from a token with no contract at its address", async () => {
+    it("reverts when transfering from a token with no contract at its address", async () => {
       await expect(
         tradeExecution.transferBuyAmountToOwnerTest({
           owner: traders[0].address,
@@ -171,7 +171,7 @@ describe("GPv2TradeExecution", () => {
           buyAmount: ethers.utils.parseEther("1.0"),
           ...withoutSell,
         }),
-      ).not.to.be.reverted;
+      ).to.be.revertedWith("not a contract");
     });
 
     it("should transfer Ether to receiver if the marker address is used", async () => {


### PR DESCRIPTION
This PR adjusts our SafeERC20 library to revert on calls to non-contracts. It is optimized to only perform a check in the cases where the `transfer` returns no return data (as a non-zero return data size implies code at the address). This allows us to not incur any overhead when interacting with standards compliant ERC20 implementations :tada:  while still [conforming to Solidity calling conventions](https://docs.soliditylang.org/en/v0.7.6/control-structures.html?highlight=extcodesize#external-function-calls).

Note that this doesn't protect against mistakenly calling pre-compiles, but the risk of a user signing an order for a bad token is much lower if the address is `0x000...000n`.

### Test Plan

Adjusted unit tests to account for new revert.

<details><summary>Benchmarks show a tiny decrease in gas usage (~10) due to refactor <b>when using standard compliant ERC20 implementations</b></summary>

```
=== Settlement Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
       tokens |       trades | interactions |      refunds |          gas 
--------------+--------------+--------------+--------------+--------------
            2 |           10 |            0 |            0 |       751147  (change: -11 / trade)
            3 |           10 |            0 |            0 |       755903  (change: -11 / trade)
            4 |           10 |            0 |            0 |       760647  (change: -12 / trade)
            5 |           10 |            0 |            0 |       765355  (change: -10 / trade)
            6 |           10 |            0 |            0 |       770087  (change: -11 / trade)
            7 |           10 |            0 |            0 |       774819  (change: -11 / trade)
            8 |           10 |            0 |            0 |       779515  (change: -4 / trade)
            8 |           20 |            0 |            0 |      1465043  (change: -8 / trade)
            8 |           30 |            0 |            0 |      2128904  (change: -12 / trade)
            8 |           40 |            0 |            0 |      2793486  (change: -13 / trade)
            8 |           50 |            0 |            0 |      3457743  (change: -8 / trade)
            8 |           60 |            0 |            0 |      4122722  (change: -9 / trade)
            8 |           70 |            0 |            0 |      4787729  (change: -9 / trade)
            8 |           80 |            0 |            0 |      5452798  (change: -10 / trade)
            2 |           10 |            1 |            0 |       822571  (change: -11 / trade)
            2 |           10 |            2 |            0 |       869235  (change: -11 / trade)
            2 |           10 |            3 |            0 |       915875  (change: -12 / trade)
            2 |           10 |            4 |            0 |       962539  (change: -7 / trade)
            2 |           10 |            5 |            0 |      1009191  (change: -11 / trade)
            2 |           10 |            6 |            0 |      1055831  (change: -8 / trade)
            2 |           10 |            7 |            0 |      1102483  (change: -12 / trade)
            2 |           10 |            8 |            0 |      1149147  (change: -8 / trade)
            2 |           50 |            0 |           10 |      3127950  (change: -9 / trade)
            2 |           50 |            0 |           15 |      3087162  (change: -9 / trade)
            2 |           50 |            0 |           20 |      3046314  (change: -8 / trade)
            2 |           50 |            0 |           25 |      3005346  (change: -9 / trade)
            2 |           50 |            0 |           30 |      2964594  (change: -9 / trade)
            2 |           50 |            0 |           35 |      2923626  (change: -6 / trade)
            2 |           50 |            0 |           40 |      2882766  (change: -11 / trade)
            2 |           50 |            0 |           45 |      2841906  (change: -10 / trade)
            2 |           50 |            0 |           50 |      2800998  (change: -10 / trade)
            2 |            2 |            0 |            0 |       186398  (change: -16 / trade)
            2 |            1 |            1 |            0 |       187132  (change: -10 / trade)
           10 |          100 |           10 |           20 |      6606118  (change: -9 / trade)
```

</details>
