### PR TITLE
Refactor Uniswap library to enable mocked pairs for unit tests

### DIFF
--- a/src/contracts/GPv2UniswapRouter.sol
+++ b/src/contracts/GPv2UniswapRouter.sol
@@ -14,7 +14,7 @@ import "./uniswap/UniswapV2Library.sol";
 
 /// @title Gnosis Protocol v2 Uniswap Router
 /// @author Gnosis Developers
-contract GPv2UniswapRouter {
+contract GPv2UniswapRouter is UniswapV2Library {
     using GPv2Trade for uint256;
     using SafeMath for uint256;
 
@@ -43,11 +43,7 @@ contract GPv2UniswapRouter {
         transfer.target = address(path[0]);
         transfer.callData = abi.encodeWithSelector(
             IERC20.transfer.selector,
-            UniswapV2Library.pairFor(
-                address(factory),
-                address(path[0]),
-                address(path[1])
-            ),
+            pairFor(address(factory), address(path[0]), address(path[1])),
             amounts[0]
         );
     }

--- a/src/contracts/test/GPv2UniswapRouterTestInterface.sol
+++ b/src/contracts/test/GPv2UniswapRouterTestInterface.sol
@@ -12,6 +12,22 @@ contract GPv2UniswapRouterTestInterface is GPv2UniswapRouter {
 
     }
 
+    function pairFor(
+        address factory_,
+        address tokenA,
+        address tokenB
+    ) internal view override returns (address pair) {
+        // NOTE: We setup the mock in such a way that if `address(0)` is
+        // returned, then the Uniswap pair `CREATE2` address is computed so it
+        // can be tested. However, setting up the mock to return different
+        // pairs for certain token addresses allows us to do a full unit test
+        // with mocked Uniswap pairs.
+        pair = IUniswapV2Factory(factory_).getPair(tokenA, tokenB);
+        if (pair == address(0)) {
+            pair = UniswapV2Library.pairFor(factory_, tokenA, tokenB);
+        }
+    }
+
     function transferInteractionTest(
         IERC20[] calldata path,
         uint256[] memory amounts

--- a/src/contracts/uniswap/UniswapV2Library.sol
+++ b/src/contracts/uniswap/UniswapV2Library.sol
@@ -5,6 +5,7 @@
 // - Modified Solidity version
 // - Formatted code
 // - Shortened revert messages
+// - Converted to an abstract contract for testing
 // <https://github.com/Uniswap/uniswap-v2-core/blob/v1.0.1/contracts/interfaces/IUniswapV2Factory.sol>
 
 pragma solidity ^0.7.6;
@@ -12,7 +13,7 @@ pragma solidity ^0.7.6;
 import "../libraries/SafeMath.sol";
 import "./IUniswapV2Pair.sol";
 
-library UniswapV2Library {
+abstract contract UniswapV2Library {
     using SafeMath for uint256;
 
     // returns sorted token addresses, used to handle return values from pairs sorted in this order
@@ -33,7 +34,7 @@ library UniswapV2Library {
         address factory,
         address tokenA,
         address tokenB
-    ) internal pure returns (address pair) {
+    ) internal view virtual returns (address pair) {
         (address token0, address token1) = sortTokens(tokenA, tokenB);
         pair = address(
             uint256(

--- a/test/GPv2UniswapRouter.test.ts
+++ b/test/GPv2UniswapRouter.test.ts
@@ -23,6 +23,7 @@ describe("GPv2UniswapRouter", () => {
       deployer,
       UniswapV2Factory.abi,
     );
+    uniswapFactory.mock.getPair.returns(ethers.constants.AddressZero);
 
     const GPv2UniswapRouter = await ethers.getContractFactory(
       "GPv2UniswapRouterTestInterface",

--- a/test/GPv2UniswapRouter.test.ts
+++ b/test/GPv2UniswapRouter.test.ts
@@ -23,7 +23,7 @@ describe("GPv2UniswapRouter", () => {
       deployer,
       UniswapV2Factory.abi,
     );
-    uniswapFactory.mock.getPair.returns(ethers.constants.AddressZero);
+    await uniswapFactory.mock.getPair.returns(ethers.constants.AddressZero);
 
     const GPv2UniswapRouter = await ethers.getContractFactory(
       "GPv2UniswapRouterTestInterface",


### PR DESCRIPTION
This PR just adds support for specified mock Uniswap pairs for unit tests :tada:. This will be used in a follow up PR.

### Test Plan

N/A
