### PR TITLE
Target ES2015 and duplicate typings in CommonJS build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v2-contracts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "LGPL-3.0-or-later",
   "scripts": {
     "deploy": "hardhat deploy",

--- a/tsconfig.lib.commonjs.json
+++ b/tsconfig.lib.commonjs.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
-    "outDir": "lib/commonjs/",
-    "declaration": false
+    "outDir": "lib/commonjs/"
   }
 }

--- a/tsconfig.lib.esm.json
+++ b/tsconfig.lib.esm.json
@@ -1,8 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es2020",
-    "module": "es2020",
+    "target": "es2015",
+    "module": "es2015",
     "outDir": "lib/esm/",
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
This PR changes the ESM build to target ES2015 for better compatibility with `create-react-app`. Additionally, typings are included in the CommonJS build (they are duplicated from the typings in the `lib/esm` directory, but it does greatly simplify using the CommonJS modules directly without increasing package size too much).

The package version was also bumped in order to prep for a new release.
