### PR TITLE
Decode trade signer in decode task

### DIFF
--- a/src/ts/sign.ts
+++ b/src/ts/sign.ts
@@ -225,3 +225,24 @@ export function encodeEip1271SignatureData({
 }: Eip1271SignatureData): string {
   return ethers.utils.solidityPack(["address", "bytes"], [verifier, signature]);
 }
+
+/**
+ * Decodes a GPv2 EIP-1271-type signature into the actual EIP-1271 signature
+ * and the verifier contract.
+ *
+ * @param signature The EIP-1271 signature data to decode.
+ * @returns decodedSignature The decoded signature object, composed of an
+ * EIP-1271 signature and a verifier.
+ */
+export function decodeEip1271SignatureData(
+  signature: BytesLike,
+): Eip1271SignatureData {
+  const arrayifiedSignature = ethers.utils.arrayify(signature);
+  const verifier = ethers.utils.getAddress(
+    ethers.utils.hexlify(arrayifiedSignature.slice(0, 20)),
+  );
+  return {
+    verifier,
+    signature: arrayifiedSignature.slice(20),
+  };
+}

--- a/test/GPv2Order.test.ts
+++ b/test/GPv2Order.test.ts
@@ -11,16 +11,7 @@ import {
 } from "../src/ts";
 
 import { encodeOrder } from "./encoding";
-
-function fillBytes(count: number, byte: number): string {
-  return ethers.utils.hexlify([...Array(count)].map(() => byte));
-}
-
-function fillDistinctBytes(count: number, start: number): string {
-  return ethers.utils.hexlify(
-    [...Array(count)].map((_, i) => (start + i) % 256),
-  );
-}
+import { fillBytes, fillDistinctBytes } from "./testHelpers";
 
 describe("GPv2Order", () => {
   let orders: Contract;

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -7,6 +7,12 @@ export function fillBytes(count: number, byte: number): string {
   return ethers.utils.hexlify([...Array(count)].map(() => byte));
 }
 
+export function fillDistinctBytes(count: number, start: number): string {
+  return ethers.utils.hexlify(
+    [...Array(count)].map((_, i) => (start + i) % 256),
+  );
+}
+
 export function fillUint(bits: number, byte: number): BigNumber {
   return BigNumber.from(fillBytes(bits / 8, byte));
 }


### PR DESCRIPTION
Addresses [this comment](https://github.com/gnosis/gp-v2-contracts/pull/596#discussion_r615610938).

Shows the user address and order uid for every trade printed by the `decode` task. New decoding functions are added to that end.

### Test Plan

New unit tests. Test the `decode` task. Example:

```
$ npx hardhat decode --txhash 0x2b1bda3ffcdda778e1378d4f51a9be25a4eeb149cec37e9d3464aa9b81fb9e12 --network rinkeby
```

Result:

![screenshot](https://user-images.githubusercontent.com/58218759/115278244-c1feba80-a134-11eb-9839-08be0ce1ca70.png)

