### PR TITLE
Specify token list for withdraw

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,14 @@ For example, adding the address `0x0000000000000000000000000000000000000042` to 
 export PK=<private key>
 yarn solvers add 0x0000000000000000000000000000000000000042
 ```
+
+### Fee Withdrawls
+
+Script to withdraw all balances of the Settlement contract. Allows to specify what minimum value the contract must have for a token to be considered (breadcrumbs might not be worth the gas costs) and how much remaining value should be left in the contract (e.g. to feed token buffers).
+
+If no token list is passed in all traded token balances will be fetched from chain (can take a long time...)
+
+```sh
+export PK=<private key>
+yarn hardhat withdraw --receiver 0x6C2999B6B1fAD608ECEA71B926D68Ee6c62BeEf8 --min-value 10000 --leftover 500 0x038a68ff68c393373ec894015816e33ad41bd564 0x913d8adf7ce6986a8cbfee5a54725d9eea4f0729
+```

--- a/src/tasks/withdraw.ts
+++ b/src/tasks/withdraw.ts
@@ -361,9 +361,13 @@ const setupWithdrawTask: () => void = () =>
       "dryRun",
       "Just simulate the settlement instead of executing the transaction on the blockchain.",
     )
+    .addVariadicPositionalParam(
+      "tokens",
+      "An optional subset of tokens to consider for withdraw (otherwise all traded tokens will be queried).",
+    )
     .setAction(
       async (
-        { minValue, dryRun, leftover, receiver: inputReceiver },
+        { minValue, dryRun, leftover, receiver: inputReceiver, tokens },
         hre: HardhatRuntimeEnvironment,
       ) => {
         const receiver = utils.getAddress(inputReceiver);
@@ -383,7 +387,9 @@ const setupWithdrawTask: () => void = () =>
           }
         }
 
-        const tokens = await getAllTradedTokens(settlement);
+        if (tokens.length === 0) {
+          tokens = await getAllTradedTokens(settlement);
+        }
 
         // TODO: add eth withdrawal
         // TODO: split large transaction in batches

--- a/src/tasks/withdraw.ts
+++ b/src/tasks/withdraw.ts
@@ -361,7 +361,7 @@ const setupWithdrawTask: () => void = () =>
       "dryRun",
       "Just simulate the settlement instead of executing the transaction on the blockchain.",
     )
-    .addVariadicPositionalParam(
+    .addOptionalVariadicPositionalParam(
       "tokens",
       "An optional subset of tokens to consider for withdraw (otherwise all traded tokens will be queried).",
     )
@@ -387,7 +387,7 @@ const setupWithdrawTask: () => void = () =>
           }
         }
 
-        if (tokens.length === 0) {
+        if (tokens === undefined) {
           tokens = await getAllTradedTokens(settlement);
         }
 


### PR DESCRIPTION
Fetching all traded tokens takes too long. This PR adds an optional last parameter that can be used to specify a subset of tokens to withdraw from.

Also added some instructions in the readme

### Test Plan
Command from README
