### PR TITLE
Add on-chain Uniswap price calculation

### DIFF
--- a/src/contracts/GPv2UniswapRouter.sol
+++ b/src/contracts/GPv2UniswapRouter.sol
@@ -29,6 +29,62 @@ contract GPv2UniswapRouter is UniswapV2Library {
         factory = factory_;
     }
 
+    /// @dev Execute a GPv2 settlement with a single trade against a Uniswap
+    /// path.
+    ///
+    /// This method performs no input validation, instead it performs on-chain
+    /// computation of the swap amounts in order to encode interactions and set
+    /// clearing prices such as the trader receives positive slippage. Verifying
+    /// the signature and validity of the trade (limit prices, expiry, etc.) is
+    /// done by the settlement contract.
+    ///
+    /// @param path The Uniswap route for trading.
+    /// @param trade The GPv2 trade to execute.
+    function settleSwap(IERC20[] calldata path, GPv2Trade.Data calldata trade)
+        external
+    {
+        uint256 tokenCount = path.length;
+        require(tokenCount > 1, "GPv2: invalid path");
+        require(
+            trade.sellTokenIndex == 0 && trade.buyTokenIndex == tokenCount - 1,
+            "GPv2: invalid trade for path"
+        );
+
+        uint256[] memory amounts;
+        {
+            (bytes32 kind, , ) = trade.flags.extractFlags();
+            amounts = kind == GPv2Order.SELL
+                ? getAmountsOut(factory, trade.sellAmount, path)
+                : getAmountsIn(factory, trade.buyAmount, path);
+        }
+
+        uint256[] memory prices = new uint256[](tokenCount);
+        prices[0] = amounts[tokenCount - 1];
+        prices[tokenCount - 1] = amounts[0];
+
+        GPv2Trade.Data[] memory trades = new GPv2Trade.Data[](1);
+        trades[0] = trade;
+
+        GPv2Interaction.Data[][3] memory interactions;
+        {
+            GPv2Interaction.Data[] memory intra =
+                new GPv2Interaction.Data[](tokenCount);
+
+            transferInteraction(path, amounts, intra[0]);
+            for (uint256 i = 1; i < tokenCount; i++) {
+                (IERC20 tokenIn, IERC20 tokenOut) = (path[i - 1], path[i]);
+                address to =
+                    i < tokenCount - 1
+                        ? address(pairFor(factory, tokenOut, path[i + 1]))
+                        : address(settlement);
+                swapInteraction(tokenIn, tokenOut, amounts[i], to, intra[i]);
+            }
+            interactions[1] = intra;
+        }
+
+        settlement.settle(path, prices, trades, interactions);
+    }
+
     /// @dev Encode the transfer interaction used for sending ERC20 tokens to
     /// the first Uniswap pair in a path to kick off the swaps.
     ///
@@ -43,7 +99,7 @@ contract GPv2UniswapRouter is UniswapV2Library {
         transfer.target = address(path[0]);
         transfer.callData = abi.encodeWithSelector(
             IERC20.transfer.selector,
-            pairFor(path[0], path[1]),
+            pairFor(factory, path[0], path[1]),
             amounts[0]
         );
     }
@@ -62,31 +118,18 @@ contract GPv2UniswapRouter is UniswapV2Library {
         address to,
         GPv2Interaction.Data memory swap
     ) internal view {
-        (address token0, ) = sortTokens(address(tokenIn), address(tokenOut));
+        (IERC20 token0, ) = sortTokens(tokenIn, tokenOut);
         (uint256 amount0Out, uint256 amount1Out) =
-            address(tokenIn) == token0
+            tokenIn == token0
                 ? (uint256(0), amountOut)
                 : (amountOut, uint256(0));
-        swap.target = address(pairFor(tokenIn, tokenOut));
+        swap.target = address(pairFor(factory, tokenIn, tokenOut));
         swap.callData = abi.encodeWithSelector(
             IUniswapV2Pair.swap.selector,
             amount0Out,
             amount1Out,
             to,
             bytes("")
-        );
-    }
-
-    /// @dev Internal helper function used for calling the `UniswapV2Library`
-    /// `pairFor` method with the global `factory` value and cast interfaces to
-    /// `address`es.
-    function pairFor(IERC20 tokenA, IERC20 tokenB)
-        private
-        view
-        returns (IUniswapV2Pair pair)
-    {
-        pair = IUniswapV2Pair(
-            pairFor(address(factory), address(tokenA), address(tokenB))
         );
     }
 }

--- a/src/contracts/GPv2UniswapRouter.sol
+++ b/src/contracts/GPv2UniswapRouter.sol
@@ -69,6 +69,7 @@ contract GPv2UniswapRouter is UniswapV2Library {
         {
             GPv2Interaction.Data[] memory intra =
                 new GPv2Interaction.Data[](tokenCount);
+            interactions[1] = intra;
 
             transferInteraction(path, amounts, intra[0]);
             for (uint256 i = 1; i < tokenCount; i++) {
@@ -79,7 +80,6 @@ contract GPv2UniswapRouter is UniswapV2Library {
                         : address(settlement);
                 swapInteraction(tokenIn, tokenOut, amounts[i], to, intra[i]);
             }
-            interactions[1] = intra;
         }
 
         settlement.settle(path, prices, trades, interactions);

--- a/src/contracts/test/GPv2UniswapRouterTestInterface.sol
+++ b/src/contracts/test/GPv2UniswapRouterTestInterface.sol
@@ -13,17 +13,19 @@ contract GPv2UniswapRouterTestInterface is GPv2UniswapRouter {
     }
 
     function pairFor(
-        address factory_,
-        address tokenA,
-        address tokenB
-    ) internal view override returns (address pair) {
+        IUniswapV2Factory factory_,
+        IERC20 tokenA,
+        IERC20 tokenB
+    ) internal view override returns (IUniswapV2Pair pair) {
         // NOTE: We setup the mock in such a way that if `address(0)` is
         // returned, then the Uniswap pair `CREATE2` address is computed so it
         // can be tested. However, setting up the mock to return different
         // pairs for certain token addresses allows us to do a full unit test
         // with mocked Uniswap pairs.
-        pair = IUniswapV2Factory(factory_).getPair(tokenA, tokenB);
-        if (pair == address(0)) {
+        pair = IUniswapV2Pair(
+            factory_.getPair(address(tokenA), address(tokenB))
+        );
+        if (address(pair) == address(0)) {
             pair = UniswapV2Library.pairFor(factory_, tokenA, tokenB);
         }
     }

--- a/test/GPv2UniswapRouter.test.ts
+++ b/test/GPv2UniswapRouter.test.ts
@@ -1,7 +1,9 @@
 import { expect } from "chai";
 import { MockContract } from "ethereum-waffle";
-import { Contract, utils } from "ethers";
+import { BigNumber, BigNumberish, Contract, utils } from "ethers";
 import { artifacts, ethers, waffle } from "hardhat";
+
+import { OrderKind, SigningScheme, Trade, encodeTradeFlags } from "../src/ts";
 
 function fillAddress(byte: number): string {
   return ethers.utils.hexlify([...Array(20)].map(() => byte));
@@ -12,12 +14,36 @@ async function interfaceFor(name: string): Promise<utils.Interface> {
   return new ethers.utils.Interface(abi);
 }
 
+function getAmountOut(
+  amountIn: BigNumber,
+  reserveIn: BigNumber,
+  reserveOut: BigNumber,
+): BigNumber {
+  const amountInWithFee = amountIn.mul(997);
+  const numerator = amountInWithFee.mul(reserveOut);
+  const denominator = reserveIn.mul(1000).add(amountInWithFee);
+  return numerator.div(denominator);
+}
+
+function getAmountIn(
+  amountOut: BigNumber,
+  reserveIn: BigNumber,
+  reserveOut: BigNumber,
+): BigNumber {
+  const numerator = reserveIn.mul(amountOut).mul(1000);
+  const denominator = reserveOut.sub(amountOut).mul(997);
+  return numerator.div(denominator).add(1);
+}
+
 describe("GPv2UniswapRouter", () => {
   const [deployer] = waffle.provider.getWallets();
 
   let settlement: MockContract;
   let uniswapFactory: MockContract;
   let uniswapRouter: Contract;
+
+  let IERC20: utils.Interface;
+  let IUniswapV2Pair: utils.Interface;
 
   beforeEach(async () => {
     const GPv2Settlement = await artifacts.readArtifact("GPv2Settlement");
@@ -37,6 +63,9 @@ describe("GPv2UniswapRouter", () => {
       settlement.address,
       uniswapFactory.address,
     );
+
+    IERC20 = await interfaceFor("src/contracts/interfaces/IERC20.sol:IERC20");
+    IUniswapV2Pair = await interfaceFor("IUniswapV2Pair");
   });
 
   describe("settlement", () => {
@@ -51,12 +80,14 @@ describe("GPv2UniswapRouter", () => {
     });
   });
 
-  function pairFor(tokenA: string, tokenB: string): string {
-    const [token0, token1] =
-      tokenA.toLowerCase() < tokenB.toLowerCase()
-        ? [tokenA, tokenB]
-        : [tokenB, tokenA];
+  function sortTokens(tokenA: string, tokenB: string): [string, string] {
+    return tokenA.toLowerCase() < tokenB.toLowerCase()
+      ? [tokenA, tokenB]
+      : [tokenB, tokenA];
+  }
 
+  function pairFor(tokenA: string, tokenB: string): string {
+    const [token0, token1] = sortTokens(tokenA, tokenB);
     return ethers.utils.getAddress(
       ethers.utils.hexDataSlice(
         ethers.utils.solidityKeccak256(
@@ -76,11 +107,259 @@ describe("GPv2UniswapRouter", () => {
     );
   }
 
+  async function deployMockPair(
+    tokenA: string,
+    tokenB: string,
+  ): Promise<MockContract> {
+    const { abi } = await artifacts.readArtifact("IUniswapV2Pair");
+    const pair = await waffle.deployMockContract(deployer, abi);
+    await uniswapFactory.mock.getPair
+      .withArgs(tokenA, tokenB)
+      .returns(pair.address);
+    await uniswapFactory.mock.getPair
+      .withArgs(tokenB, tokenA)
+      .returns(pair.address);
+
+    return pair;
+  }
+
+  describe("settleSwap", () => {
+    function sampleTrade({
+      kind,
+      ...flags
+    }: {
+      kind: OrderKind;
+      sellTokenIndex: number;
+      buyTokenIndex: number;
+      sellAmount: BigNumberish;
+      buyAmount: BigNumberish;
+    }): Trade {
+      return {
+        receiver: ethers.constants.AddressZero,
+        validTo: 0xffffffff,
+        appData: `0x${"beefc0de".repeat(8)}`,
+        feeAmount: ethers.utils.parseEther("0.1337"),
+        flags: encodeTradeFlags({
+          kind,
+          partiallyFillable: false,
+          signingScheme: SigningScheme.EIP712,
+        }),
+        executedAmount: 0,
+        signature: `0x${"51".repeat(65)}`,
+        ...flags,
+      };
+    }
+
+    it("reverts for paths without at least two tokens", async () => {
+      await expect(
+        uniswapRouter.settleSwap(
+          [fillAddress(1)],
+          sampleTrade({
+            kind: OrderKind.SELL,
+            sellTokenIndex: 0,
+            buyTokenIndex: 0,
+            sellAmount: ethers.constants.Zero,
+            buyAmount: ethers.constants.Zero,
+          }),
+        ),
+      ).to.be.revertedWith("invalid path");
+    });
+
+    it("reverts for trades that do not correspond to specified path", async () => {
+      await expect(
+        uniswapRouter.settleSwap(
+          [fillAddress(1), fillAddress(2)],
+          sampleTrade({
+            kind: OrderKind.SELL,
+            // NOTE: The trade is going in the opposite direction of the path.
+            sellTokenIndex: 1,
+            buyTokenIndex: 0,
+            sellAmount: ethers.constants.Zero,
+            buyAmount: ethers.constants.Zero,
+          }),
+        ),
+      ).to.be.revertedWith("invalid trade for path");
+    });
+
+    it("executes a GPv2 settlement", async () => {
+      const pair = await deployMockPair(fillAddress(1), fillAddress(2));
+      const [reserveSell, reserveBuy] = [
+        ethers.utils.parseEther("200000.0"),
+        ethers.utils.parseEther("100.0"),
+      ];
+
+      const sellAmount = ethers.utils.parseEther("1.0");
+      const amountOut = getAmountOut(sellAmount, reserveSell, reserveBuy);
+
+      const trade = sampleTrade({
+        kind: OrderKind.SELL,
+        sellTokenIndex: 0,
+        buyTokenIndex: 1,
+        sellAmount,
+        buyAmount: ethers.utils.parseEther("0.0003"),
+      });
+
+      await pair.mock.getReserves.returns(reserveSell, reserveBuy, 0);
+      await settlement.mock.settle
+        .withArgs(
+          [fillAddress(1), fillAddress(2)],
+          [amountOut, sellAmount],
+          [trade],
+          [
+            [],
+            [
+              {
+                target: fillAddress(1),
+                value: ethers.constants.Zero,
+                callData: IERC20.encodeFunctionData("transfer", [
+                  pair.address,
+                  sellAmount,
+                ]),
+              },
+              {
+                target: pair.address,
+                value: ethers.constants.Zero,
+                callData: IUniswapV2Pair.encodeFunctionData("swap", [
+                  0,
+                  amountOut,
+                  settlement.address,
+                  "0x",
+                ]),
+              },
+            ],
+            [],
+          ],
+        )
+        .returns();
+
+      await expect(
+        uniswapRouter.settleSwap([fillAddress(1), fillAddress(2)], trade),
+      ).to.not.be.reverted;
+    });
+
+    describe("Swap Amounts", () => {
+      const path = [fillAddress(1), fillAddress(42), fillAddress(2)];
+      const pairReserves = [
+        {
+          reserve0: ethers.utils.parseEther("100.0"), // T1
+          reserve1: ethers.utils.parseEther("200.0"), // T42
+        },
+        {
+          reserve0: ethers.utils.parseEther("300.0"), // T2
+          reserve1: ethers.utils.parseEther("400.0"), // T42
+        },
+      ];
+
+      const sellAmount = ethers.utils.parseEther("1.0");
+      const buyAmount = ethers.utils.parseEther("1.0");
+
+      async function swapWithAmounts(kind: OrderKind, amounts: BigNumber[]) {
+        const trade = sampleTrade({
+          kind,
+          sellTokenIndex: 0,
+          buyTokenIndex: 2,
+          sellAmount,
+          buyAmount,
+        });
+
+        const pairs: MockContract[] = [];
+        for (const [i, { reserve0, reserve1 }] of pairReserves.entries()) {
+          const [tokenIn, tokenOut] = path.slice(i);
+          const pair = await deployMockPair(tokenIn, tokenOut);
+          await pair.mock.getReserves.returns(reserve0, reserve1, 0);
+
+          pairs.push(pair);
+        }
+
+        await settlement.mock.settle
+          .withArgs(
+            path,
+            [amounts[amounts.length - 1], 0, amounts[0]],
+            [trade],
+            [
+              [],
+              [
+                {
+                  target: path[0],
+                  value: ethers.constants.Zero,
+                  callData: IERC20.encodeFunctionData("transfer", [
+                    pairs[0].address,
+                    amounts[0],
+                  ]),
+                },
+                ...pairs.map((pair, i) => {
+                  const [tokenIn, tokenOut] = path.slice(i);
+                  const [token0] = sortTokens(tokenIn, tokenOut);
+                  return {
+                    target: pair.address,
+                    value: ethers.constants.Zero,
+                    callData: IUniswapV2Pair.encodeFunctionData("swap", [
+                      tokenIn == token0 ? 0 : amounts[i + 1],
+                      tokenIn == token0 ? amounts[i + 1] : 0,
+                      (pairs[i + 1] ?? settlement).address,
+                      "0x",
+                    ]),
+                  };
+                }),
+              ],
+              [],
+            ],
+          )
+          .returns();
+
+        return uniswapRouter.settleSwap(path, trade);
+      }
+
+      it("computes correct swap amounts for sell orders", async () => {
+        const intermediateAmount = getAmountOut(
+          sellAmount,
+          pairReserves[0].reserve0,
+          pairReserves[0].reserve1,
+        );
+        const executedBuyAmount = getAmountOut(
+          intermediateAmount,
+          // NOTE: The second hop has tokens in reverse sorting order, so make
+          // sure to adjust reserves accordingly.
+          pairReserves[1].reserve1,
+          pairReserves[1].reserve0,
+        );
+
+        await expect(
+          swapWithAmounts(OrderKind.SELL, [
+            sellAmount,
+            intermediateAmount,
+            executedBuyAmount,
+          ]),
+        ).to.not.be.reverted;
+      });
+
+      it("computes correct swap amounts for buy orders", async () => {
+        const intermediateAmount = getAmountIn(
+          buyAmount,
+          // NOTE: The second hop has tokens in reverse sorting order, so make
+          // sure to adjust reserves accordingly.
+          pairReserves[1].reserve1,
+          pairReserves[1].reserve0,
+        );
+        const executedSellAmount = getAmountIn(
+          intermediateAmount,
+          pairReserves[0].reserve0,
+          pairReserves[0].reserve1,
+        );
+
+        await expect(
+          swapWithAmounts(OrderKind.BUY, [
+            executedSellAmount,
+            intermediateAmount,
+            buyAmount,
+          ]),
+        ).to.not.be.reverted;
+      });
+    });
+  });
+
   describe("transferInteraction", () => {
     it("should encode a transfer for the first swap amount of the first token", async () => {
-      const erc20 = await interfaceFor(
-        "src/contracts/interfaces/IERC20.sol:IERC20",
-      );
       const {
         target,
         value,
@@ -93,7 +372,7 @@ describe("GPv2UniswapRouter", () => {
       expect({ target, value, callData }).to.deep.equal({
         target: fillAddress(1),
         value: ethers.constants.Zero,
-        callData: erc20.encodeFunctionData("transfer", [
+        callData: IERC20.encodeFunctionData("transfer", [
           pairFor(fillAddress(1), fillAddress(2)),
           ethers.utils.parseEther("1.0"),
         ]),
@@ -103,7 +382,6 @@ describe("GPv2UniswapRouter", () => {
 
   describe("swapInteraction", () => {
     it("should encode a swap for the given tokens and receiver", async () => {
-      const uniswapPair = await interfaceFor("IUniswapV2Pair");
       const {
         target,
         value,
@@ -118,7 +396,7 @@ describe("GPv2UniswapRouter", () => {
       expect({ target, value, callData }).to.deep.equal({
         target: pairFor(fillAddress(1), fillAddress(2)),
         value: ethers.constants.Zero,
-        callData: uniswapPair.encodeFunctionData("swap", [
+        callData: IUniswapV2Pair.encodeFunctionData("swap", [
           ethers.constants.Zero,
           ethers.utils.parseEther("1.0"),
           fillAddress(3),
@@ -128,7 +406,6 @@ describe("GPv2UniswapRouter", () => {
     });
 
     it("correctly orders the tokens", async () => {
-      const uniswapPair = await interfaceFor("IUniswapV2Pair");
       const { callData } = await uniswapRouter.swapInteractionTest(
         // NOTE: `fillAddress(2) > fillAddress(1)`, this means that the pair's
         // `token0` is `tokenOut` in this case.
@@ -139,7 +416,7 @@ describe("GPv2UniswapRouter", () => {
       );
 
       expect(callData).to.deep.equal(
-        uniswapPair.encodeFunctionData("swap", [
+        IUniswapV2Pair.encodeFunctionData("swap", [
           ethers.utils.parseEther("1.0"),
           ethers.constants.Zero,
           fillAddress(3),


### PR DESCRIPTION
Closes #493 
 
This PR completes the GPv2 Uniswap router code allowing for use of the GPv2 for settling directly with Uniswap V2. With this settlement wrapper contract, it is possible to send a transaction with a token path and an order and have it get settled with the on-chain Uniswap price, where the trade keeps positive slippage :tada:. 

### Test Plan

Added unit tests with mind-bending price calculations. End to end tests and benchmarks will be added in follow up PRs.
