### PR TITLE
Sign typed data v3 support

### DIFF
--- a/test/sign.test.ts
+++ b/test/sign.test.ts
@@ -33,6 +33,7 @@ const patchedSignMessageBuilder = (key: SigningKey) => async (
 type SpyProvider = JsonRpcProvider & {
   called: number;
   method: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   params: any[];
 };
 
@@ -42,6 +43,7 @@ type SpyProvider = JsonRpcProvider & {
 const patchProvider = (p: SpyProvider) => {
   p.called = 0;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   p.send = async (method: string, params: any[]): Promise<string> => {
     p.method = method;
     p.params = params;

--- a/test/sign.test.ts
+++ b/test/sign.test.ts
@@ -1,5 +1,6 @@
 import { joinSignature } from "@ethersproject/bytes";
 import { hashMessage } from "@ethersproject/hash";
+import type { JsonRpcProvider } from "@ethersproject/providers";
 import { SigningKey } from "@ethersproject/signing-key";
 import { expect } from "chai";
 import { ethers, waffle } from "hardhat";
@@ -29,6 +30,31 @@ const patchedSignMessageBuilder = (key: SigningKey) => async (
   );
 };
 
+type SpyProvider = JsonRpcProvider & {
+  called: number;
+  method: string;
+  params: any[];
+};
+
+// Custom made spy for the provider
+// Patches the `send` method to track calls and params
+// Returns a fake signature
+const patchProvider = (p: SpyProvider) => {
+  p.called = 0;
+
+  p.send = async (method: string, params: any[]): Promise<string> => {
+    p.method = method;
+    p.params = params;
+    p.called += 1;
+
+    // Fake signature, don't care about it.
+    // Besides, the Signer provided by hardhat doesn't support `eth_signTypedMessage_v3` and will throw
+    return "0x80bc78815e333b8c62c6f493dacecd47b283ca04d0cf18394e22a050a2ff356a65ea766c393671682a053be36c395a5d45d8524235132ba660563178a2e15c7e1c";
+  };
+
+  return p;
+};
+
 describe("signOrder", () => {
   it("should pad the `v` byte when needed", async () => {
     const [signer] = waffle.provider.getWallets();
@@ -49,6 +75,50 @@ describe("signOrder", () => {
       );
       // Confirm it is either 27 or 28, in hex
       expect(v).to.be.oneOf(["0x1b", "0x1c"]);
+    }
+  });
+
+  it("should call eth_signTypedData_v3", async () => {
+    const [signer] = waffle.provider.getWallets();
+    // Patch the provider's `send` method
+    Object.defineProperty(
+      signer,
+      "provider",
+      patchProvider(signer.provider as SpyProvider),
+    );
+
+    const domain = { name: "test" };
+
+    await signOrder(domain, SAMPLE_ORDER, signer, SigningScheme.EIP712, {
+      signTypedDataVersion: "v3",
+    });
+
+    expect((signer.provider as SpyProvider).called).to.be.equal(1);
+    expect((signer.provider as SpyProvider).method).to.be.equal(
+      "eth_signTypedData_v3",
+    );
+  });
+
+  it("should not call eth_signTypedData_v3", async () => {
+    const [signer] = waffle.provider.getWallets();
+    // Patch the provider's `send` method
+    Object.defineProperty(
+      signer,
+      "provider",
+      patchProvider(signer.provider as SpyProvider),
+    );
+
+    const domain = { name: "test" };
+
+    for (const [scheme, options] of [
+      [SigningScheme.EIP712, undefined],
+      [SigningScheme.EIP712, { signTypedDataVersion: "v4" }],
+      [SigningScheme.ETHSIGN, undefined],
+    ] as const) {
+      await signOrder(domain, SAMPLE_ORDER, signer, scheme, options);
+
+      // Non `v3` won't use the patched provider
+      expect((signer.provider as SpyProvider).called).to.be.equal(0);
     }
   });
 });
@@ -115,6 +185,58 @@ describe("signOrderCancellation", () => {
       );
       // Confirm it is either 27 or 28, in hex
       expect(v).to.be.oneOf(["0x1b", "0x1c"]);
+    }
+  });
+
+  it("should call eth_signTypedData_v3", async () => {
+    const [signer] = waffle.provider.getWallets();
+    // Patch the provider's `send` method
+    Object.defineProperty(
+      signer,
+      "provider",
+      patchProvider(signer.provider as SpyProvider),
+    );
+
+    const domain = { name: "test" };
+    const orderUid = `0x${"2a".repeat(56)}`;
+
+    await signOrderCancellation(
+      domain,
+      orderUid,
+      signer,
+      SigningScheme.EIP712,
+      {
+        signTypedDataVersion: "v3",
+      },
+    );
+
+    expect((signer.provider as SpyProvider).called).to.be.equal(1);
+    expect((signer.provider as SpyProvider).method).to.be.equal(
+      "eth_signTypedData_v3",
+    );
+  });
+
+  it("should not call eth_signTypedData_v3", async () => {
+    const [signer] = waffle.provider.getWallets();
+    // Patch the provider's `send` method
+    Object.defineProperty(
+      signer,
+      "provider",
+      patchProvider(signer.provider as SpyProvider),
+    );
+
+    const domain = { name: "test" };
+    const orderUid = `0x${"2a".repeat(56)}`;
+
+    for (const [scheme, options] of [
+      [SigningScheme.EIP712, undefined],
+      [SigningScheme.EIP712, { signTypedDataVersion: "v4" }],
+      [SigningScheme.ETHSIGN, undefined],
+    ] as const) {
+      await signOrderCancellation(domain, orderUid, signer, scheme, options);
+
+      // Non `v3` won't use the patched provider
+      expect((signer.provider as SpyProvider).called).to.be.equal(0);
     }
   });
 });


### PR DESCRIPTION
Updated signOrder and signOrderCancellation functions

Both functions now accept an optional `options` parameter.
When using EIP712 signing scheme, the option `signTypedDataVersion` is
checked.
Options are `v3`|`v4` for `eth_signTypedData_v3|v4`.
It defaults to `v4`.
Setting has no effect on other signing schemes.


### Test Plan

Added unit tests

Also tested on CowSwap with TrustWallet.

# :warning: Warning :warning: 

This change is based off of https://github.com/gnosis/gp-v2-contracts/releases/tag/v0.0.1-alpha.17
Latest on main branch is currently not compatible with the Frontend.

Not sure how you guys want to handle deploying this change.
Keep a `v0.0` branch and backport it to `main`?
