### PR TITLE
Refactor common functions outside of single tasks

### DIFF
--- a/src/tasks/ts/deployment.ts
+++ b/src/tasks/ts/deployment.ts
@@ -1,0 +1,13 @@
+import { Contract } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+export async function getDeployedContract(
+  name: string,
+  { ethers, deployments }: HardhatRuntimeEnvironment,
+): Promise<Contract> {
+  const deployment = await deployments.get(name);
+
+  return new Contract(deployment.address, deployment.abi).connect(
+    ethers.provider,
+  );
+}

--- a/src/tasks/ts/deployment.ts
+++ b/src/tasks/ts/deployment.ts
@@ -1,8 +1,10 @@
 import { Contract } from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
+import { ContractName } from "../../ts";
+
 export async function getDeployedContract(
-  name: string,
+  name: ContractName,
   { ethers, deployments }: HardhatRuntimeEnvironment,
 ): Promise<Contract> {
   const deployment = await deployments.get(name);

--- a/src/tasks/ts/erc20.ts
+++ b/src/tasks/ts/erc20.ts
@@ -1,0 +1,35 @@
+import { BigNumber, Contract } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+export interface TokenDetails {
+  contract: Contract;
+  symbol: string | null;
+  decimals: number | null;
+  address: string;
+}
+
+export async function tokenDetails(
+  address: string,
+  hre: HardhatRuntimeEnvironment,
+): Promise<TokenDetails> {
+  const IERC20 = await hre.artifacts.readArtifact(
+    "src/contracts/interfaces/IERC20.sol:IERC20",
+  );
+  const contract = new Contract(address, IERC20.abi, hre.ethers.provider);
+  const [symbol, decimals] = await Promise.all([
+    contract
+      .symbol()
+      .then((s: unknown) => (typeof s !== "string" ? null : s))
+      .catch(() => null),
+    contract
+      .decimals()
+      .then((s: unknown) => BigNumber.from(s))
+      .catch(() => null),
+  ]);
+  return {
+    contract,
+    symbol,
+    decimals,
+    address,
+  };
+}


### PR DESCRIPTION
A simple PR that isolates some functions that will be used later in a task that withdraws all funds from the settlement contract.

### Test Plan

The `solvers` and `decode` tasks still work:

```
$ npx hardhat --network rinkeby solvers check 0x0e1401b7037163764b161fd989bdcf224bb5dcc4
0x0e1401b7037163764b161fd989bdcf224bb5dcc4 is a solver.
```

```
$ npx hardhat decode --network mainnet --txhash 0x8375745a3383e73f4c20b90ff5e2cad110723c46a995045ef91e711cad671abc
=== Tokens ===
                                    address | index | symbol |               price 
--------------------------------------------+-------+--------+---------------------
 0x3472A5A71965499acd81997a54BBA8D852C6E53d |     0 | BADGER |   97965666666666667 
 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 |     1 |   WETH | 7781607459051520757 
<snip>
```