### PR TITLE
Refactor solver allow list

### DIFF
--- a/src/contracts/GPv2AllowListAuthentication.sol
+++ b/src/contracts/GPv2AllowListAuthentication.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.7.6;
 
 import "@gnosis.pm/util-contracts/contracts/StorageAccessible.sol";
 import "@openzeppelin/contracts/proxy/Initializable.sol";
-import "@openzeppelin/contracts/utils/EnumerableSet.sol";
 import "./interfaces/GPv2Authentication.sol";
 import "./libraries/GPv2EIP1967.sol";
 
@@ -14,21 +13,47 @@ contract GPv2AllowListAuthentication is
     Initializable,
     StorageAccessible
 {
-    using EnumerableSet for EnumerableSet.AddressSet;
-
+    /// @dev The address of the manager that has permissions to add and remove
+    /// solvers.
     address public manager;
 
-    EnumerableSet.AddressSet private solvers;
+    /// @dev The set of allowed solvers. Allowed solvers have a value of `true`
+    /// in this mapping.
+    mapping(address => bool) private solvers;
 
+    /// @dev Event emitted when a solver gets added.
+    event ManagerChanged(address newManager, address oldManager);
+
+    /// @dev Event emitted when a solver gets added.
+    event SolverAdded(address solver);
+
+    /// @dev Event emitted when a solver gets removed.
+    event SolverRemoved(address solver);
+
+    /// @dev Initialize the manager to a value.
+    ///
+    /// This method is a contract initializer that is called exactly once after
+    /// creation. An initializer is used instead of a constructor so that this
+    /// contract can be used behind a proxy.
+    ///
+    /// @param manager_ The manager to initialize the contract with.
     function initializeManager(address manager_) external initializer {
         manager = manager_;
+        emit ManagerChanged(manager_, address(0));
     }
 
+    /// @dev Modifier that ensures a method can only be called by the contract
+    /// manager. Reverts if called by other addresses.
     modifier onlyManager() {
         require(manager == msg.sender, "GPv2: caller not manager");
         _;
     }
 
+    /// @dev Modifier that ensures method can be either called by the contract
+    /// manager or the proxy owner.
+    ///
+    /// This modifier assumes that the proxy uses an EIP-1967 compliant storage
+    /// slot for the admin.
     modifier onlyManagerOrOwner() {
         require(
             manager == msg.sender || GPv2EIP1967.getAdmin() == msg.sender,
@@ -37,24 +62,44 @@ contract GPv2AllowListAuthentication is
         _;
     }
 
+    /// @dev Set the manager for this contract.
+    ///
+    /// This method can be called by the current manager (if they want to to
+    /// reliquish the role and give it to another address) or the contract
+    /// owner (i.e. the proxy admin).
+    ///
+    /// @param manager_ The new contract manager address.
     function setManager(address manager_) external onlyManagerOrOwner {
+        address oldManager = manager;
         manager = manager_;
+        emit ManagerChanged(manager_, oldManager);
     }
 
+    /// @dev Add an address to the set of allowed solvers. This method can only
+    /// be called by the contract manager.
+    ///
+    /// @param solver The solver address to add.
     function addSolver(address solver) external onlyManager {
-        solvers.add(solver);
+        solvers[solver] = true;
+        emit SolverAdded(solver);
     }
 
+    /// @dev Removes an address to the set of allowed solvers. This method can
+    /// only be called by the contract manager.
+    ///
+    /// @param solver The solver address to remove.
     function removeSolver(address solver) external onlyManager {
-        solvers.remove(solver);
+        solvers[solver] = false;
+        emit SolverRemoved(solver);
     }
 
+    /// @inheritdoc GPv2Authentication
     function isSolver(address prospectiveSolver)
         external
         view
         override
         returns (bool)
     {
-        return solvers.contains(prospectiveSolver);
+        return solvers[prospectiveSolver];
     }
 }

--- a/src/contracts/GPv2AllowListAuthentication.sol
+++ b/src/contracts/GPv2AllowListAuthentication.sol
@@ -36,6 +36,8 @@ contract GPv2AllowListAuthentication is
     /// creation. An initializer is used instead of a constructor so that this
     /// contract can be used behind a proxy.
     ///
+    /// This initializer is idempotent.
+    ///
     /// @param manager_ The manager to initialize the contract with.
     function initializeManager(address manager_) external initializer {
         manager = manager_;
@@ -78,6 +80,8 @@ contract GPv2AllowListAuthentication is
     /// @dev Add an address to the set of allowed solvers. This method can only
     /// be called by the contract manager.
     ///
+    /// This function is idempotent.
+    ///
     /// @param solver The solver address to add.
     function addSolver(address solver) external onlyManager {
         solvers[solver] = true;
@@ -86,6 +90,8 @@ contract GPv2AllowListAuthentication is
 
     /// @dev Removes an address to the set of allowed solvers. This method can
     /// only be called by the contract manager.
+    ///
+    /// This function is idempotent.
     ///
     /// @param solver The solver address to remove.
     function removeSolver(address solver) external onlyManager {

--- a/src/contracts/reader/AllowListStorageReader.sol
+++ b/src/contracts/reader/AllowListStorageReader.sol
@@ -1,23 +1,22 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 pragma solidity ^0.7.6;
 
-import "@gnosis.pm/util-contracts/contracts/StorageAccessible.sol";
-import "@openzeppelin/contracts/utils/EnumerableSet.sol";
-import "../GPv2AllowListAuthentication.sol";
-
 /// @title Gnosis Protocol v2 Allow List Storage Reader
 /// @author Gnosis Developers
 contract AllowListStorageReader {
-    using EnumerableSet for EnumerableSet.AddressSet;
+    address private manager;
+    mapping(address => bool) private solvers;
 
-    address private _owner;
-    EnumerableSet.AddressSet private solvers;
-
-    function getSolverAt(uint256 index) external view returns (address) {
-        return solvers.at(index);
-    }
-
-    function numSolvers() external view returns (uint256) {
-        return solvers.length();
+    function areSolvers(address[] calldata prospectiveSolvers)
+        external
+        view
+        returns (bool)
+    {
+        for (uint256 i = 0; i < prospectiveSolvers.length; i++) {
+            if (!solvers[prospectiveSolvers[i]]) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/src/ts/reader.ts
+++ b/src/ts/reader.ts
@@ -1,10 +1,8 @@
-import { BigNumber, BigNumberish, BytesLike, Contract } from "ethers";
+import { BigNumber, BytesLike, Contract } from "ethers";
 
-type AllowListReaderMethods = "getSolverAt" | "numSolvers";
-type AllowListReaderParameters<M> = M extends "getSolverAt"
-  ? [BigNumberish]
-  : M extends "numSolvers"
-  ? []
+type AllowListReaderMethods = "areSolvers";
+type AllowListReaderParameters<M> = M extends "areSolvers"
+  ? [BytesLike[]]
   : never;
 
 type SettlementReaderMethods = "filledAmountsForOrders";
@@ -52,17 +50,10 @@ export class AllowListReader {
   ) {}
 
   /**
-   * Read the address of the solver at the specified index.
+   * Returns true if all the specified addresses are allowed solvers.
    */
-  public getSolverAt(index: number): Promise<string> {
-    return readStorage(this.allowList, this.reader, "getSolverAt", [index]);
-  }
-
-  /**
-   * Read the total number of authorized solvers in the allow list contract.
-   */
-  public numSolvers(): Promise<number> {
-    return readStorage(this.allowList, this.reader, "numSolvers", []);
+  public areSolvers(solvers: BytesLike[]): Promise<string> {
+    return readStorage(this.allowList, this.reader, "areSolvers", [solvers]);
   }
 }
 


### PR DESCRIPTION
This PR refactors the solver allow list contract to no longer make use of the `EnumerableSet` library. The main motivations behind this change are:
- We would like to vendor our dependencies used in the Settlement contract in tree (this is to avoid package bumps leading to code changes) and this removes one 300-line dependency.
- We don't need to enumerate solvers on-chain (as we may want to enumerate them off-chain, log events were added to facilitate this).

I also took this opportunity to add doc-comments to all the methods.

### Test Plan

Adjusted unit tests and added new ones for emitted events.
