### PR TITLE
Bump to 0.0.1-alpha.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v2-contracts",
-  "version": "0.0.1-alpha.16",
+  "version": "0.0.1-alpha.17",
   "license": "LGPL-3.0-or-later",
   "scripts": {
     "deploy": "hardhat deploy",


### PR DESCRIPTION
This PR just bumps the package version to alpha.17 in preparation for an npm release with #580 
