### PR TITLE
Allow solvers to specify tigher slippage for Balancer fast-path

### DIFF
--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -589,7 +589,7 @@ describe("GPv2Settlement", () => {
 
         it(`reverts when specified limit amount does not satisfy ${kind} price`, async () => {
           const [swaps, tokens, trade] = await encodeSwap({
-            // Specify a swap limit about that is slightly worse than the
+            // Specify a swap limit amount that is slightly worse than the
             // order's limit price.
             limitAmount:
               kind == OrderKind.SELL

--- a/test/GPv2Settlement.test.ts
+++ b/test/GPv2Settlement.test.ts
@@ -21,6 +21,7 @@ import {
   SettlementEncoder,
   SigningScheme,
   SwapEncoder,
+  SwapExecution,
   TradeExecution,
   TypedDataDomain,
   computeOrderUid,
@@ -515,13 +516,14 @@ describe("GPv2Settlement", () => {
         };
         const orderUid = () =>
           computeOrderUid(testDomain, order, traders[0].address);
-        const encodeSwap = () =>
+        const encodeSwap = (swapExecution?: Partial<SwapExecution>) =>
           SwapEncoder.encodeSwap(
             testDomain,
             [],
             order,
             traders[0],
             SigningScheme.ETHSIGN,
+            swapExecution,
           );
 
         it(`executes ${kind} order against swap`, async () => {
@@ -583,6 +585,27 @@ describe("GPv2Settlement", () => {
           await expect(
             settlement.connect(solver).swap(...(await encodeSwap())),
           ).to.be.revertedWith(`${kind} amount not respected`);
+        });
+
+        it(`reverts when specified limit amount does not satisfy ${kind} price`, async () => {
+          const [swaps, tokens, trade] = await encodeSwap({
+            // Specify a swap limit about that is slightly worse than the
+            // order's limit price.
+            limitAmount:
+              kind == OrderKind.SELL
+                ? order.buyAmount.sub(1) // receive slightly less buy token
+                : order.sellAmount.add(1), // pay slightly more sell token
+          });
+
+          await vault.mock.batchSwap.returns([sellAmount, buyAmount.mul(-1)]);
+          await vault.mock.manageUserBalance.returns();
+
+          await authenticator.connect(owner).addSolver(solver.address);
+          await expect(
+            settlement.connect(solver).swap(swaps, tokens, trade),
+          ).to.be.revertedWith(
+            kind == OrderKind.SELL ? "limit too low" : "limit too high",
+          );
         });
 
         it(`emits a ${kind} trade event`, async () => {

--- a/test/e2e/balancerSwap.test.ts
+++ b/test/e2e/balancerSwap.test.ts
@@ -305,8 +305,9 @@ describe("E2E: Direct Balancer swap", () => {
       await mintAndApprove(trader, tokens[0], ethers.utils.parseEther("100.1"));
 
       const pool = poolFor(tokens[0], tokens[1]);
-      // NOTE: Set a multiplier that does not satisfy the order's limit price.
-      await pool.setMultiplier(ethers.utils.parseEther("0.5"));
+      // NOTE: Set a multiplier that satisfies the order's limit price but not
+      // the specified limit amount.
+      await pool.setMultiplier(ethers.utils.parseEther("1.1"));
 
       const encoder = new SwapEncoder(domainSeparator);
       await encoder.signEncodeTrade(
@@ -323,15 +324,18 @@ describe("E2E: Direct Balancer swap", () => {
         },
         trader,
         SigningScheme.EIP712,
+        {
+          limitAmount:
+            kind == OrderKind.SELL
+              ? ethers.utils.parseEther("120.0")
+              : ethers.utils.parseEther("80.0"),
+        },
       );
       encoder.encodeSwapStep({
         poolId: await pool.getPoolId(),
         assetIn: tokens[0].address,
         assetOut: tokens[1].address,
-        amount:
-          kind == OrderKind.SELL
-            ? ethers.utils.parseEther("100.0")
-            : ethers.utils.parseEther("100.0"),
+        amount: ethers.utils.parseEther("100.0"),
       });
 
       await expect(


### PR DESCRIPTION
Closes #611 

This PR allows solvers to specify tighter slippage for settling orders directly with Balancer. This would allow larger orders against Balancer to still have MEV protection as if it went through the full settlement.

The question is whether or not we want to include this in the `1.0.0` release, and do these small changes require another audit?

### Test Plan

Added unit tests and adjusted E2E test to use solver-specified limit amounts.
