### PR TITLE
Clarify single transfer differences

### DIFF
--- a/src/contracts/GPv2VaultRelayer.sol
+++ b/src/contracts/GPv2VaultRelayer.sol
@@ -81,6 +81,6 @@ contract GPv2VaultRelayer {
             limits,
             deadline
         );
-        vault.transferFromAccount(feeTransfer, msg.sender);
+        vault.fastTransferFromAccount(feeTransfer, msg.sender);
     }
 }

--- a/src/contracts/libraries/GPv2Transfer.sol
+++ b/src/contracts/libraries/GPv2Transfer.sol
@@ -35,9 +35,10 @@ library GPv2Transfer {
     /// Note that this method is subtly different from `transferFromAccounts`
     /// with a single transfer with respect to how it deals with internal
     /// balances. Specifically, this method will perform an **internal balance
-    /// transfer to the settlement contract instead of a withdrawal to the external balance of the settlement contract** for trades that
-    /// specify trading with internal balances. This is done as a gas
-    /// optimization in the single order "fast-path".
+    /// transfer to the settlement contract instead of a withdrawal to the
+    /// external balance of the settlement contract** for trades that specify
+    /// trading with internal balances. This is done as a gas optimization in
+    /// the single order "fast-path".
     ///
     /// @param vault The Balancer vault to use.
     /// @param transfer The transfer to perform specifying the sender account.

--- a/src/contracts/libraries/GPv2Transfer.sol
+++ b/src/contracts/libraries/GPv2Transfer.sol
@@ -32,10 +32,17 @@ library GPv2Transfer {
     /// This method is used for transferring fees to the settlement contract
     /// when settling a single order directly with Balancer.
     ///
+    /// Note that this method is subtly different that `transferFromAccounts`
+    /// with a single transfer with respect to how it deals with internal
+    /// balances. Specifically, this method will perform an **internal balance
+    /// transfer instead of an intenal balance withdrawal** for trades that
+    /// specify trading with internal balances. This is done as a gas
+    /// optimization in the single order "fast-path".
+    ///
     /// @param vault The Balancer vault to use.
     /// @param transfer The transfer to perform specifying the sender account.
     /// @param recipient The recipient for the transfer.
-    function transferFromAccount(
+    function fastTransferFromAccount(
         IVault vault,
         Data calldata transfer,
         address recipient

--- a/src/contracts/libraries/GPv2Transfer.sol
+++ b/src/contracts/libraries/GPv2Transfer.sol
@@ -35,7 +35,7 @@ library GPv2Transfer {
     /// Note that this method is subtly different from `transferFromAccounts`
     /// with a single transfer with respect to how it deals with internal
     /// balances. Specifically, this method will perform an **internal balance
-    /// transfer instead of an intenal balance withdrawal** for trades that
+    /// transfer to the settlement contract instead of a withdrawal to the external balance of the settlement contract** for trades that
     /// specify trading with internal balances. This is done as a gas
     /// optimization in the single order "fast-path".
     ///

--- a/src/contracts/libraries/GPv2Transfer.sol
+++ b/src/contracts/libraries/GPv2Transfer.sol
@@ -32,7 +32,7 @@ library GPv2Transfer {
     /// This method is used for transferring fees to the settlement contract
     /// when settling a single order directly with Balancer.
     ///
-    /// Note that this method is subtly different that `transferFromAccounts`
+    /// Note that this method is subtly different from `transferFromAccounts`
     /// with a single transfer with respect to how it deals with internal
     /// balances. Specifically, this method will perform an **internal balance
     /// transfer instead of an intenal balance withdrawal** for trades that

--- a/src/contracts/test/GPv2TransferTestInterface.sol
+++ b/src/contracts/test/GPv2TransferTestInterface.sol
@@ -5,12 +5,12 @@ pragma abicoder v2;
 import "../libraries/GPv2Transfer.sol";
 
 contract GPv2TransferTestInterface {
-    function transferFromAccountTest(
+    function fastTransferFromAccountTest(
         IVault vault,
         GPv2Transfer.Data calldata transfer,
         address recipient
     ) external {
-        GPv2Transfer.transferFromAccount(vault, transfer, recipient);
+        GPv2Transfer.fastTransferFromAccount(vault, transfer, recipient);
     }
 
     function transferFromAccountsTest(

--- a/test/GPv2Transfer.test.ts
+++ b/test/GPv2Transfer.test.ts
@@ -36,7 +36,7 @@ describe("GPv2Transfer", () => {
         .withArgs(traders[0].address, recipient.address, amount)
         .returns(true);
       await expect(
-        transfer.transferFromAccountTest(
+        transfer.fastTransferFromAccountTest(
           vault.address,
           {
             account: traders[0].address,
@@ -62,7 +62,7 @@ describe("GPv2Transfer", () => {
         ])
         .returns();
       await expect(
-        transfer.transferFromAccountTest(
+        transfer.fastTransferFromAccountTest(
           vault.address,
           {
             account: traders[0].address,
@@ -88,7 +88,7 @@ describe("GPv2Transfer", () => {
         ])
         .returns();
       await expect(
-        transfer.transferFromAccountTest(
+        transfer.fastTransferFromAccountTest(
           vault.address,
           {
             account: traders[0].address,
@@ -108,7 +108,7 @@ describe("GPv2Transfer", () => {
         OrderBalanceId.INTERNAL,
       ]) {
         await expect(
-          transfer.transferFromAccountTest(
+          transfer.fastTransferFromAccountTest(
             vault.address,
             {
               account: traders[0].address,
@@ -128,7 +128,7 @@ describe("GPv2Transfer", () => {
         .revertsWithReason("test error");
 
       await expect(
-        transfer.transferFromAccountTest(
+        transfer.fastTransferFromAccountTest(
           vault.address,
           {
             account: traders[0].address,
@@ -155,7 +155,7 @@ describe("GPv2Transfer", () => {
         .revertsWithReason("test error");
 
       await expect(
-        transfer.transferFromAccountTest(
+        transfer.fastTransferFromAccountTest(
           vault.address,
           {
             account: traders[0].address,
@@ -182,7 +182,7 @@ describe("GPv2Transfer", () => {
         .revertsWithReason("test error");
 
       await expect(
-        transfer.transferFromAccountTest(
+        transfer.fastTransferFromAccountTest(
           vault.address,
           {
             account: traders[0].address,


### PR DESCRIPTION
This PR addresses a note from the SC audit that `transferFromAccount` and `transferFromAccounts` behave differently and it wasn't clear why.

This method renames the `transferFromAccount` to `fastTransferFromAccount` and adds additional function documentation to clarify the subtle difference between the two functions as well as the reason.

### Test Plan

No logic changes, just a function rename and additional documentation - existing CI is sufficient.
