### PR TITLE
Add withdraw task

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@typescript-eslint/parser": "^4.22.0",
     "@uniswap/v2-core": "^1.0.1",
     "@uniswap/v2-periphery": "^1.1.0-beta.0",
+    "axios": "^0.21.1",
     "canonical-weth": "^1.4.0",
     "chai": "^4.3.4",
     "chalk": "^4.1.1",

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -2,10 +2,12 @@ import { setupCopyArtifactsTask } from "./artifacts";
 import { setupDecodeTask } from "./decode";
 import { setupSolversTask } from "./solvers";
 import { setupTenderlyTask } from "./tenderly";
+import { setupWithdrawTask } from "./withdraw";
 
 export function setupTasks(): void {
   setupCopyArtifactsTask();
   setupDecodeTask();
   setupSolversTask();
   setupTenderlyTask();
+  setupWithdrawTask();
 }

--- a/src/tasks/withdraw.ts
+++ b/src/tasks/withdraw.ts
@@ -1,0 +1,396 @@
+import "@nomiclabs/hardhat-ethers";
+
+import readline from "readline";
+
+import axios from "axios";
+import chalk from "chalk";
+import { BigNumber, utils, constants, Contract } from "ethers";
+import { task, types } from "hardhat/config";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+import { BUY_ETH_ADDRESS, SettlementEncoder } from "../ts";
+
+import { getDeployedContract } from "./ts/deployment";
+import { TokenDetails, tokenDetails } from "./ts/erc20";
+import { Align, displayTable } from "./ts/table";
+
+const MAINNET_DAI = "0x6b175474e89094c44da98b954eedeac495271d0f";
+const ONEINCH_ETH_FLAG = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+const DAI_DECIMALS = 18;
+
+interface Withdrawal {
+  token: TokenDetails;
+  balance: BigNumber;
+  usdValue: BigNumber;
+}
+
+interface DisplayWithdrawal {
+  symbol: string;
+  balance: string;
+  value: string;
+  address: string;
+}
+
+// https://api.1inch.exchange/swagger/ethereum/#/Tokens/TokensController_getTokens
+type OneinchTokenList = Record<
+  string,
+  { symbol: string; decimals: number; address: string }
+>;
+const ONEINCH_TOKENS: Promise<OneinchTokenList> = axios
+  .get("https://api.1inch.exchange/v3.0/1/tokens")
+  .then((response) => response.data.tokens)
+  .catch(() => {
+    console.warn("Warning: unable to recover token list from 1inch");
+    return {};
+  });
+
+async function fastTokenDetails(
+  address: string,
+  hre: HardhatRuntimeEnvironment,
+): Promise<TokenDetails> {
+  const oneinchTokens = await ONEINCH_TOKENS;
+  if (
+    hre.network.name === "mainnet" &&
+    oneinchTokens[address.toLowerCase()] !== undefined
+  ) {
+    const IERC20 = await hre.artifacts.readArtifact(
+      "src/contracts/interfaces/IERC20.sol:IERC20",
+    );
+    const contract = new Contract(address, IERC20.abi, hre.ethers.provider);
+    return { ...oneinchTokens[address.toLowerCase()], contract };
+  }
+  return tokenDetails(address, hre);
+}
+
+// Recovers mainnet address from token symbol. Useful to get prices out of xdai
+// and rinkeby tokens.
+async function addressFromSymbol(
+  symbol: string,
+  network: string,
+): Promise<string | null> {
+  const oneinchTokens = await ONEINCH_TOKENS;
+  const tokensFromSymbol = Object.entries(oneinchTokens).filter(
+    ([, token]) => token.symbol.toLowerCase() === symbol.toLowerCase(),
+  );
+  let result = tokensFromSymbol.length == 0 ? null : tokensFromSymbol[0][0];
+  if (tokensFromSymbol.length > 1) {
+    // More than one token available. Using the most valued token to be safe.
+    const tokenValues = await Promise.all(
+      tokensFromSymbol.map(([, token]) =>
+        oneinchUsdValue(token, BigNumber.from(10).pow(15), network),
+      ),
+    );
+    const mostValued = tokenValues.reduce(
+      (max, value, i) => (value.gt(tokenValues[max]) ? i : max),
+      0,
+    );
+    result = tokensFromSymbol[mostValued][0];
+  }
+  return result;
+}
+
+// https://api.1inch.exchange/swagger/ethereum/#/Swap/SwapController_getQuote
+const oneinchUsdValue = async function (
+  token: Pick<TokenDetails, "symbol" | "address">,
+  amount: BigNumber,
+  network: string,
+): Promise<BigNumber> {
+  let fromTokenAddress: string;
+  if (Object.keys(await ONEINCH_TOKENS).includes(token.address.toLowerCase())) {
+    // Assumption: if a mainnet token has value, it's supported by 1inch.
+    // If it's not on mainnet, then either it was deployed to the same address
+    // on mainnet (and is the same token, i.e., same value), or its address is
+    // overwhelmingly likely not to be in the 1inch list.
+    fromTokenAddress = token.address;
+  } else if (network === "mainnet" || token.symbol === null) {
+    // Assumption: a token with no name has no value.
+    return constants.Zero;
+  } else {
+    // Assumption: if the token has value on xdai, then a token with the same
+    // name and approximately the same value exists on mainnet. WXDAI is the
+    // only exception.
+    // There will be false positives, but on Rinkeby and xdai the low gas prices
+    // make it an acceptable loss.
+    const symbol =
+      token.symbol.toLowerCase() === "wxdai" ? "DAI" : token.symbol;
+    const address = await addressFromSymbol(symbol, network);
+    if (address === null) {
+      return constants.Zero;
+    }
+    fromTokenAddress = address;
+  }
+
+  const toTokenAddress = MAINNET_DAI;
+  // Note: 1inch API calls fail if from and to addresses are the same
+  if (fromTokenAddress === toTokenAddress) {
+    return amount;
+  }
+
+  try {
+    const response = await axios.get(
+      "https://api.1inch.exchange/v3.0/1/quote",
+      {
+        params: {
+          fromTokenAddress,
+          toTokenAddress,
+          amount: amount.toString(),
+        },
+      },
+    );
+    // Note: in principle 1inch could use less than the provided input amount.
+    // In this case, we assume that the token has no more value that what is
+    // available from the available liquidity.
+    return BigNumber.from(response.data.toTokenAmount);
+  } catch (e) {
+    console.warn(
+      `Warning: 1inch price retrieval failed for token ${token.symbol} (${token.address}). Token will be ignored.`,
+    );
+    return constants.Zero;
+  }
+};
+
+async function getAllTradedTokens(settlement: Contract): Promise<string[]> {
+  const trades = await settlement.queryFilter(settlement.filters.Trade());
+  const tokens = new Set(
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    trades.map((trade) => [trade.args!.sellToken, trade.args!.buyToken]).flat(),
+  );
+  tokens.delete(BUY_ETH_ADDRESS);
+  return Array.from(tokens).sort((lhs, rhs) =>
+    lhs.toLowerCase() < rhs.toLowerCase() ? -1 : lhs === rhs ? 0 : 1,
+  );
+}
+
+function clearLine() {
+  if (
+    process.stdout.clearLine !== undefined &&
+    process.stdout.cursorTo !== undefined
+  ) {
+    process.stdout.clearLine(0);
+    process.stdout.cursorTo(0);
+  }
+}
+
+async function getWithdrawals(
+  tokens: string[],
+  settlement: Contract,
+  minValue: string,
+  hre: HardhatRuntimeEnvironment,
+): Promise<Withdrawal[]> {
+  const withdrawals = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const address = tokens[i];
+    clearLine();
+    process.stdout.write(`Processing token ${i + 1}/${tokens.length}...`);
+    const token = await fastTokenDetails(address, hre);
+    const balance = await token.contract.balanceOf(settlement.address);
+    if (balance.eq(0)) {
+      continue;
+    }
+    const usdValue = await oneinchUsdValue(token, balance, hre.network.name);
+    clearLine();
+    if (usdValue.gte(utils.parseUnits(minValue, DAI_DECIMALS))) {
+      withdrawals.push({ token, balance, usdValue });
+    } else {
+      console.warn(
+        `Ignored ${utils.formatUnits(balance, token.decimals ?? 0)} units of ${
+          token.symbol ?? "unknown token"
+        } (${token.address}) with value ${formatUsdValue(usdValue)} USD`,
+      );
+    }
+  }
+  clearLine();
+  return withdrawals;
+}
+
+// Format amount so that it has exactly a fixed amount of decimals.
+function formatTokenValue(
+  amount: BigNumber,
+  actualDecimals: number,
+  targetDecimals: number,
+): string {
+  const normalized =
+    targetDecimals <= actualDecimals
+      ? amount.div(BigNumber.from(10).pow(actualDecimals - targetDecimals))
+      : amount.mul(BigNumber.from(10).pow(-actualDecimals + targetDecimals));
+  const powDecimals = BigNumber.from(10).pow(targetDecimals);
+  return `${normalized.div(powDecimals).toString()}.${normalized
+    .mod(powDecimals)
+    .toString()
+    .padStart(targetDecimals, "0")}`;
+}
+
+function formatUsdValue(amount: BigNumber): string {
+  return formatTokenValue(amount, DAI_DECIMALS, 2);
+}
+
+function formatWithdrawal(withdrawal: Withdrawal): DisplayWithdrawal {
+  return {
+    address: withdrawal.token.address,
+    value: formatUsdValue(withdrawal.usdValue),
+    balance: formatTokenValue(
+      withdrawal.balance,
+      withdrawal.token.decimals ?? DAI_DECIMALS,
+      18,
+    ),
+    symbol: withdrawal.token.symbol ?? "unknown token",
+  };
+}
+
+function displayWithdrawals(withdrawals: Withdrawal[]) {
+  const formattedWithdtrawals = withdrawals.map(formatWithdrawal);
+  const order = ["address", "value", "balance", "symbol"] as const;
+  const header = {
+    address: "address",
+    value: "value (usd)",
+    balance: "balance",
+    symbol: "symbol",
+  };
+  console.log(chalk.bold("Amounts to withdraw:"));
+  displayTable(header, formattedWithdtrawals, order, {
+    value: { align: Align.Right },
+    balance: { align: Align.Right, maxWidth: 30 },
+    symbol: { maxWidth: 20 },
+  });
+  console.log();
+}
+
+async function formatGasCost(
+  amount: BigNumber,
+  network: string,
+): Promise<string> {
+  switch (network) {
+    case "mainnet": {
+      const value = await oneinchUsdValue(
+        { symbol: "ETH", address: ONEINCH_ETH_FLAG },
+        amount,
+        "mainnet",
+      );
+      return `${utils.formatEther(amount)} ETH (${formatUsdValue(value)} USD)`;
+    }
+    case "xdai":
+      return `${utils.formatEther(amount)} XDAI`;
+    default:
+      return `${utils.formatEther(amount)} ETH`;
+  }
+}
+
+async function prompt(message: string) {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  const response = await new Promise<string>((resolve) =>
+    rl.question(`${message} (y/N) `, (response) => resolve(response)),
+  );
+  return "y" === response.toLowerCase();
+}
+
+const setupWithdrawTask: () => void = () =>
+  task("withdraw", "Withdraw funds from the settlement contract")
+    .addOptionalParam(
+      "minValue",
+      "If specified, sets a minimum USD value required to withdraw the balance of a token.",
+      "0",
+      types.string,
+    )
+    .addParam("receiver", "The address receiving the withdrawn tokens.")
+    .addFlag(
+      "dryRun",
+      "Just simulate the settlement instead of executing the transaction on the blockchain.",
+    )
+    .setAction(
+      async (
+        { minValue, dryRun, receiver: inputReceiver },
+        hre: HardhatRuntimeEnvironment,
+      ) => {
+        const receiver = utils.getAddress(inputReceiver);
+        const [authenticator, settlement, [solver]] = await Promise.all([
+          getDeployedContract("GPv2AllowListAuthentication", hre),
+          getDeployedContract("GPv2Settlement", hre),
+          hre.ethers.getSigners(),
+        ]);
+
+        if (!(await authenticator.isSolver(solver.address))) {
+          const message =
+            "Current account is not a solver. Only a solver can withdraw funds from the settlement contract.";
+          if (!dryRun) {
+            throw Error(message);
+          } else {
+            console.warn(message);
+          }
+        }
+
+        const tokens = await getAllTradedTokens(settlement);
+
+        // TODO: add eth withdrawal
+        // TODO: split large transaction in batches
+        const withdrawals = await getWithdrawals(
+          tokens,
+          settlement,
+          minValue,
+          hre,
+        );
+        withdrawals.sort((lhs, rhs) => {
+          const diff = lhs.usdValue.sub(rhs.usdValue);
+          return diff.isZero() ? 0 : diff.isNegative() ? -1 : 1;
+        });
+
+        displayWithdrawals(withdrawals);
+
+        if (withdrawals.length === 0) {
+          console.log("No tokens to withdraw.");
+          process.exit(0);
+        }
+
+        const finalSettlement = SettlementEncoder.encodedSetup(
+          ...withdrawals.map(({ token, balance }) => ({
+            target: token.address,
+            callData: token.contract.interface.encodeFunctionData("transfer", [
+              receiver,
+              balance,
+            ]),
+          })),
+        );
+
+        // TODO: use the address of a solver as the from address in dry run so
+        // that the price can always be estimated
+        const [gas, gasPrice] = await Promise.all([
+          settlement.estimateGas.settle(...finalSettlement),
+          hre.ethers.provider.getGasPrice(),
+        ]);
+        const amount = gas.mul(gasPrice);
+        const totalValue = withdrawals.reduce(
+          (sum, { usdValue }) => sum.add(usdValue),
+          constants.Zero,
+        );
+        console.log(
+          `The transaction will cost approximately ${await formatGasCost(
+            amount,
+            hre.network.name,
+          )} and will withdraw the balance of ${
+            withdrawals.length
+          } tokens for an estimated total value of ${formatUsdValue(
+            totalValue,
+          )} USD. All withdrawn funds will be sent to ${receiver}.`,
+        );
+
+        if (!dryRun && (await prompt("Submit?"))) {
+          console.log(
+            "Executing the withdraw transaction on the blockchain...",
+          );
+          const response = await settlement
+            .connect(solver)
+            .settle(...finalSettlement);
+          console.log(
+            "Transaction submitted to the blockchain. Waiting for acceptance in a block...",
+          );
+          const receipt = await response.wait();
+          console.log(
+            `Transaction successfully executed. Transaction hash: ${receipt.transactionHash}`,
+          );
+        }
+      },
+    );
+
+export { setupWithdrawTask };


### PR DESCRIPTION
Creates a task that allows a solver to withdraw the entire token balance of the settlement contract.

It has some niceties like:
- a `--min-value` flag, which sets the minimum value necessary for a token balance to be withdrawn.
- a `--dry-run` flag to simulate the transaction without executing it.

My biggest concern with this task is that the number of tokens becomes so large that Infura starts to rate limit us. So far, this never happened in my tests, and this is the reason why the main for loop is executed synchronously.

There were many arbitrary decisions taken when choosing how to determine the USD price. I preferred to avoid using onchain prices for fear of rate limiting, so I went for 1inch mainnet and ported these values to the other networks. Do you know any nice offchain price oracle for xdai?

Should there be a dedicated "solver" for this purpose? Currently, I use the Rinkeby solver PK for testing, but it might interfere with the solution submission from the services.

### Test Plan

Here is an example of it running on Rinkeby. Note that I sent the fund from the contract to the contract itself, so that I could keep testing.
```
$ npx hardhat --network rinkeby withdraw --receiver 0x3328f5f2cecaf00a2443082b657cedeaf70bfaef --min-value 1
Ignored 0.002057673129615732 units of UNI (0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984) with value 0.08 USD
Ignored 0.428804159828336768 units of PAX (0xBD6A9921504fae42EaD2024F43305A8ED3890F6f) with value 0.42 USD
Ignored 0.559003883643002753 units of BAT (0xbF7A7169562078c96f0eC1A8aFD6aE50f12e5A99) with value 0.59 USD
Ignored 0.000019883182074749 units of MKR (0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85) with value 0.08 USD
Amounts to withdraw:
 address                                    | value (usd)    | balance                        | symbol 
--------------------------------------------+----------------+--------------------------------+--------
 0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b |           1.68 |           1.666510000000000000 | USDC   
 0xa7D1C04fAF998F9161fC9F800a99A809b84cfc9D |           1.69 |           1.509199093558927079 | OWL    
 0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c |           1.77 |           0.016176772768765133 | GNO    
 0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa |         131.48 |         131.483855693681555312 | DAI    
 0xc778417E063141139Fce010982780140Aa0cD5Ab |         209.21 |           0.076157512658069544 | WETH   
 0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02 |  1000306547.96 |           2.026985309566957056 | USDT   
 0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735 | 14769687292.39 | 14769687292.398689374041812062 | DAI    

The transaction will cost approximately 0.000155976 ETH and will withdraw the balance of 7 tokens for an estimated total value of 15769994186.20 USD. All withdrawn funds will be sent to 0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf.
Submit? (y/n) y
Executing the withdraw transaction on the blockchain...
Transaction submitted to the blockchain. Waiting for acceptance in a block...
Transaction successfully executed. Transaction hash: 0x7bd0d5b5ea7eaaea92f831e0589a26ffa4ca3294e67578be750f901cac199352
```

The resulting transaction can be found [here](https://rinkeby.etherscan.io/tx/0x7bd0d5b5ea7eaaea92f831e0589a26ffa4ca3294e67578be750f901cac199352). You can also decode it and see that everything looks right:
```
$ npx hardhat decode --network rinkeby --txhash 0x7bd0d5b5ea7eaaea92f831e0589a26ffa4ca3294e67578be750f901cac199352
```

<details><summary>Test on mainnet, not executed and with some changes to the code not to require the solver PK</summary>

```
$  npx hardhat --network mainnet withdraw --receiver 0x3328f5f2cecaf00a2443082b657cedeaf70bfaef --min-value 1  
Ignored 0.150611619518508192 units of LON (0x0000000000095413afc295d19edeb1ad7b71c952) with value 0.80 USD
Ignored 15.403545659788133376 units of DNT (0x0AbdAce70D3790235af448C88547603b945604ea) with value 0.00 USD
Ignored 32.69270209482514432 units of BLT (0x107c4504cd79C5d2696Ea0030a8dD4e92601B82e) with value 0.00 USD
Ignored 96.746923491051454464 units of CRE (0x115eC79F1de567eC68B7AE7eDA501b406626478e) with value 0.00 USD
Ignored 831.541192895538528256 units of DOGEFATHER (0x11cFdA8C07eAF4903329458fE5826528DAD65cb6) with value 0.00 USD
Ignored 51284.395327678622728192 units of DOGEN (0x17eb50FDD2995696eE82912a80a9766fCBb0ECcA) with value 0.00 USD
Ignored 0.134376512895210384 units of REP (0x1985365e9f78359a9B6AD760e32412f4a445E862) with value 0.00 USD
Ignored 106.0204604928987136 units of TALAO (0x1D4cCC31dAB6EA20f461d329a0562C1c58412515) with value 0.00 USD
Ignored 9579.80114567937666238 units of STAK (0x1F8A626883d7724DBd59eF51CBD4BF1Cf2016D13) with value 0.00 USD
Ignored 0.144586 units of CLV (0x22222C03318440305aC3e8a7820563d6A9FD777F) with value 0.00 USD
Ignored 110.718534488326467584 units of ARES (0x358AA737e033F34df7c54306960a38d09AaBd523) with value 0.00 USD
Ignored 0.173064453608728384 units of FWB (0x35bD01FC9d6D5D81CA9E055Db88Dc49aa2c699A8) with value 0.00 USD
Ignored 78.0 units of SLP (0x37236CD05b34Cc79d3715AF2383E96dd7443dCF1) with value 0.00 USD
Ignored 7482.86469653857828864 units of ELT (0x380291A9A8593B39f123cF39cc1cc47463330b1F) with value 0.00 USD
Ignored 5.67221278023506944 units of MICRO (0x3B4102dfE101EC3fC22f4c95FBEf78EF6213656b) with value 0.00 USD
Ignored 232.913087627952553984 units of IMS (0x3c4030839708a20fd2fb379cf11810dde4888d93) with value 0.00 USD
Ignored 3.89128990209083648 units of DRGN (0x419c4dB4B9e25d6Db2AD9691ccb832C8D9fDA05E) with value 0.00 USD
Ignored 16.60102199434996736 units of XIV (0x44f262622248027f8E2a8Fb1090c4Cf85072392C) with value 0.00 USD
Ignored 249.07 units of TEL (0x467Bccd9d29f223BcE8043b84E8C8B282827790F) with value 0.00 USD
Ignored 14.291960900894280192 units of UNO (0x474021845C4643113458ea4414bdb7fB74A01A77) with value 0.00 USD
Ignored 10.239162021531009024 units of XFIT (0x4aa41bC1649C9C3177eD16CaaA11482295fC7441) with value 0.00 USD
Ignored 1.89442975736388576 units of GDAO (0x515d7E9D75E2b76DB60F8a051Cd890eBa23286Bc) with value 0.00 USD
Ignored 12.718525193977480192 units of eRSDL (0x5218E472cFCFE0b64A064F055B43b4cdC9EfD3A6) with value 0.00 USD
Ignored 0.815440796427987712 units of LOC (0x5e3346444010135322268a4630d2ED5F8D09446c) with value 0.00 USD
Ignored 0.00236846786510796 units of FLX (0x6243d8CEA23066d098a15582d81a598b4e8391F4) with value 0.00 USD
Ignored 0.916158078552996864 units of BRIBE (0x679fA6dC913aCAB6dEF33Ec469FC6E421bC794F5) with value 0.00 USD
Ignored 50.261815114028793856 units of FORCE (0x6807D7f7dF53b7739f6438EABd40Ab8c262c0aa8) with value 0.00 USD
Ignored 0.083908481066941506 units of LQTY (0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D) with value 0.00 USD
Ignored 213.217488288607535104 units of IOTX (0x6fB3e0A217407EFFf7Ca062D46c26E5d60a14d69) with value 0.00 USD
Ignored 41.427347914657519616 units of VVT (0x755be920943eA95e39eE2DC437b268917B580D6e) with value 0.00 USD
Ignored 2013747.678225941359089656 units of ELON (0x761D38e5ddf6ccf6Cf7c55759d5210750B5D60F3) with value 0.00 USD
Ignored 198.513555210712907776 units of cBSN (0x7d4B1d793239707445305D8d2456D2c735F6B25B) with value 0.00 USD
Ignored 19.059192750087235584 units of FF (0x7E9D8f07A64e363e97A648904a89fb4cd5fB94CD) with value 0.00 USD
Ignored 3.987012583690302976 units of FRAX (0x853d955acef822db058eb8505911ed77f175b99e) with value 0.69 USD
Ignored 0.942112196769334144 units of BLUE (0x927937aA4c989f8C907941E39AbD79cC2bfd7cB1) with value 0.00 USD
Ignored 0.4817712701105712 units of POP! (0x98629512Ed2239974e169341be5b920EA4dcdB21) with value 0.00 USD
Ignored 440.683765710497120256 units of QSP (0x99ea4dB9EE77ACD40B119BD1dC4E33e1C070b80d) with value 0.00 USD
Ignored 3.789668875989592064 units of POLC (0xaA8330FB2B4D5D07ABFE7A72262752a8505C6B37) with value 0.00 USD
Ignored 0.009999999999999555 units of ROOM (0xad4f86a25bbc20ffb751f2fac312a0b4d8f88c64) with value 0.01 USD
Ignored 57.236015695355867136 units of LOTTO (0xb0dFd28d3CF7A5897C694904Ace292539242f858) with value 0.00 USD
Ignored 0.009999999999999966 units of YAX (0xb1dC9124c395c1e97773ab855d66E879f053A289) with value 0.00 USD
Ignored 3660.12903385385664512 units of ALD (0xb339FcA531367067e98d7c4f9303Ffeadff7B881) with value 0.00 USD
Ignored 11.777538610058515136 units of DCTD (0xb566E883555aEBf5B1DB211070b530Ab00a4B18a) with value 0.00 USD
Ignored 0.889396747409995008 units of NEXO (0xb62132e35a6c13ee1ee0f84dc5d40bad8d815206) with value 0.13 USD
Ignored 58.360507094552076288 units of PCT (0xbc16da9df0A22f01A16BC0620a27e7D6d6488550) with value 0.00 USD
Ignored 50.800243693861142528 units of SPDR (0xbcD4b7dE6fde81025f74426D43165a5b0D790Fdd) with value 0.00 USD
Ignored 50092279689.524082808734089216 units of SHELON (0xC29e9Cd9DDC53E60CBc2417517DDd93EF071D18b) with value 0.00 USD
Ignored 3.65613725272415744 units of NFT (0xcB8d1260F9c92A3A545d409466280fFdD7AF7042) with value 0.00 USD
Ignored 7.411711960234550439 units of BONDLY (0xd2dda223b2617cb616c1580db421e4cfae6a8a85) with value 0.75 USD
Ignored 0.322726450032860624 units of STACK (0xe0955F26515d22E347B17669993FCeFcc73c3a0a) with value 0.00 USD
Ignored 1.107171089381117248 units of USF (0xE0e05c43c097B0982Db6c9d626c4eb9e95C3b9ce) with value 0.00 USD
Ignored 0.709656016159350144 units of STN (0xe63d6B308BCe0F6193AeC6b7E6eBa005f41e36AB) with value 0.00 USD
Ignored 0.000000000000000006 units of KBTC (0xe6c3502997f97f9bde34cb165fbce191065e068f) with value 0.00 USD
Ignored 0.099999999999999965 units of ID (0xebd9d99a3982d547c5bb4db7e3b1f9f14b67eb83) with value 0.07 USD
Ignored 7.885390691559115776 units of SALE (0xF063fE1aB7a291c5d06a86e14730b00BF24cB589) with value 0.00 USD
Ignored 0.883206557483534336 units of ICE (0xf16e81dce15B08F326220742020379B855B87DF9) with value 0.00 USD
Ignored 692.75413330866888704 units of SAITO (0xFa14Fa6958401314851A17d6C5360cA29f74B57B) with value 0.00 USD
Ignored 1842036.604159542840786944 units of AVO (0xfa6f7881E52fDF912c4a285D78a3141B089cE859) with value 0.00 USD
Ignored 0.005055731028276144 units of DDIM (0xfbeea1c75e4c4465cb2fccc9c6d6afe984558e20) with value 0.25 USD
Ignored 0.003721801471254996 units of LAYERX (0xfe56E974C1C85e9351325fb2D62963A022Ad624F) with value 0.00 USD
Amounts to withdraw:
 address                                    | value (usd) | balance                    | symbol       
--------------------------------------------+-------------+----------------------------+--------------
 0x68a3637ba6e75c0f66b61a42639c4e9fcd3d4824 |        1.04 |       0.987460674618375936 | MOON         
 0x0954906da0bf32d5479e25f46056d22f08464cab |        1.04 |       0.026347582524577004 | INDEX        
 0xf433089366899d83a9f26a773d59ec7ecf30355e |        1.05 |       0.278487660000000000 | MTL          
 0xfef4185594457050cc9c23980d301908fe057bb1 |        1.07 |       0.982474241710663040 | VIDT         
 0x48c3399719b582dd63eb5aadf12a40b4c3f52fa2 |        1.11 |       5.119290310703567872 | SWISE        
 0x5a98fcbea516cf06857215779fd812ca3bef1b32 |        1.19 |       0.527555080097293824 | LDO          
 0x875773784af8135ea0ef43b5a374aad105c5d39e |        1.21 |       0.106049195971024016 | IDLE         
 0x126c121f99e1e211df2e5f8de2d96fa36647c855 |        1.23 |       0.152356518598778624 | DEGEN        
 0x178c820f862b14f316509ec36b13123da19a6054 |        1.25 |       0.084587455746110480 | EWTB         
 0xd23ac27148af6a2f339bd82d0e3cff380b5093de |        1.33 |       0.678180751610238592 | SI           
 0x99fe3b1391503a1bc1788051347a1324bff41452 |        1.34 |       2.100849682905732864 | SX           
 0xb78b3320493a4efaa1028130c5ba26f0b6085ef8 |        1.37 |       0.504160540979272832 | DRC          
 0xac3211a5025414af2866ff09c23fc18bc97e79b1 |        1.39 |      25.225426162184658944 | DOV          
 0x3d6f0dea3ac3c607b3998e6ce14b6350721752d9 |        1.40 |       0.039236799773616392 | CARDS        
 0x00c83aecc790e8a4453e5dd3b0b4b3680501a7a7 |        1.47 |       2.065682063709253632 | SKL          
 0x817bbdbc3e8a1204f3691d14bb44992841e3db35 |        1.47 |      31.680259255120261120 | CUDOS        
 0xf680429328caaacabee69b7a9fdb21a71419c063 |        1.48 |       2.966940256250521088 | BFLY         
 0x8207c1ffc5b6804f6024322ccf34f29c3541ae26 |        1.50 |       0.830466166067597696 | OGN          
 0xf1f955016ecbcd7321c7266bccfb96c68ea5e49b |        1.53 |       1.510080045367205632 | RLY          
 0x8a9c67fee641579deba04928c4bc45f66e26343a |        1.59 |       9.334126404910669824 | JRT          
 0xad32a8e6220741182940c5abf610bde99e737b2d |        1.71 |       1.040039004589960960 | DOUGH        
 0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb |        1.81 |       0.000996641805088226 | sETH         
 0xdd974d5c2e2928dea5f71b9825b8b646686bd200 |        1.85 |       0.571800152806676256 | KNCL         
 0x33d0568941c0c64ff7e0fb4fba0b11bd37deed9f |        1.97 |       3.922985908690109440 | RAMP         
 0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce |        2.00 | 1170188.332494252117327872 | SHIB         
 0xb4272071ecadd69d933adcd19ca99fe80664fc08 |        2.00 |       1.787725379851048448 | XCHF         
 0xc944e90c64b2c07662a292be6244bdf05cda44a7 |        2.06 |       1.417282722020539818 | GRT          
 0x5dc02ea99285e17656b8350722694c35154db1e8 |        2.18 |      63.273630790000000000 | BOND_finance 
 0xeeaa40b28a2d1b0b08f6f97bb1dd4b75316c6107 |        2.19 |       0.580949031310495872 | GOVI         
 0xeb4c2781e4eba804ce9a9803c67d0893436bb27d |        2.19 |       0.000042450000000000 | renBTC       
 0x429881672b9ae42b8eba0e26cd9c73711b891ca5 |        2.21 |       0.162172662669454880 | PICKLE       
 0x69af81e73a73b40adf4f3d4223cd9b1ece623074 |        2.28 |       0.151637253302042000 | MASK_NTWRK   
 0xf418588522d5dd018b425e472991e52ebbeeeeee |        2.33 |       0.477252947673300034 | PUSH         
 0x4a220e6096b25eadb88358cb44068a3248254675 |        2.36 |       0.055468224217239384 | QNT          
 0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec |        2.43 |       6.729860405744791040 | POLY         
 0xc0ba369c8db6eb3924965e5c4fd0b4c1b91e305f |        2.46 |       2.430543338833439744 | DUCK         
 0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd |        2.51 |      10.407183581988000000 | GRID         
 0xa8b919680258d369114910511cc87595aec0be6d |        2.53 |       0.109557376797665024 | LYXe         
 0x6149c26cd2f7b5ccdb32029af817123f6e37df5b |        2.62 |       0.199502869354256512 | LPOOL        
 0xbbc2ae13b23d715c30720f079fcd9b4a74093505 |        2.66 |       0.129718257775038864 | ERN          
 0xdbdb4d16eda451d0503b854cf79d55697f90c8df |        2.69 |       0.002052362422551868 | ALCX         
 0x5eaa69b29f99c84fe5de8200340b4e9b4ab38eac |        2.78 |       2.143027235883594765 | RAZE         
 0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713 |        2.79 |       0.003846827354524543 | COVER        
 0x159751323a9e0415dd3d6d42a1212fe9f4a0848c |        2.86 |      12.241497409642713088 | INFI         
 0x89bd2e7e388fab44ae88bef4e1ad12b4f1e0911c |        2.90 |       1.567489894721627136 | NUX          
 0x0000000000004946c0e9f43f4dee607b0ef1fa1c |        2.95 |       1.000000000000000000 | CHI          
 0xe28b3b32b6c345a34ff64674606124dd5aceca30 |        2.98 |       0.132548366301166208 | INJ          
 0x8f8221afbb33998d8584a2b05749ba73c37a938a |        3.05 |      23.238445117922000896 | REQ          
 0x7eaf9c89037e4814dc0d9952ac7f888c784548db |        3.08 |      10.769462295774316544 | ROYA         
 0x31c8eacbffdd875c74b94b077895bd78cf1e64a3 |        3.09 |       0.191072047166370049 | RAD          
 0x7b0c06043468469967dba22d1af33d77d44056c8 |        3.14 |       1.488600000000000000 | MRPH         
 0x543ff227f64aa17ea132bf9886cab5db55dcaddf |        3.24 |      12.120966975753836544 | GEN          
 0x21bfbda47a0b4b5b1248c767ee49f7caa9b23697 |        3.30 |       2.207180481542716416 | OVR          
 0xd15ecdcf5ea68e3995b2d0527a0ae0a3258302f8 |        3.31 |     395.708223527037435904 | MCX          
 0x26c8afbbfe1ebaca03c2bb082e69d0476bffe099 |        3.31 |       1.269663664116123392 | CELL         
 0xff20817765cb7f73d4bde2e66e067e58d11095c2 |        3.33 |      63.021936869964701696 | AMP          
 0x0f5d2fb29fb7d3cfee444a200298f468908cc942 |        3.39 |       2.509939227274531840 | MANA         
 0xe796d6ca1ceb1b022ece5296226bf784110031cd |        3.44 |       2.367101366493764096 | BLES         
 0x0d438f3b5175bebc262bf23753c1e53d03432bde |        3.46 |       0.039129724104806920 | wNXM         
 0x3155ba85d5f96b2d030a4966af206230e46849cb |        3.47 |       0.251163792666473504 | RUNE         
 0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7 |        3.55 |      70.149202873372262400 | AKRO         
 0xd26114cd6ee289accf82350c8d8487fedb8a0c07 |        3.55 |       0.471528121183831936 | OMG          
 0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9 |        3.76 |       0.008955251086282862 | AAVE         
 0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2 |        3.78 |       1.409013748138866688 | MTA          
 0x03ab458634910aad20ef5f1c8ee96f1d6ac54919 |        3.79 |       1.267020979909926016 | RAI          
 0xb20043f149817bff5322f1b928e89abfc65a9925 |        3.90 |    1019.353247660000000000 | EXRT         
 0x0391d2021f89dc339f60fff84546ea23e337750f |        3.90 |       0.091388856165238736 | BOND         
 0xf5d669627376ebd411e34b98f19c868c8aba5ada |        4.09 |       0.434162710063019616 | AXS          
 0x4e15361fd6b4bb609fa63c81a2be19d873717870 |        4.13 |       5.375615037216554496 | FTM          
 0xb4efd85c19999d84251304bda99e90b92300bd93 |        4.20 |       0.308256437879174612 | RPL          
 0x0ada190c81b814548ddc2f6adc4a689ce7c1fe73 |        4.30 |       0.095941103801386308 | YAXIS        
 0x960b236a07cf122663c4303350609a66a7b288c0 |        4.56 |       0.289834572899651872 | ANTv1        
 0x4691937a7508860f876c9c0a2a617e7d9e945d4b |        4.61 |       4.913420887439031808 | WOO          
 0xbbbbca6a901c926f240b89eacb641d8aec7aeafd |        4.77 |       8.841308941059921776 | LRC          
 0xa47c8bf37f92abed4a126bda807a7b7498661acd |        4.78 |       4.787290415046169600 | UST          
 0xba11d00c5f74255f56a5e366f4f77f5a186d7f55 |        4.79 |       0.205498423900756608 | BAND         
 0x8a854288a5976036a725879164ca3e91d30c6a1b |        4.96 |       0.879579788851925888 | GET          
 0xefc1c73a3d8728dc4cf2a18ac5705fe93e5914ac |        4.99 |       1.539977769875409920 | METRIC       
 0xd46ba6d942050d489dbd938a2c909a5d5039a161 |        5.15 |       4.710446263000000000 | AMPL         
 0x27054b13b1b798b345b591a4d22e6562d47ea75a |        5.17 |      11.299400000000000000 | AST          
 0xd291e7a03283640fdc51b121ac401383a46cc623 |        5.22 |       0.306572596807365968 | RGT          
 0xcbfef8fdd706cde6f208460f2bf39aa9c785f05d |        5.23 |       1.714778108593809024 | KINE         
 0x956f47f50a910163d8bf957cf5846d573e7f87ca |        5.37 |       5.673366608956048128 | FEI          
 0x85eee30c52b0b379b046fb0f85f4f3dc3009afec |        5.40 |       8.085643005385578240 | KEEP         
 0xf938424f7210f31df2aee3011291b658f872e91e |        5.42 |       1.826056840446850560 | VISR         
 0xf3dcbc6d72a4e1892f7917b7c43b74131df8480e |        5.57 |       2.804184416405680640 | BDP          
 0x9f9c8ec3534c3ce16f928381372bfbfbfb9f4d24 |        5.60 |     118.145895437910941696 | GLQ          
 0x41d5d79431a913c4ae7d69a668ecdfe5ff9dfb68 |        5.62 |       0.007247822928571607 | INV          
 0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b |        5.63 |       0.010793288077249486 | DPI          
 0xf0939011a9bb95c3b791f0cb546377ed2693a574 |        5.88 |      21.293913432161800192 | ZERO         
 0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6 |        5.93 |       5.714038839965841920 | RDN          
 0x43044f861ec040db59a7e324c40507addb673142 |        6.07 |       0.279836812098535760 | CAP          
 0xb8baa0e4287890a5f79863ab62b7f175cecbd433 |        6.08 |       1.967821457111798528 | SWRV         
 0x8888801af4d980682e47f1a9036e589479e835c5 |        6.10 |       0.054680135264273622 | MPH          
 0x04fa0d235c4abf4bcf4787af4cf447de572ef828 |        6.26 |       0.210945115947887024 | UMA          
 0x4fe83213d56308330ec302a8bd641f1d0113a4cc |        6.31 |      12.187455178373740032 | NU           
 0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c |        6.43 |       2.363443081694471296 | ENJ          
 0x5f98805a4e8be255a32880fdec7f6728c6568ba0 |        6.45 |       6.474499171409545728 | LUSD         
 0x408e41876cccdc0f92210600ef50372656052a38 |        6.47 |       7.827470869601827584 | REN          
 0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd |        6.53 |      61.925917011583733760 | HAKKA        
 0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d |        6.63 |      33.982967526781839360 | PNK          
 0xa1faa113cbe53436df28ff0aee54275c13b40975 |        6.76 |       3.612616490087735936 | ALPHA        
 0x3472a5a71965499acd81997a54bba8d852c6e53d |        6.84 |       0.272813658646128016 | BADGER       
 0x7f3edcdd180dbe4819bd98fee8929b5cedb3adeb |        6.91 |      11.449667287089800192 | XTK          
 0x67b6d479c7bb412c54e03dca8e1bc6740ce6b99c |        6.93 |       6.113682557021622784 | KYL          
 0x57ab1ec28d129707052df4df418d58a2d46d5f51 |        6.98 |       6.986485833463702272 | sUSD         
 0x374cb8c27130e2c9e04f44303f3c8351b9de61c1 |        6.99 |    7214.342442874706198528 | BAO          
 0xf970b8e36e23f7fc3fd752eea86f8be8d83375a6 |        7.00 |      39.951788231510491136 | RCN          
 0x24a6a37576377f63f194caa5f518a60f45b42921 |        7.22 |       0.011342401499412459 | BANK         
 0x5cf04716ba20127f1e2297addcf4b5035000c9eb |        7.22 |      11.003084851159939072 | NKN          
 0x0d8775f648430679a709e98d2b0cb6250d2887ef |        7.37 |       7.077313152608984237 | BAT          
 0x28a06c02287e657ec3f8e151a13c36a1d43814b0 |        7.38 |      15.499781359137296896 | BAG          
 0x0b38210ea11411557c13457d4da7dc6ea731b88a |        7.64 |       1.078193564138480064 | API3         
 0x43dfc4159d86f3a37a5a4b3d4580b888ad7d4ddd |        7.74 |       2.053597110815159680 | DODO         
 0x2ba592f78db6436527729929aaf6c908497cb200 |        8.09 |       0.046043565110949484 | CREAM        
 0xaa6e8127831c9de45ae56bb1b0d4d4da6e5665bd |        8.37 |       0.045524830050079648 | ETH2x-FLI    
 0x0ff6ffcfda92c53f615a4a75d982f399c989366b |        8.88 |       2.792821906688984512 | LAYER        
 0x77fba179c79de5b7653f68b5039af940ada60ce0 |        9.08 |       0.217316364614077484 | FORTH        
 0x83e6f1e41cdd28eaceb20cb649155049fac3d5aa |        9.17 |       3.054165279056208128 | POLS         
 0xb6ca7399b4f9ca56fc27cbff44f4d2e4eef1fc81 |        9.29 |       0.374477012067809160 | MUSE         
 0x73968b9a57c6e53d41345fd57a6e6ae27d6cdb2f |        9.98 |       1.761922785438692256 | SDT          
 0xeb269732ab75a6fd61ea60b06fe994cd32a83549 |       10.02 |       9.948686348063961088 | USDx         
 0xe41d2489571d322189246dafa5ebde1f4699f498 |       11.30 |       6.696835032254643968 | ZRX          
 0x77777feddddffc19ff86db637967013e6c6a116c |       11.39 |       0.089703688116899942 | TORN         
 0xfc1e690f61efd961294b3e1ce3313fbd8aa4f85d |       12.59 |      17.979071948538917379 | aDAIv1       
 0xfa5047c9c78b8877af97bdcb85db743fd7313d4a |       14.21 |       0.036321091548296504 | ROOK         
 0x798d1be841a82a273720ce31c822c61a67a601c3 |       16.03 |       0.000300858000000000 | DIGG         
 0x0cec1a9154ff802e7934fc916ed7ca50bde6844e |       17.05 |       0.965828060472570576 | POOL         
 0xc00e94cb662c3520282e6f5717214004a7f26888 |       18.45 |       0.027240428917206179 | COMP         
 0x58b6a8a3302369daec383334672404ee733ab239 |       20.24 |       0.560581350098667056 | LPT          
 0xd533a949740bb3306d119cc777fa900ba034cd52 |       21.70 |       7.595491334278202581 | CRV          
 0x5d3a536e4d6dbd6114cc1ead35777bab948e3643 |       23.63 |     846.656628550000000000 | cDAI         
 0x514910771af9ca656af840dff83e8264ecf986ca |       24.21 |       0.661542974641105580 | LINK         
 0xe2f2a5c287993345a840db3b0845fbc70f5935a5 |       25.04 |      24.663021350002020352 | mUSD         
 0x2260fac5e5542a773aa44fbcfedf7c193bc2c599 |       26.07 |       0.000473790000000000 | WBTC         
 0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab |       29.89 |       0.197346462600706069 | MIST         
 0x0ae055097c6d159879521c384f1d2123d1f195e6 |       31.98 |       1.057531216051700664 | STAKE        
 0x6b3595068778dd592e39a122f4f5a5cf09c90fe2 |       32.84 |       2.323599794926335278 | SUSHI        
 0x111111111117dc0aa78b770fa6a738034120c302 |       34.75 |       6.308027804483865502 | 1INCH        
 0xec67005c4e498ec7f55e092bd1d35cbc47c91892 |       35.01 |       0.298649807251363558 | MLN          
 0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f |       35.80 |       2.020292453592274536 | SNX          
 0x0cf0ee63788a0849fe5297f3407f701e122cc023 |       41.09 |     245.428947658983958528 | DATA         
 0x6c6ee5e31d828de241282b9606c8e98ea48526e2 |       44.38 |    2878.733891803479474176 | HOT          
 0xc3771d47e2ab5a519e2917e61e23078d0c05ed7f |       45.63 |     119.942024382711978549 | GTH          
 0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c |       51.91 |       7.602403836349714208 | BNT          
 0x459086f2376525bdceba5bdda135e4e9d3fef5bf |       58.90 |       0.063945000000000000 | renBCH       
 0x1a5f9352af8af974bfc03399e3767df6370d82e4 |       70.14 |      62.698358112815252224 | OWL          
 0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2 |       73.62 |       0.017404462936577209 | MKR          
 0xdd1ad9a21ce722c151a836373babe42c868ce9a4 |       76.11 |     197.886616978132417709 | UBI          
 0xba100000625a3754423978a60c9317c58a424e3d |       76.91 |       1.290359323320928892 | BAL          
 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984 |       88.92 |       2.138358345065805893 | UNI          
 0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e |      127.57 |       0.002626320659691537 | YFI          
 0xdac17f958d2ee523a2206206994597c13d831ec7 |      218.82 |     218.911579000000000000 | USDT         
 0x6810e776880c02933d47db1b9fc05908e5386b96 |      235.23 |       1.074232580823507219 | GNO          
 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 |      310.36 |     309.312703000000000000 | USDC         
 0x6b175474e89094c44da98b954eedeac495271d0f |      421.29 |     421.291864262137166313 | DAI          
 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 |     2010.05 |       0.735129449790659045 | WETH         

The transaction will cost approximately 0.144129252 ETH (394.59 USD) and will withdraw the balance of 157 tokens for an estimated total value of 4903.63 USD. All withdrawn funds will be sent to 0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf.
Submit? (y/n) n
```
</details>

<details><summary>Same for xdai, but there is basically nothing to withdraw there.</summary>

```
$ npx hardhat --network xdai withdraw --receiver 0x3328f5f2cecaf00a2443082b657cedeaf70bfaef --min-value 1 
Ignored 0.000018868279978627 units of UNCX (0x0116e28B43A358162B96f70B4De14C98A4465f25) with value 0.00 USD
Ignored 0.0012 units of CEL (0x0aCD91f92Fe07606ab51EA97d8521E29D110fD09) with value 0.00 USD
Ignored 0.000021983370723643 units of SHWEATPANTS (0x11C9F4c3E960CCe4464E25a9fA5414Ab72fc45EA) with value 0.00 USD
Ignored 0.000377987488643227 units of GEN (0x12daBe79cffC1fdE82FCd3B96DBE09FA4D8cd599) with value 0.00 USD
Ignored 0.000000924870733268 units of CREAM (0x1939D3431CF0E44B1d63b86e2cE489E5a341B1Bf) with value 0.00 USD
Ignored 0.000021190837007354 units of NIF (0x1A186E7268F3Ed5AdFEa6B9e0655f70059941E11) with value 0.00 USD
Ignored 0.001332866018351985 units of CRC (0x1B86ad8974662Af64E663a4cd799310C249889a7) with value 0.00 USD
Ignored 0.80736761412247502 units of xMOON (0x1e16aa4Df73d29C029d94CeDa3e3114EC191E25A) with value 0.00 USD
Ignored 0.000111251227436866 units of ZRX (0x226bCf0e417428a25012d0fA2183d37f92bCeDF6) with value 0.00 USD
Ignored 7.984984425367467707 units of FR (0x270DE58F54649608D316fAa795a9941b355A2Bd0) with value 0.00 USD
Ignored 0.042023848278502243 units of BID (0x2977893F4C04bfbd6EFc68d0e46598d27810d3dB) with value 0.00 USD
Ignored 0.000000009625161467 units of FRACTION (0x2bF2ba13735160624a0fEaE98f6aC8F70885eA61) with value 0.00 USD
Ignored 3.292917155885210783 units of xBRICK (0x2f9ceBf5De3bc25E0643D0E66134E5bf5c48e191) with value 0.00 USD
Ignored 0.101079177768033298 units of HOT (0x346b2968508d32f0192cD7a60Ef3D9C39a3cF549) with value 0.00 USD
Ignored 0.000015553766518889 units of AGVE (0x3a97704a1b25F08aa230ae53B352e2e72ef52843) with value 0.00 USD
Ignored 0.729917049374458483 units of JPYC (0x417602f4fbdd471A431Ae29fB5fe0A681964C11b) with value 0.00 USD
Ignored 0.000093086481197965 units of UNI (0x4537e328Bf7e4eFA29D05CAeA260D7fE26af9D74) with value 0.00 USD
Ignored 0.040727925399264961 units of TRIPS (0x479e32cDFF5F216f93060700C711D1cC8E811a6B) with value 0.00 USD
Ignored 0.00000026 units of renBTC (0x4A88248BAa5b39bB4A9CAa697Fb7f8ae0C3f0ddB) with value 0.01 USD
Ignored 0.000012065579629622 units of RARI (0x4bE85ACC1cd711F403dC7BdE9e6caDfC5A94744b) with value 0.00 USD
Ignored 0.002391 units of USDT (0x4ECaBa5870353805a9F068101A40E0f32ed605C6) with value 0.00 USD
Ignored 0.000022001210435194 units of ALVIN (0x50DBde932A94b0c23D27cdd30Fbc6B987610c831) with value 0.00 USD
Ignored 0.00000265 units of MEME (0x512a2Eb0277573ae9Be0d48c782590b624048fdF) with value 0.00 USD
Ignored 0.554893738452724518 units of DONUT (0x524B969793a64a602342d89BC2789D43a016B13A) with value 0.00 USD
Ignored 0.00096506785360463 units of CRC (0x55b702c10044cE03F712eb7A07C70bfb5c338649) with value 0.00 USD
Ignored 0.000487370242272968 units of ENJ (0x5A757F0BcAdFDb78651B7bDBe67e44e8Fd7F7f6b) with value 0.00 USD
Ignored 0.000000043734478428 units of MKR (0x5fd896D248fbfa54d26855C267859eb1b4DAEe72) with value 0.00 USD
Ignored 0.0809 units of JOON (0x5fE9885226677F3Eb5C9ad8aB6c421B4EA38535d) with value 0.00 USD
Ignored 0.000169072068934123 units of CRC (0x6293268785399bed001CB68A8Ee04d50DA9C854D) with value 0.00 USD
Ignored 0.021054839143598466 units of MIVA (0x63e62989D9EB2d37dfDB1F93A22f063635b07d51) with value 0.00 USD
Ignored 0.001470081492724824 units of CRC (0x685B01e3Cf8107C8E4dD3043E6098f4F050B3949) with value 0.00 USD
Ignored 0.000003888615299231 units of WETH (0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1) with value 0.01 USD
Ignored 0.000010563548252741 units of EWTB (0x6A8cb6714B1EE5b471a7D2eC4302cb4f5Ff25eC2) with value 0.00 USD
Ignored 0.001168156638141164 units of UNCL (0x703120F2f2011a0D03A03a531Ac0e84e81F15989) with value 0.00 USD
Ignored 0.002954766450617989 units of MATIC (0x7122d7661c4564b7C6Cd4878B06766489a6028A2) with value 0.00 USD
Ignored 0.000012461146773865 units of HNY (0x71850b7E9Ee3f13Ab46d67167341E4bDc905Eef9) with value 0.00 USD
Ignored 0.00596576 units of CHSB (0x76eaFffA1873a8aCd43864B66A728bd873c5E08a) with value 0.00 USD
Ignored 0.000468253991747251 units of MANA (0x7838796B6802B18D7Ef58fc8B757705D6c9d12b3) with value 0.00 USD
Ignored 0.001062767916971086 units of 1INCH (0x7f7440C5098462f833E123B44B8A03E1d9785BAb) with value 0.00 USD
Ignored 0.000021758398063852 units of OMG (0x8395F7123ba3FFAD52E7414433D825931C81C879) with value 0.00 USD
Ignored 0.000004138918063443 units of ROBOT (0x8D02b73904856De6998Ffdf6e7ee18cC21137a79) with value 0.00 USD
Ignored 0.00000093 units of WBTC (0x8e5bBbb09Ed1ebdE8674Cda39A0c169401db4252) with value 0.05 USD
Ignored 0.066059992894517426 units of HIVESHARE (0x97E4ebc14C117C1ac2D032a5A8140C84628b0d17) with value 0.00 USD
Ignored 0.031599556108666906 units of PAN (0x981fB9BA94078a2275A8fc906898ea107B9462A8) with value 0.00 USD
Ignored 0.000494645074797687 units of CRC (0x9Ae18aF73C10dAA6c5159299cCEF0b943Bd0b5aA) with value 0.00 USD
Ignored 0.000190236275289733 units of YLD (0xA2FEc95B3d3feCb39098E81f108533E1abF22CcF) with value 0.00 USD
Ignored 0.001233980714157017 units of CRC (0xa8Edb428D303B02Fb9b6FF35137a3Fa040b873E6) with value 0.00 USD
Ignored 0.000208667939804685 units of HAUS (0xb0C5f3100A4d9d9532a4CfD68c55F1AE8da987Eb) with value 0.00 USD
Ignored 0.000894679477932241 units of ETHO (0xB17d999E840e0c1B157Ca5Ab8039Bd958b5fA317) with value 0.00 USD
Ignored 0.000408386145983035 units of CRC (0xb2Eb4956610C3aF22Dd4ab064C2a8B2A0a7ce081) with value 0.00 USD
Ignored 0.024860843169102517 units of PRTCLE (0xB5d592f85ab2D955c25720EbE6FF8D4d1E1Be300) with value 0.00 USD
Ignored 0.00098414054999822 units of STAKE (0xb7D311E2Eb55F2f68a9440da38e7989210b9A05e) with value 0.04 USD
Ignored 0.001246277316877066 units of CRC (0xB8d2f3Ecb887c3D61adD80F23A023360dc6eBE9e) with value 0.00 USD
Ignored 0.000341955282947703 units of CRC (0xbc24Fde08BB61e59c466a737908a40E8993aDd03) with value 0.00 USD
Ignored 0.000000356513547688 units of YFI (0xbf65bfcb5da067446CeE6A706ba3Fe2fB1a9fdFd) with value 0.00 USD
Ignored 0.07 units of MCDC (0xC577cDdABB7893cC2cA15eF4b5D5e5E13c3FeeD3) with value 0.00 USD
Ignored 0.000000298608145893 units of WBNB (0xCa8d20f3e0144a72C6B5d576e9Bd3Fd8557E2B04) with value 0.00 USD
Ignored 0.00062365491659162 units of AUT (0xcaE40062a887581A3d1661d0AC2b481c32e3E938) with value 0.00 USD
Ignored 0.000457130574394506 units of LTI (0xcF9Dc2de2A67d7db1A7171e3b8456D2171E4da75) with value 0.00 USD
Ignored 0.032330860237568702 units of HOPR (0xD057604A14982FE8D88c5fC25Aac3267eA142a08) with value 0.01 USD
Ignored 0.00039948 units of UBT (0xd3b93fF74E43Ba9568e5019b38AdDB804feF719B) with value 0.00 USD
Ignored 0.000331227244021042 units of CRC (0xD5084760914184D78A9E21Cd7aA3da9015fD59bD) with value 0.00 USD
Ignored 0.006369506 units of AMIS (0xD51e1ddD116fFF9A71C1B8FEEb58113aFa2B4d93) with value 0.00 USD
Ignored 0.28706728 units of HEX (0xd9Fa47e33d4Ff7a1ACA489DE1865ac36c042B07a) with value 0.00 USD
Ignored 2.361056526605340672 units of xdbx (0xDaADd8D96D01e47ee5E4eAFEcF14cbe46909f335) with value 0.00 USD
Ignored 0.037614368092366738 units of COLD (0xdbcadE285846131a5e7384685EADDBDFD9625557) with value 0.00 USD
Ignored 0.028649 units of USDC (0xDDAfbb505ad214D7b80b1f830fcCc89B60fb7A83) with value 0.02 USD
Ignored 0.000124181635682552 units of BADGER (0xdfc20AE04ED70bd9c7D720F449eEDAe19F659D65) with value 0.00 USD
Ignored 0.00012940400620986 units of LINK (0xE2e73A1c69ecF83F464EFCE6A5be353a37cA09b2) with value 0.00 USD
Ignored 0.091447997804467295 units of DATA (0xE4a2620edE1058D61BEe5F45F6414314fdf10548) with value 0.01 USD
Ignored 1.473139510077576192 units of MESH (0xE7EF58d8180Cc269C6620dED3E6cc536A52E2ebD) with value 0.00 USD
Ignored 0.030751190931811177 units of WXDAI (0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d) with value 0.03 USD
Ignored 0.052549314931712844 units of CHEEMS (0xEaF7B3376173DF8BC0C22Ad6126943cC8353C1Ee) with value 0.00 USD
Ignored 0.011010874386765347 units of TRAC (0xEddd81E0792E764501AaE206EB432399a0268DB5) with value 0.00 USD
Ignored 0.141401827594982836 units of XGT (0xf1738912ae7439475712520797583ac784ea9033) with value 0.00 USD
Ignored 0.014108944880427338 units of GRT (0xFAdc59D012Ba3c110B08A15B7755A5cb7Cbe77D7) with value 0.02 USD
Ignored 0.00208251081992543 units of ALBC (0xfb23CfD35046466FdBA7f73dC2FcCb5b17ABf1Aa) with value 0.00 USD
Ignored 0.004248763065264472 units of DAI (0xFc8B2690F66B46fEC8B3ceeb95fF4Ac35a0054BC) with value 0.00 USD
Ignored 0.410916668197570343 units of XYO (0xfd4e5f45eA24eC50C4Db4367380b014875caF219) with value 0.00 USD
Ignored 0.00006722312388814 units of TRIB (0xff0Ce179a303F26017019acf78B951cB743B8D9b) with value 0.00 USD
Amounts to withdraw:
 address                                    | value (usd) | balance              | symbol 
--------------------------------------------+-------------+----------------------+--------
 0x48b1B0d077b4919b65b4E4114806dD803901E1D9 |       59.32 | 0.004474948506367516 | DIP    

The transaction will cost approximately 0.40976076 XDAI and will withdraw the balance of 1 tokens for an estimated total value of 59.32 USD. All withdrawn funds will be sent to 0x3328f5f2cecaf00a2443082b657cedeaf70bfaef.
Submit? (y/n) n
```
</details>