### PR TITLE
Fix rounding issue in executed amount computation

### DIFF
--- a/src/contracts/GPv2Settlement.sol
+++ b/src/contracts/GPv2Settlement.sol
@@ -375,7 +375,9 @@ contract GPv2Settlement is GPv2Signing, ReentrancyGuard, StorageAccessible {
                 executedFeeAmount = order.feeAmount;
             }
 
-            executedBuyAmount = executedSellAmount.mul(sellPrice).div(buyPrice);
+            executedBuyAmount = executedSellAmount.mul(sellPrice).ceilDiv(
+                buyPrice
+            );
 
             currentFilledAmount = filledAmount[orderUid].add(
                 executedSellAmount

--- a/src/contracts/libraries/SafeMath.sol
+++ b/src/contracts/libraries/SafeMath.sol
@@ -101,6 +101,6 @@ library SafeMath {
      */
     function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {
         require(b > 0, "SafeMath: ceiling division by 0");
-        return add(a, b - 1) / b;
+        return a / b + (a % b == 0 ? 0 : 1);
     }
 }

--- a/src/contracts/libraries/SafeMath.sol
+++ b/src/contracts/libraries/SafeMath.sol
@@ -3,7 +3,7 @@
 // Vendored from OpenZeppelin contracts with minor modifications:
 // - Modified Solidity version
 // - Formatted code
-// - Shortned multiplication overflow revert messages
+// - Shortened some revert messages
 // - Removed unused methods
 // - Added `ceilDiv` method
 // <https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v3.4.0/contracts/math/SafeMath.sol>

--- a/src/contracts/libraries/SafeMath.sol
+++ b/src/contracts/libraries/SafeMath.sol
@@ -5,6 +5,7 @@
 // - Formatted code
 // - Shortned multiplication overflow revert messages
 // - Removed unused methods
+// - Added `ceilDiv` method
 // <https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v3.4.0/contracts/math/SafeMath.sol>
 
 pragma solidity ^0.7.6;
@@ -84,7 +85,22 @@ library SafeMath {
      * - The divisor cannot be zero.
      */
     function div(uint256 a, uint256 b) internal pure returns (uint256) {
-        require(b > 0, "SafeMath: division by zero");
+        require(b > 0, "SafeMath: division by 0");
         return a / b;
+    }
+
+    /**
+     * @dev Returns the ceiling integer division of two unsigned integers,
+     * reverting on division by zero. The result is rounded towards up the
+     * nearest integer, instead of truncating the fractional part.
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     * - The sum of the dividend and divisor cannot overflow.
+     */
+    function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {
+        require(b > 0, "SafeMath: ceiling division by 0");
+        return add(a, b - 1) / b;
     }
 }

--- a/test/e2e/wineOilMarket.test.ts
+++ b/test/e2e/wineOilMarket.test.ts
@@ -11,6 +11,7 @@ import {
   TypedDataDomain,
   domain,
 } from "../../src/ts";
+import { ceilDiv } from "../testHelpers";
 
 import { deployTestContracts } from "./fixture";
 
@@ -152,7 +153,7 @@ describe("E2E: RetrETH Red Wine and Olive Oil Market", () => {
       ),
     );
     expect(await oil.balanceOf(traders[0].address)).to.deep.equal(
-      ethers.utils.parseEther("12.0").mul(14).div(13),
+      ceilDiv(ethers.utils.parseEther("12.0").mul(14), 13),
     );
 
     expect(await oil.balanceOf(traders[1].address)).to.deep.equal(

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "ethers";
+import { BigNumber, BigNumberish } from "ethers";
 import { ethers } from "hardhat";
 
 import { OrderKind } from "../src/ts";
@@ -29,3 +29,7 @@ export const SAMPLE_ORDER = {
   kind: OrderKind.SELL,
   partiallyFillable: false,
 };
+
+export function ceilDiv(p: BigNumberish, q: BigNumberish): BigNumber {
+  return BigNumber.from(p).add(q).sub(1).div(q);
+}


### PR DESCRIPTION
This PR fixes a minor issue where rounding was done in favour of the SC instead of being in favour of the trader for partially fillable sell orders.

In theory, if gas-price was 0, a malicious solver could take a partially fillable sell order with a low value sell token and high value buy token and fill it atom by atom to take the complete sell amount from the trader with a 0 buy amount (higher differences in price made it possible to fill more sell amount at a time while still producing 0 buy amount).

This PR addresses the issue by computing the executed buy amount with a ceiling division instead of a truncating one, rounding in favour of the trader.

### Test Plan

Adjusted unit tests to compute exact buy amount using ceiling division, added new unit tests that verify rounding in executed amounts benefit the trader.
