### PR TITLE
Fix router copy-pasta

### DIFF
--- a/src/contracts/GPv2UniswapRouter.sol
+++ b/src/contracts/GPv2UniswapRouter.sol
@@ -67,9 +67,6 @@ contract GPv2UniswapRouter is UniswapV2Library {
                 amounts = getAmountsIn(factory, trade.buyAmount, path);
                 require(limitAmount >= amounts[0], "GPv2: swap in too high");
             }
-            amounts = kind == GPv2Order.SELL
-                ? getAmountsOut(factory, trade.sellAmount, path)
-                : getAmountsIn(factory, trade.buyAmount, path);
         }
 
         GPv2Interaction.Data[][3] memory interactions;


### PR DESCRIPTION
https://github.com/gnosis/gp-v2-contracts/pull/558 accidentally introduced a copy-pasta error which caused the Uniswap route price to be computed twice.

This added significant gas overhead, and removing it already makes us perform better than the standard Uniswap router all the while giving positive slippage to the trader (instead of keeping it in the contract).

```
=== Uniswap Gas Benchmarks ===
--------------+--------------+--------------+--------------+--------------
         hops |     strategy |   batch size |  direct swap |   batch swap 
--------------+--------------+--------------+--------------+--------------
            1 |    gp router |            1 |       112096 |       195181 
            1 |       router |            1 |       112096 |       199102 
...
```

### Test Plan

CI still passes uncahnged.
