### PR TITLE
Use regular enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v2-contracts",
-  "version": "0.0.1-alpha.15",
+  "version": "0.0.1-alpha.16",
   "license": "LGPL-3.0-or-later",
   "scripts": {
     "deploy": "hardhat deploy",

--- a/src/ts/sign.ts
+++ b/src/ts/sign.ts
@@ -33,7 +33,7 @@ export const PRE_SIGNED = ethers.utils.id("GPv2Signing.Scheme.PreSign");
 /**
  * The signing scheme used to sign the order.
  */
-export const enum SigningScheme {
+export enum SigningScheme {
   /**
    * The EIP-712 typed data signing scheme. This is the preferred scheme as it
    * provides more infomation to wallets performing the signature on the data


### PR DESCRIPTION
This PR just removes the `const enum` usage. While it is nice to have stricter compiler guarantees on enum values, it makes it harder to use it with bundlers.

Also bump the package version so we can make a new release for the FE.

### Test Plan

CI still passes.
