### PR TITLE
Add functions decoding trade flags

### DIFF
--- a/src/ts/settlement.ts
+++ b/src/ts/settlement.ts
@@ -135,7 +135,7 @@ export type EncodedSettlement = [
 /**
  * An object listing all flag options in order along with their bit offset.
  */
-export const flagMasks = {
+export const FLAG_MASKS = {
   kind: {
     offset: 0,
     options: [OrderKind.SELL, OrderKind.BUY],
@@ -156,16 +156,16 @@ export const flagMasks = {
 } as const;
 
 function encodeFlag<
-  K extends keyof typeof flagMasks,
-  V extends typeof flagMasks[K]["options"][number]
+  K extends keyof typeof FLAG_MASKS,
+  V extends typeof FLAG_MASKS[K]["options"][number]
 >(key: K, flag: V): number {
-  const index = flagMasks[key].options.findIndex(
+  const index = FLAG_MASKS[key].options.findIndex(
     (search: unknown) => search === flag,
   );
   if (index === undefined) {
     throw new Error(`Bad key/value pair to encode: ${key}/${flag}`);
   }
-  return index << flagMasks[key].offset;
+  return index << FLAG_MASKS[key].offset;
 }
 
 // Counts the smallest mask needed to store the input options in the masked
@@ -177,10 +177,10 @@ function mask(options: readonly unknown[]): number {
 }
 
 function decodeFlag<
-  K extends keyof typeof flagMasks,
-  V extends typeof flagMasks[K]["options"][number]
+  K extends keyof typeof FLAG_MASKS,
+  V extends typeof FLAG_MASKS[K]["options"][number]
 >(key: K, flag: number): V {
-  const { offset, options } = flagMasks[key];
+  const { offset, options } = FLAG_MASKS[key];
   const index = (flag >> offset) & mask(options);
   // This type casting should not be needed
   const decoded = options[index] as V;

--- a/src/ts/settlement.ts
+++ b/src/ts/settlement.ts
@@ -155,10 +155,11 @@ export const FLAG_MASKS = {
   },
 } as const;
 
-function encodeFlag<
-  K extends keyof typeof FLAG_MASKS,
-  V extends typeof FLAG_MASKS[K]["options"][number]
->(key: K, flag: V): number {
+export type FlagKey = keyof typeof FLAG_MASKS;
+export type FlagOptions<K extends FlagKey> = typeof FLAG_MASKS[K]["options"];
+export type FlagValue<K extends FlagKey> = FlagOptions<K>[number];
+
+function encodeFlag<K extends FlagKey>(key: K, flag: FlagValue<K>): number {
   const index = FLAG_MASKS[key].options.findIndex(
     (search: unknown) => search === flag,
   );
@@ -176,14 +177,11 @@ function mask(options: readonly unknown[]): number {
   return (1 << bitCount) - 1;
 }
 
-function decodeFlag<
-  K extends keyof typeof FLAG_MASKS,
-  V extends typeof FLAG_MASKS[K]["options"][number]
->(key: K, flag: number): V {
+function decodeFlag<K extends FlagKey>(key: K, flag: number): FlagValue<K> {
   const { offset, options } = FLAG_MASKS[key];
   const index = (flag >> offset) & mask(options);
   // This type casting should not be needed
-  const decoded = options[index] as V;
+  const decoded = options[index] as FlagValue<K>;
   if (decoded === undefined || index < 0) {
     throw new Error(`Invalid input flag for ${key}: 0b${flag.toString(2)}`);
   }

--- a/src/ts/settlement.ts
+++ b/src/ts/settlement.ts
@@ -173,7 +173,7 @@ function encodeFlag<K extends FlagKey>(key: K, flag: FlagValue<K>): number {
 // bitfield.
 function mask(options: readonly unknown[]): number {
   const num = options.length;
-  const bitCount = num === 0 ? 0 : (num - 1).toString(2).length;
+  const bitCount = 32 - Math.clz32(num - 1);
   return (1 << bitCount) - 1;
 }
 

--- a/test/decoding.test.ts
+++ b/test/decoding.test.ts
@@ -5,6 +5,7 @@ import {
   decodeTradeFlags,
   FLAG_MASKS,
   TradeFlags,
+  FlagKey,
 } from "../src/ts";
 
 type UnknownArray = unknown[] | readonly unknown[];
@@ -61,14 +62,12 @@ function validEncodedFlags(): number[] {
 }
 
 // Returns an object that assigns to every key all encoded flags for that key.
-function allEncodedFlagOptions<
-  Out extends Record<keyof typeof FLAG_MASKS, number[]>
->(): Out {
+function allEncodedFlagOptions<Out extends Record<FlagKey, number[]>>(): Out {
   const result: Partial<Out> = {};
   Object.entries(FLAG_MASKS).map(([key, { offset, options }]) => {
-    result[
-      key as keyof typeof FLAG_MASKS
-    ] = (options as readonly unknown[]).map((_, index) => index << offset);
+    result[key as FlagKey] = (options as readonly unknown[]).map(
+      (_, index) => index << offset,
+    );
   });
   return result as Out;
 }

--- a/test/decoding.test.ts
+++ b/test/decoding.test.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 import {
   encodeTradeFlags,
   decodeTradeFlags,
-  flagMasks,
+  FLAG_MASKS,
   TradeFlags,
 } from "../src/ts";
 
@@ -62,20 +62,20 @@ function validEncodedFlags(): number[] {
 
 // Returns an object that assigns to every key all encoded flags for that key.
 function allEncodedFlagOptions<
-  Out extends Record<keyof typeof flagMasks, number[]>
+  Out extends Record<keyof typeof FLAG_MASKS, number[]>
 >(): Out {
   const result: Partial<Out> = {};
-  Object.entries(flagMasks).map(([key, { offset, options }]) => {
-    result[key as keyof typeof flagMasks] = (options as readonly unknown[]).map(
-      (_, index) => index << offset,
-    );
+  Object.entries(FLAG_MASKS).map(([key, { offset, options }]) => {
+    result[
+      key as keyof typeof FLAG_MASKS
+    ] = (options as readonly unknown[]).map((_, index) => index << offset);
   });
   return result as Out;
 }
 
 function validFlags(): TradeFlags[] {
   /* eslint-disable @typescript-eslint/no-explicit-any */
-  const keyedOptions = Object.entries(flagMasks).map(([key, { options }]) =>
+  const keyedOptions = Object.entries(FLAG_MASKS).map(([key, { options }]) =>
     options.map((option: unknown) => [key, option]),
   );
   const combinations = cartesian(...keyedOptions);

--- a/test/decoding.test.ts
+++ b/test/decoding.test.ts
@@ -1,0 +1,108 @@
+import { expect } from "chai";
+
+import {
+  encodeTradeFlags,
+  decodeTradeFlags,
+  flagMasks,
+  TradeFlags,
+} from "../src/ts";
+
+type UnknownArray = unknown[] | readonly unknown[];
+// [A, B, C] -> [A, B]
+type RemoveLast<T extends UnknownArray> = T extends [...infer U, unknown]
+  ? U
+  : [];
+// [A, B, C] -> C
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type GetLast<T extends UnknownArray> = T extends [...infer _, infer U]
+  ? U
+  : never;
+// A[] -> A
+type ArrayType<T> = T extends (infer U)[]
+  ? U
+  : T extends readonly (infer U)[]
+  ? U
+  : [];
+type UnknownMatrix = UnknownArray[] | readonly UnknownArray[];
+// [A[], B[], C[]] -> [A, B, C]
+type ArrayTupleType<T extends UnknownMatrix> = T extends []
+  ? []
+  : [...ArrayTupleType<RemoveLast<T>>, ArrayType<GetLast<T>>];
+// [A[], B[], C[]] -> [A, B, C][]
+type Transpose<T extends UnknownMatrix> = ArrayTupleType<T>[];
+
+// Computes the Cartesian product between all input arrays.
+function cartesian<T extends UnknownMatrix>(...arrays: T): Transpose<T> {
+  if (arrays.length === 0) {
+    return [];
+  }
+
+  let partialProd: UnknownMatrix = [[]];
+  arrays.map((array: readonly unknown[]) => {
+    partialProd = partialProd
+      .map((tuple: UnknownArray) =>
+        array.map((elt: unknown) => [...tuple, elt]),
+      )
+      .flat();
+  });
+
+  return partialProd as Transpose<T>;
+}
+
+function validEncodedFlags(): number[] {
+  return cartesian(
+    ...Object.values(allEncodedFlagOptions()),
+  ).map((flagOptions) =>
+    flagOptions.reduce(
+      (cumulative: number, flagOption: number) => cumulative | flagOption,
+      0,
+    ),
+  );
+}
+
+// Returns an object that assigns to every key all encoded flags for that key.
+function allEncodedFlagOptions<
+  Out extends Record<keyof typeof flagMasks, number[]>
+>(): Out {
+  const result: Partial<Out> = {};
+  Object.entries(flagMasks).map(([key, { offset, options }]) => {
+    result[key as keyof typeof flagMasks] = (options as readonly unknown[]).map(
+      (_, index) => index << offset,
+    );
+  });
+  return result as Out;
+}
+
+function validFlags(): TradeFlags[] {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  const keyedOptions = Object.entries(flagMasks).map(([key, { options }]) =>
+    options.map((option: unknown) => [key, option]),
+  );
+  const combinations = cartesian(...keyedOptions);
+  return combinations.map((transposedKeyedOptions) => {
+    const tradeFlags: any = {};
+    transposedKeyedOptions.forEach(
+      ([key, option]: any) => (tradeFlags[key] = option),
+    );
+    return (tradeFlags as unknown) as TradeFlags;
+  });
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+}
+
+describe("Flag decoding", () => {
+  it("encodeTradeFlags is the right inverse of decodeTradeFlags", () => {
+    for (const tradeFlags of validFlags()) {
+      expect(decodeTradeFlags(encodeTradeFlags(tradeFlags))).to.deep.equal(
+        tradeFlags,
+      );
+    }
+  });
+
+  it("encodeTradeFlags is the left inverse of decodeTradeFlags", () => {
+    for (const encodedTradeFlags of validEncodedFlags()) {
+      expect(encodeTradeFlags(decodeTradeFlags(encodedTradeFlags))).to.equal(
+        encodedTradeFlags,
+      );
+    }
+  });
+});

--- a/test/encoding.ts
+++ b/test/encoding.ts
@@ -1,7 +1,14 @@
 import { BigNumber } from "ethers";
 import { ethers } from "hardhat";
 
-import { Order, OrderKind, normalizeOrder, FLAG_MASKS } from "../src/ts";
+import {
+  Order,
+  OrderKind,
+  normalizeOrder,
+  FLAG_MASKS,
+  FlagKey,
+  FlagOptions,
+} from "../src/ts";
 
 export type AbiOrder = [
   string,
@@ -16,9 +23,7 @@ export type AbiOrder = [
   boolean,
 ];
 
-function optionsForKey<K extends keyof typeof FLAG_MASKS>(
-  key: K,
-): typeof FLAG_MASKS[K]["options"] {
+function optionsForKey<K extends FlagKey>(key: K): FlagOptions<K> {
   return FLAG_MASKS[key].options;
 }
 export const allOrderKinds = optionsForKey("kind");
@@ -26,10 +31,10 @@ export const allPartiallyFillable = optionsForKey("partiallyFillable");
 export const allSigningSchemes = optionsForKey("signingScheme");
 
 export function allOptions<
-  K extends keyof typeof FLAG_MASKS,
-  AllOptions extends Record<K, typeof FLAG_MASKS[K]["options"]>
+  K extends FlagKey,
+  AllOptions extends Record<K, FlagOptions<K>>
 >(): AllOptions {
-  const result: Record<string, typeof FLAG_MASKS[K]["options"]> = {};
+  const result: Record<string, FlagOptions<K>> = {};
   Object.entries(FLAG_MASKS).map(
     ([key, value]) => (result[key] = value.options),
   );

--- a/test/encoding.ts
+++ b/test/encoding.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from "ethers";
 import { ethers } from "hardhat";
 
-import { Order, OrderKind, normalizeOrder, flagMasks } from "../src/ts";
+import { Order, OrderKind, normalizeOrder, FLAG_MASKS } from "../src/ts";
 
 export type AbiOrder = [
   string,
@@ -16,21 +16,21 @@ export type AbiOrder = [
   boolean,
 ];
 
-function optionsForKey<K extends keyof typeof flagMasks>(
+function optionsForKey<K extends keyof typeof FLAG_MASKS>(
   key: K,
-): typeof flagMasks[K]["options"] {
-  return flagMasks[key].options;
+): typeof FLAG_MASKS[K]["options"] {
+  return FLAG_MASKS[key].options;
 }
 export const allOrderKinds = optionsForKey("kind");
 export const allPartiallyFillable = optionsForKey("partiallyFillable");
 export const allSigningSchemes = optionsForKey("signingScheme");
 
 export function allOptions<
-  K extends keyof typeof flagMasks,
-  AllOptions extends Record<K, typeof flagMasks[K]["options"]>
+  K extends keyof typeof FLAG_MASKS,
+  AllOptions extends Record<K, typeof FLAG_MASKS[K]["options"]>
 >(): AllOptions {
-  const result: Record<string, typeof flagMasks[K]["options"]> = {};
-  Object.entries(flagMasks).map(
+  const result: Record<string, typeof FLAG_MASKS[K]["options"]> = {};
+  Object.entries(FLAG_MASKS).map(
     ([key, value]) => (result[key] = value.options),
   );
   return result as AllOptions;

--- a/test/encoding.ts
+++ b/test/encoding.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from "ethers";
 import { ethers } from "hardhat";
 
-import { Order, OrderKind, normalizeOrder } from "../src/ts";
+import { Order, OrderKind, normalizeOrder, flagMasks } from "../src/ts";
 
 export type AbiOrder = [
   string,
@@ -15,6 +15,26 @@ export type AbiOrder = [
   string,
   boolean,
 ];
+
+function optionsForKey<K extends keyof typeof flagMasks>(
+  key: K,
+): typeof flagMasks[K]["options"] {
+  return flagMasks[key].options;
+}
+export const allOrderKinds = optionsForKey("kind");
+export const allPartiallyFillable = optionsForKey("partiallyFillable");
+export const allSigningSchemes = optionsForKey("signingScheme");
+
+export function allOptions<
+  K extends keyof typeof flagMasks,
+  AllOptions extends Record<K, typeof flagMasks[K]["options"]>
+>(): AllOptions {
+  const result: Record<string, typeof flagMasks[K]["options"]> = {};
+  Object.entries(flagMasks).map(
+    ([key, value]) => (result[key] = value.options),
+  );
+  return result as AllOptions;
+}
 
 export function encodeOrder(order: Order): AbiOrder {
   const o = normalizeOrder(order);


### PR DESCRIPTION
Adds a new functions that decodes a bitfield into standard trade brackets. This code will be used in the task that decodes trade calldata.

This PR refactors the way flags encoding is handled in the TS code.

All function should be properly typed, but I had to use type casting quite often, ideas to remove them are welcome..

### Test Plan

New unit tests.