### PR TITLE
Change the salt for deployment

### DIFF
--- a/src/ts/deploy.ts
+++ b/src/ts/deploy.ts
@@ -3,7 +3,7 @@ import { utils } from "ethers";
 /**
  * The salt used when deterministically deploying smart contracts.
  */
-export const SALT = utils.formatBytes32String("mattresses in Berlin!");
+export const SALT = utils.formatBytes32String("Mattresses in Berlin!");
 
 /**
  * The contract used to deploy contracts deterministically with CREATE2.


### PR DESCRIPTION
This PR changes the deployment salt. This is done because the authenticator storage layout changed during development, and we don't want to deal with upgrading storage of pre-release versions.
