### PR TITLE
Add method for encoding a single Uniswap pair swap

### DIFF
--- a/src/contracts/test/GPv2UniswapRouterTestInterface.sol
+++ b/src/contracts/test/GPv2UniswapRouterTestInterface.sol
@@ -34,4 +34,13 @@ contract GPv2UniswapRouterTestInterface is GPv2UniswapRouter {
     ) external view returns (GPv2Interaction.Data memory transfer) {
         transferInteraction(path, amounts, transfer);
     }
+
+    function swapInteractionTest(
+        IERC20 tokenIn,
+        IERC20 tokenOut,
+        uint256 amountOut,
+        address to
+    ) external view returns (GPv2Interaction.Data memory swap) {
+        swapInteraction(tokenIn, tokenOut, amountOut, to, swap);
+    }
 }

--- a/src/contracts/uniswap/UniswapV2Library.sol
+++ b/src/contracts/uniswap/UniswapV2Library.sol
@@ -5,7 +5,7 @@
 // - Modified Solidity version
 // - Formatted code
 // - Shortened revert messages
-// - Converted to an abstract contract for testing
+// - Converted to an abstract contract with virtual `pairFor` for testing
 // <https://github.com/Uniswap/uniswap-v2-core/blob/v1.0.1/contracts/interfaces/IUniswapV2Factory.sol>
 
 pragma solidity ^0.7.6;


### PR DESCRIPTION
This PR adds a method for encoding a UniswapV2Pair swap as an interaction for given input and output tokens and amount.

### Test Plan

Added unit tests.
