### PR TITLE
Bump version to `0.0.1-alpha.18`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v2-contracts",
-  "version": "0.0.1-alpha.17",
+  "version": "0.0.1-alpha.18",
   "license": "LGPL-3.0-or-later",
   "scripts": {
     "deploy": "hardhat deploy",


### PR DESCRIPTION
Release `v0.0.1 alpha.18`

Version bump to release this change: https://github.com/gnosis/gp-v2-contracts/pull/659