### PR TITLE
Version bump to `0.1.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v2-contracts",
-  "version": "0.0.1-alpha.17",
+  "version": "0.1.0",
   "license": "LGPL-3.0-or-later",
   "scripts": {
     "deploy": "hardhat deploy",


### PR DESCRIPTION
This PR just bumps the version to `v0.1.0` in preparation for the bug bounty program.
