### PR TITLE
Update prettier to v2.3.0

### DIFF
--- a/bench/fixture.ts
+++ b/bench/fixture.ts
@@ -341,12 +341,10 @@ export class BenchFixture {
       const [tokenIn, tokenOut] = [i % 2, (i + 1) % 2];
       encoder.encodeInteraction({
         target: uniswapTokens[tokenIn].address,
-        callData: uniswapTokens[
-          tokenIn
-        ].interface.encodeFunctionData("transfer", [
-          uniswapPair.address,
-          ethers.utils.parseEther("1.0"),
-        ]),
+        callData: uniswapTokens[tokenIn].interface.encodeFunctionData(
+          "transfer",
+          [uniswapPair.address, ethers.utils.parseEther("1.0")],
+        ),
       });
 
       debug(`encoding Uniswap T00${tokenIn} -> T00${tokenOut} token swap`);

--- a/bench/trace/gas.ts
+++ b/bench/trace/gas.ts
@@ -58,7 +58,7 @@ export function decodeGasTrace(
   );
   const transactionGas = baseGas + calldataGas;
 
-  const { gasRefund } = (trace as unknown) as GasExtension;
+  const { gasRefund } = trace as unknown as GasExtension;
 
   return node({
     name: callName(trace),
@@ -166,7 +166,7 @@ function computeGasTrace(
 ): GasTrace[] {
   const nodes = [];
 
-  const { gasLeft: initialGasLeft } = (steps[0] as unknown) as GasExtension;
+  const { gasLeft: initialGasLeft } = steps[0] as unknown as GasExtension;
   const gasLimit = num(initialGasLeft).add(transactionGas);
 
   for (const [i, step] of steps.entries()) {
@@ -182,12 +182,12 @@ function computeGasTrace(
       throw new Error("expected EVM step after sub trace");
     }
 
-    const { gasLeft: gasLeftAfterCall } = (nextStep as unknown) as GasExtension;
+    const { gasLeft: gasLeftAfterCall } = nextStep as unknown as GasExtension;
     const cumulativeGas = gasLimit.sub(num(gasLeftAfterCall));
     const { gasUsed } = step;
 
     if (isCallTrace(step)) {
-      const { gasRefund } = (step as unknown) as GasExtension;
+      const { gasRefund } = step as unknown as GasExtension;
       nodes.push(
         node({
           name: callName(step),

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "hardhat": "^2.2.1",
     "hardhat-deploy": "^0.7.3",
     "hardhat-gas-reporter": "^1.0.4",
-    "prettier": "^2.2.1",
+    "prettier": "^2.3.0",
     "prettier-plugin-solidity": "^1.0.0-beta.10",
     "solhint": "^3.3.4",
     "solhint-plugin-prettier": "^0.0.5",

--- a/src/tasks/decode.ts
+++ b/src/tasks/decode.ts
@@ -322,15 +322,11 @@ const setupDecodeTask: () => void = () => {
       const GPv2Settlement = await artifacts.readArtifact("GPv2Settlement");
       const settlementInterface = new utils.Interface(GPv2Settlement.abi);
 
-      const [
-        tokenAddresses,
-        clearingPrices,
-        trades,
-        interactions,
-      ] = settlementInterface.decodeFunctionData(
-        "settle",
-        calldata,
-      ) as EncodedSettlement;
+      const [tokenAddresses, clearingPrices, trades, interactions] =
+        settlementInterface.decodeFunctionData(
+          "settle",
+          calldata,
+        ) as EncodedSettlement;
 
       const tokens = await Promise.all(
         tokenAddresses.map(async (address: string, index: number) => ({

--- a/src/tasks/tenderly.ts
+++ b/src/tasks/tenderly.ts
@@ -5,9 +5,10 @@ import "@tenderly/hardhat-tenderly";
 import { Deployment } from "hardhat-deploy/types";
 import { task } from "hardhat/config";
 
-function separateProxiedContracts(
-  allDeployments: Record<string, Deployment>,
-): { proxied: string[]; unproxied: string[] } {
+function separateProxiedContracts(allDeployments: Record<string, Deployment>): {
+  proxied: string[];
+  unproxied: string[];
+} {
   const proxied = Object.entries(allDeployments)
     .filter(([, deployment]) => deployment.implementation !== undefined)
     .map(([name]) => name);

--- a/src/ts/deploy.ts
+++ b/src/ts/deploy.ts
@@ -30,13 +30,12 @@ export type ContractName = typeof CONTRACT_NAMES[keyof typeof CONTRACT_NAMES];
 /**
  * The deployment args for a contract.
  */
-export type DeploymentArguments<
-  T
-> = T extends typeof CONTRACT_NAMES.authenticator
-  ? never
-  : T extends typeof CONTRACT_NAMES.settlement
-  ? [string, string]
-  : unknown[];
+export type DeploymentArguments<T> =
+  T extends typeof CONTRACT_NAMES.authenticator
+    ? never
+    : T extends typeof CONTRACT_NAMES.settlement
+    ? [string, string]
+    : unknown[];
 
 /**
  * Allowed ABI definition types by Ethers.js.

--- a/test/GPv2AllowListAuthenticator.test.ts
+++ b/test/GPv2AllowListAuthenticator.test.ts
@@ -3,14 +3,8 @@ import { Contract } from "ethers";
 import { ethers, waffle } from "hardhat";
 
 describe("GPv2AllowListAuthentication", () => {
-  const [
-    deployer,
-    owner,
-    manager,
-    newManager,
-    nobody,
-    solver,
-  ] = waffle.provider.getWallets();
+  const [deployer, owner, manager, newManager, nobody, solver] =
+    waffle.provider.getWallets();
   let authenticator: Contract;
   let initialization: Promise<unknown>;
 

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -729,14 +729,12 @@ describe("GPv2Settlement", () => {
         );
       }
 
-      const {
-        inTransfers,
-        outTransfers,
-      } = await settlement.callStatic.computeTradeExecutionsTest(
-        encoder.tokens,
-        encoder.clearingPrices(prices),
-        encoder.trades,
-      );
+      const { inTransfers, outTransfers } =
+        await settlement.callStatic.computeTradeExecutionsTest(
+          encoder.tokens,
+          encoder.clearingPrices(prices),
+          encoder.trades,
+        );
       expect(inTransfers.length).to.equal(tradeCount);
       expect(outTransfers.length).to.equal(tradeCount);
     });
@@ -864,15 +862,11 @@ describe("GPv2Settlement", () => {
       };
 
       it("should compute amounts for fill-or-kill sell orders", async () => {
-        const {
-          executedSellAmount,
-          sellPrice,
-          executedBuyAmount,
-          buyPrice,
-        } = await computeSettlementForOrderVariant({
-          kind: OrderKind.SELL,
-          partiallyFillable: false,
-        });
+        const { executedSellAmount, sellPrice, executedBuyAmount, buyPrice } =
+          await computeSettlementForOrderVariant({
+            kind: OrderKind.SELL,
+            partiallyFillable: false,
+          });
 
         expect(executedSellAmount).to.deep.equal(sellAmount);
         expect(executedBuyAmount).to.deep.equal(
@@ -890,15 +884,11 @@ describe("GPv2Settlement", () => {
       });
 
       it("should compute amounts for fill-or-kill buy orders", async () => {
-        const {
-          executedSellAmount,
-          sellPrice,
-          executedBuyAmount,
-          buyPrice,
-        } = await computeSettlementForOrderVariant({
-          kind: OrderKind.BUY,
-          partiallyFillable: false,
-        });
+        const { executedSellAmount, sellPrice, executedBuyAmount, buyPrice } =
+          await computeSettlementForOrderVariant({
+            kind: OrderKind.BUY,
+            partiallyFillable: false,
+          });
 
         expect(executedSellAmount).to.deep.equal(
           buyAmount.mul(buyPrice).div(sellPrice),
@@ -916,15 +906,11 @@ describe("GPv2Settlement", () => {
       });
 
       it("should compute amounts for partially fillable sell orders", async () => {
-        const {
-          executedSellAmount,
-          sellPrice,
-          executedBuyAmount,
-          buyPrice,
-        } = await computeSettlementForOrderVariant({
-          kind: OrderKind.SELL,
-          partiallyFillable: true,
-        });
+        const { executedSellAmount, sellPrice, executedBuyAmount, buyPrice } =
+          await computeSettlementForOrderVariant({
+            kind: OrderKind.SELL,
+            partiallyFillable: true,
+          });
 
         expect(executedSellAmount).to.deep.equal(executedAmount);
         expect(executedBuyAmount).to.deep.equal(
@@ -933,13 +919,11 @@ describe("GPv2Settlement", () => {
       });
 
       it("should respect the limit price for partially fillable sell orders", async () => {
-        const {
-          executedSellAmount,
-          executedBuyAmount,
-        } = await computeSettlementForOrderVariant({
-          kind: OrderKind.SELL,
-          partiallyFillable: true,
-        });
+        const { executedSellAmount, executedBuyAmount } =
+          await computeSettlementForOrderVariant({
+            kind: OrderKind.SELL,
+            partiallyFillable: true,
+          });
 
         expect(
           executedBuyAmount
@@ -949,15 +933,11 @@ describe("GPv2Settlement", () => {
       });
 
       it("should compute amounts for partially fillable buy orders", async () => {
-        const {
-          executedSellAmount,
-          sellPrice,
-          executedBuyAmount,
-          buyPrice,
-        } = await computeSettlementForOrderVariant({
-          kind: OrderKind.BUY,
-          partiallyFillable: true,
-        });
+        const { executedSellAmount, sellPrice, executedBuyAmount, buyPrice } =
+          await computeSettlementForOrderVariant({
+            kind: OrderKind.BUY,
+            partiallyFillable: true,
+          });
 
         expect(executedSellAmount).to.deep.equal(
           executedAmount.mul(buyPrice).div(sellPrice),
@@ -966,13 +946,11 @@ describe("GPv2Settlement", () => {
       });
 
       it("should respect the limit price for partially fillable buy orders", async () => {
-        const {
-          executedSellAmount,
-          executedBuyAmount,
-        } = await computeSettlementForOrderVariant({
-          kind: OrderKind.BUY,
-          partiallyFillable: true,
-        });
+        const { executedSellAmount, executedBuyAmount } =
+          await computeSettlementForOrderVariant({
+            kind: OrderKind.BUY,
+            partiallyFillable: true,
+          });
 
         expect(
           executedBuyAmount
@@ -1112,23 +1090,21 @@ describe("GPv2Settlement", () => {
       };
 
       it("should add the full fee for fill-or-kill sell orders", async () => {
-        const {
-          executedSellAmount,
-        } = await computeExecutedTradeForOrderVariant({
-          kind: OrderKind.SELL,
-          partiallyFillable: false,
-        });
+        const { executedSellAmount } =
+          await computeExecutedTradeForOrderVariant({
+            kind: OrderKind.SELL,
+            partiallyFillable: false,
+          });
 
         expect(executedSellAmount).to.deep.equal(sellAmount.add(feeAmount));
       });
 
       it("should add the full fee for fill-or-kill buy orders", async () => {
-        const {
-          executedSellAmount,
-        } = await computeExecutedTradeForOrderVariant({
-          kind: OrderKind.BUY,
-          partiallyFillable: false,
-        });
+        const { executedSellAmount } =
+          await computeExecutedTradeForOrderVariant({
+            kind: OrderKind.BUY,
+            partiallyFillable: false,
+          });
 
         const expectedSellAmount = buyAmount.mul(buyPrice).div(sellPrice);
         expect(executedSellAmount).to.deep.equal(
@@ -1140,12 +1116,11 @@ describe("GPv2Settlement", () => {
         const executedAmount = sellAmount.div(3);
         const executedFee = feeAmount.div(3);
 
-        const {
-          executedSellAmount,
-        } = await computeExecutedTradeForOrderVariant(
-          { kind: OrderKind.SELL, partiallyFillable: true },
-          { executedAmount },
-        );
+        const { executedSellAmount } =
+          await computeExecutedTradeForOrderVariant(
+            { kind: OrderKind.SELL, partiallyFillable: true },
+            { executedAmount },
+          );
 
         expect(executedSellAmount).to.deep.equal(
           executedAmount.add(executedFee),
@@ -1156,12 +1131,11 @@ describe("GPv2Settlement", () => {
         const executedBuyAmount = buyAmount.div(4);
         const executedFee = feeAmount.div(4);
 
-        const {
-          executedSellAmount,
-        } = await computeExecutedTradeForOrderVariant(
-          { kind: OrderKind.BUY, partiallyFillable: true },
-          { executedAmount: executedBuyAmount },
-        );
+        const { executedSellAmount } =
+          await computeExecutedTradeForOrderVariant(
+            { kind: OrderKind.BUY, partiallyFillable: true },
+            { executedAmount: executedBuyAmount },
+          );
 
         const expectedSellAmount = executedBuyAmount
           .mul(buyPrice)
@@ -1413,9 +1387,8 @@ describe("GPv2Settlement", () => {
             },
             {
               target: mockRevert.address,
-              callData: mockRevert.interface.encodeFunctionData(
-                "alwaysReverts",
-              ),
+              callData:
+                mockRevert.interface.encodeFunctionData("alwaysReverts"),
             },
           ]),
         ),

--- a/test/GPv2Trade.test.ts
+++ b/test/GPv2Trade.test.ts
@@ -173,9 +173,8 @@ describe("GPv2Trade", () => {
         SigningScheme.EIP1271,
         SigningScheme.PRESIGN,
       ]) {
-        const {
-          signingScheme: extractedScheme,
-        } = await tradeLib.extractFlagsTest(encodeSigningScheme(scheme));
+        const { signingScheme: extractedScheme } =
+          await tradeLib.extractFlagsTest(encodeSigningScheme(scheme));
         expect(extractedScheme).to.deep.equal(scheme);
       }
     });

--- a/test/GPv2Transfer.test.ts
+++ b/test/GPv2Transfer.test.ts
@@ -10,12 +10,8 @@ import { UserBalanceOpKind } from "./balancer";
 import { OrderBalanceId } from "./encoding";
 
 describe("GPv2Transfer", () => {
-  const [
-    deployer,
-    recipient,
-    funder,
-    ...traders
-  ] = waffle.provider.getWallets();
+  const [deployer, recipient, funder, ...traders] =
+    waffle.provider.getWallets();
 
   let transfer: Contract;
   let vault: MockContract;

--- a/test/GPv2VaultRelayer.test.ts
+++ b/test/GPv2VaultRelayer.test.ts
@@ -10,12 +10,8 @@ import { SwapKind, UserBalanceOpKind } from "./balancer";
 import { OrderBalanceId } from "./encoding";
 
 describe("GPv2VaultRelayer", () => {
-  const [
-    deployer,
-    creator,
-    nonCreator,
-    ...traders
-  ] = waffle.provider.getWallets();
+  const [deployer, creator, nonCreator, ...traders] =
+    waffle.provider.getWallets();
 
   let vault: MockContract;
   let vaultRelayer: Contract;

--- a/test/decoding.test.ts
+++ b/test/decoding.test.ts
@@ -65,13 +65,12 @@ function cartesian<T extends UnknownMatrix>(...arrays: T): Transpose<T> {
 }
 
 function validEncodedFlags(): number[] {
-  return cartesian(
-    ...Object.values(allEncodedFlagOptions()),
-  ).map((flagOptions) =>
-    flagOptions.reduce(
-      (cumulative: number, flagOption: number) => cumulative | flagOption,
-      0,
-    ),
+  return cartesian(...Object.values(allEncodedFlagOptions())).map(
+    (flagOptions) =>
+      flagOptions.reduce(
+        (cumulative: number, flagOption: number) => cumulative | flagOption,
+        0,
+      ),
   );
 }
 
@@ -103,7 +102,7 @@ function validFlags(): TradeFlags[] {
     transposedKeyedOptions.forEach(
       ([key, option]: any) => (tradeFlags[key] = option),
     );
-    return (tradeFlags as unknown) as TradeFlags;
+    return tradeFlags as unknown as TradeFlags;
   });
   /* eslint-enable @typescript-eslint/no-explicit-any */
 }
@@ -142,8 +141,9 @@ describe("Signer", () => {
   for (const scheme of ecdsaSchemes) {
     it(`ecdsa ${scheme}`, async () => {
       const signature = await utils.joinSignature(
-        (await signOrder(domainSeparator, SAMPLE_ORDER, ecdsaSigner, scheme))
-          .data,
+        (
+          await signOrder(domainSeparator, SAMPLE_ORDER, ecdsaSigner, scheme)
+        ).data,
       );
       expect(
         decodeSignatureOwner(domainSeparator, SAMPLE_ORDER, scheme, signature),

--- a/test/e2e/fixture.ts
+++ b/test/e2e/fixture.ts
@@ -19,68 +19,69 @@ export interface TestDeployment {
   gasToken: Contract;
 }
 
-export const deployTestContracts: () => Promise<TestDeployment> = deployments.createFixture(
-  async ({
-    deployments,
-    ethers,
-    getNamedAccounts,
-    getUnnamedAccounts,
-    waffle,
-  }) => {
-    const {
-      GPv2AllowListAuthentication,
-      GPv2Settlement,
-      Vault,
-      VaultAuthorizer,
-      WETH,
-    } = await deployments.fixture();
+export const deployTestContracts: () => Promise<TestDeployment> =
+  deployments.createFixture(
+    async ({
+      deployments,
+      ethers,
+      getNamedAccounts,
+      getUnnamedAccounts,
+      waffle,
+    }) => {
+      const {
+        GPv2AllowListAuthentication,
+        GPv2Settlement,
+        Vault,
+        VaultAuthorizer,
+        WETH,
+      } = await deployments.fixture();
 
-    const allWallets = waffle.provider.getWallets();
-    const { deployer, owner, manager } = await getNamedAccounts();
-    const unnamedAccounts = await getUnnamedAccounts();
-    const deployerWallet = findAccountWallet(allWallets, deployer);
+      const allWallets = waffle.provider.getWallets();
+      const { deployer, owner, manager } = await getNamedAccounts();
+      const unnamedAccounts = await getUnnamedAccounts();
+      const deployerWallet = findAccountWallet(allWallets, deployer);
 
-    const weth = new Contract(WETH.address, WETHArtifact.abi, deployerWallet);
-    const vaultAuthorizer = new Contract(
-      VaultAuthorizer.address,
-      AuthorizerArtifact.abi,
-      deployerWallet,
-    );
-    const vault = new Contract(
-      Vault.address,
-      VaultArtifact.abi,
-      deployerWallet,
-    );
-    const authenticator = await ethers.getContractAt(
-      "GPv2AllowListAuthentication",
-      GPv2AllowListAuthentication.address,
-    );
-    const settlement = await ethers.getContractAt(
-      "GPv2Settlement",
-      GPv2Settlement.address,
-    );
-    const vaultRelayer = await ethers.getContractAt(
-      "GPv2VaultRelayer",
-      await settlement.vaultRelayer(),
-    );
+      const weth = new Contract(WETH.address, WETHArtifact.abi, deployerWallet);
+      const vaultAuthorizer = new Contract(
+        VaultAuthorizer.address,
+        AuthorizerArtifact.abi,
+        deployerWallet,
+      );
+      const vault = new Contract(
+        Vault.address,
+        VaultArtifact.abi,
+        deployerWallet,
+      );
+      const authenticator = await ethers.getContractAt(
+        "GPv2AllowListAuthentication",
+        GPv2AllowListAuthentication.address,
+      );
+      const settlement = await ethers.getContractAt(
+        "GPv2Settlement",
+        GPv2Settlement.address,
+      );
+      const vaultRelayer = await ethers.getContractAt(
+        "GPv2VaultRelayer",
+        await settlement.vaultRelayer(),
+      );
 
-    return {
-      deployer: deployerWallet,
-      owner: findAccountWallet(allWallets, owner),
-      manager: findAccountWallet(allWallets, manager),
-      wallets: unnamedAccounts.map((account) =>
-        findAccountWallet(allWallets, account),
-      ),
-      weth,
-      vaultAuthorizer,
-      vault,
-      authenticator,
-      settlement,
-      vaultRelayer,
-      gasToken: await deployGasToken(allWallets[0]),
-    };
-  },
-);
+      return {
+        deployer: deployerWallet,
+        owner: findAccountWallet(allWallets, owner),
+        manager: findAccountWallet(allWallets, manager),
+        wallets: unnamedAccounts.map((account) =>
+          findAccountWallet(allWallets, account),
+        ),
+        weth,
+        vaultAuthorizer,
+        vault,
+        authenticator,
+        settlement,
+        vaultRelayer,
+        gasToken: await deployGasToken(allWallets[0]),
+      };
+    },
+  );
 
 const CHI_TOKEN_DEPLOYER = "0x7E1E3334130355799F833ffec2D731BCa3E68aF6";
 

--- a/test/encoding.ts
+++ b/test/encoding.ts
@@ -35,7 +35,7 @@ export const allSigningSchemes = optionsForKey("signingScheme");
 
 export function allOptions<
   K extends FlagKey,
-  AllOptions extends Record<K, FlagOptions<K>>
+  AllOptions extends Record<K, FlagOptions<K>>,
 >(): AllOptions {
   const result: Record<string, FlagOptions<K>> = {};
   Object.entries(FLAG_MASKS).map(

--- a/test/sign.test.ts
+++ b/test/sign.test.ts
@@ -13,21 +13,21 @@ import {
 
 import { SAMPLE_ORDER } from "./testHelpers";
 
-const patchedSignMessageBuilder = (key: SigningKey) => async (
-  message: string,
-): Promise<string> => {
-  // Reproducing `@ethersproject/wallet/src.ts/index.ts` sign message behavior
-  const sig = joinSignature(key.signDigest(hashMessage(message)));
+const patchedSignMessageBuilder =
+  (key: SigningKey) =>
+  async (message: string): Promise<string> => {
+    // Reproducing `@ethersproject/wallet/src.ts/index.ts` sign message behavior
+    const sig = joinSignature(key.signDigest(hashMessage(message)));
 
-  // Unpack the signature
-  const { r, s, v } = ethers.utils.splitSignature(sig);
-  // Pack it again
-  return ethers.utils.solidityPack(
-    ["bytes32", "bytes32", "uint8"],
-    // Remove last byte's `27` padding
-    [r, s, v - 27],
-  );
-};
+    // Unpack the signature
+    const { r, s, v } = ethers.utils.splitSignature(sig);
+    // Pack it again
+    return ethers.utils.solidityPack(
+      ["bytes32", "bytes32", "uint8"],
+      // Remove last byte's `27` padding
+      [r, s, v - 27],
+    );
+  };
 
 describe("signOrder", () => {
   it("should pad the `v` byte when needed", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11521,6 +11521,11 @@ prettier@^2.1.2, prettier@^2.2.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
   integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
+prettier@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
+  integrity sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==
+
 printj@~1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"


### PR DESCRIPTION
Closes #632.

It looks like Prettier's version bump changes how whitespace is handled in Prettier, and some diff in updating [is expected](https://github.com/thorn0/prettier/blob/b9c1975c7ef582baf3b3201748a2b6c4a421b5dc/changelog_unreleased/blog-post-intro.md). This PR applies the necessary formatting changes. 

### Test Plan

CI.