### PR TITLE
Running signed data over ethers.utils.splitSignare/joinSignature

### DIFF
--- a/src/ts/sign.ts
+++ b/src/ts/sign.ts
@@ -165,15 +165,23 @@ export async function signOrder(
   owner: Signer,
   scheme: EcdsaSigningScheme,
 ): Promise<EcdsaSignature> {
+  const signature = await ecdsaSignTypedData(
+    scheme,
+    owner,
+    domain,
+    { Order: ORDER_TYPE_FIELDS },
+    normalizeOrder(order),
+  );
+  // Passing the signature over split/join to normalize the `v` byte.
+  // Some wallets do not pad it with `27`, which causes a signature failure
+  // `splitSignature` pads it if needed, and `joinSignature` simply puts it back together
+  const data = ethers.utils.joinSignature(
+    ethers.utils.splitSignature(signature),
+  );
+
   return {
     scheme,
-    data: await ecdsaSignTypedData(
-      scheme,
-      owner,
-      domain,
-      { Order: ORDER_TYPE_FIELDS },
-      normalizeOrder(order),
-    ),
+    data,
   };
 }
 

--- a/test/sign.test.ts
+++ b/test/sign.test.ts
@@ -1,3 +1,6 @@
+import { joinSignature } from "@ethersproject/bytes";
+import { hashMessage } from "@ethersproject/hash";
+import { SigningKey } from "@ethersproject/signing-key";
 import { expect } from "chai";
 import { ethers, waffle } from "hardhat";
 
@@ -5,7 +8,50 @@ import {
   SigningScheme,
   signOrderCancellation,
   hashOrderCancellation,
+  signOrder,
 } from "../src/ts";
+
+import { SAMPLE_ORDER } from "./testHelpers";
+
+const patchedSignMessageBuilder = (key: SigningKey) => async (
+  message: string,
+): Promise<string> => {
+  // Reproducing `@ethersproject/wallet/src.ts/index.ts` sign message bahaviour
+  const sig = joinSignature(key.signDigest(hashMessage(message)));
+
+  // Unpack the signature
+  const { r, s, v } = ethers.utils.splitSignature(sig);
+  // Pack it again
+  return ethers.utils.solidityPack(
+    ["bytes32", "bytes32", "uint8"],
+    // Remove last byte's `27` padding
+    [r, s, v - 27],
+  );
+};
+
+describe("signOrder", () => {
+  it("should pad the `v` byte when needed", async () => {
+    const [signer] = waffle.provider.getWallets();
+    // Patch signMessage
+    signer.signMessage = patchedSignMessageBuilder(signer._signingKey());
+
+    const domain = { name: "test" };
+
+    for (const scheme of [
+      SigningScheme.EIP712,
+      SigningScheme.ETHSIGN,
+    ] as const) {
+      // Extract `v` from the signature data
+      const v = ethers.utils.hexDataSlice(
+        (await signOrder(domain, SAMPLE_ORDER, signer, scheme)).data as string,
+        64,
+        65,
+      );
+      // Confirm it is either 27 or 28, in hex
+      expect(v).to.be.oneOf(["0x1b", "0x1c"]);
+    }
+  });
+});
 
 function recoverSigningDigest(
   scheme: SigningScheme,
@@ -45,6 +91,30 @@ describe("signOrderCancellation", () => {
       expect(ethers.utils.recoverAddress(signingHash, signature)).to.equal(
         signer.address,
       );
+    }
+  });
+
+  it("should pad the `v` byte when needed", async () => {
+    const [signer] = waffle.provider.getWallets();
+    // Patch signMessage
+    signer.signMessage = patchedSignMessageBuilder(signer._signingKey());
+
+    const domain = { name: "test" };
+    const orderUid = `0x${"2a".repeat(56)}`;
+
+    for (const scheme of [
+      SigningScheme.EIP712,
+      SigningScheme.ETHSIGN,
+    ] as const) {
+      // Extract `v` from the signature data
+      const v = ethers.utils.hexDataSlice(
+        (await signOrderCancellation(domain, orderUid, signer, scheme))
+          .data as string,
+        64,
+        65,
+      );
+      // Confirm it is either 27 or 28, in hex
+      expect(v).to.be.oneOf(["0x1b", "0x1c"]);
     }
   });
 });

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -1,0 +1,25 @@
+import { BigNumber } from "ethers";
+import { ethers } from "hardhat";
+
+import { OrderKind } from "../src/ts";
+
+export function fillBytes(count: number, byte: number): string {
+  return ethers.utils.hexlify([...Array(count)].map(() => byte));
+}
+
+export function fillUint(bits: number, byte: number): BigNumber {
+  return BigNumber.from(fillBytes(bits / 8, byte));
+}
+
+export const SAMPLE_ORDER = {
+  sellToken: fillBytes(20, 0x01),
+  buyToken: fillBytes(20, 0x02),
+  receiver: fillBytes(20, 0x03),
+  sellAmount: ethers.utils.parseEther("42"),
+  buyAmount: ethers.utils.parseEther("13.37"),
+  validTo: 0xffffffff,
+  appData: ethers.constants.HashZero,
+  feeAmount: ethers.utils.parseEther("1.0"),
+  kind: OrderKind.SELL,
+  partiallyFillable: false,
+};


### PR DESCRIPTION
Closes #579 

As described on issue https://github.com/gnosis/gp-v2-contracts/issues/579, this change makes sure the `v` signature byte is always padded with `27`.
This is done by running the signature through [`splitSignature`/`joinSignature`](https://docs.ethers.io/v5/api/utils/bytes/#utils-splitSignature)

### Test Plan

#### Unit test
~Did not find out how to write a unit test for this, happy to add one if anyone know how.~
Thanks to Nick's help, I've added 2 similar unit tests. 1 for `signOrder` and one for `signOrderCancellation`

#### Manual end to end test

I did test it locally with CowSwap and a Ledger device. Steps:

1. Using [`yalc`](https://github.com/wclr/yalc), publish the package locally with `yalc publish`
2. On `gp-swap-ui`
    1. Using the code on https://github.com/gnosis/gp-swap-ui/pull/387 locally, add the local package with `yalc add @gnosis.pm/gp-v2-contracts`
    1. Install packages and start the app with `yarn && yarn start`
3. Head over to http://localhost:3000
4. On Metamask, connect a Ledger device
5. Back to the app, connect Metamask, and make sure the Ledger account is the one connected
6. Pick any token you have funds for in the `From` field, and any token from the list in the `To` field
7. Place the swap order.
    1. You should see two signature requests. The first has all the order details:
![screenshot_2021-04-07_13-47-24](https://user-images.githubusercontent.com/43217/113931821-c7105100-97a7-11eb-8332-8deb7ae129b7.png)
    1. When clicking on sign, nothing will show up in your wallet, and another signature will be requested:
![screenshot_2021-04-07_13-48-19](https://user-images.githubusercontent.com/43217/113931897-dee7d500-97a7-11eb-8bb1-d83476deec1f.png)
    1. When clicking on sign, check your ledger and confirm
 
The order will be placed successfully.
Example https://protocol-explorer.dev.gnosisdev.com/rinkeby/orders/0xf6fe1e7ab1233895635fe543a02934840dbcc74759595bc8a236cf5836ba696c8821b5f32454f47c768c1a326d8326e124a6bb77606e17f2


