### PR TITLE
Port withdraw script from main

### DIFF
--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -1,9 +1,11 @@
 import { setupCopyArtifactsTask } from "./artifacts";
 import { setupSolversTask } from "./solvers";
 import { setupTenderlyTask } from "./tenderly";
+import { setupWithdrawTask } from "./withdraw";
 
 export function setupTasks(): void {
   setupCopyArtifactsTask();
   setupSolversTask();
   setupTenderlyTask();
+  setupWithdrawTask();
 }

--- a/src/tasks/ts/deployment.ts
+++ b/src/tasks/ts/deployment.ts
@@ -1,0 +1,15 @@
+import { Contract } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+import { ContractName } from "../../ts";
+
+export async function getDeployedContract(
+  name: ContractName,
+  { ethers, deployments }: HardhatRuntimeEnvironment,
+): Promise<Contract> {
+  const deployment = await deployments.get(name);
+
+  return new Contract(deployment.address, deployment.abi).connect(
+    ethers.provider,
+  );
+}

--- a/src/tasks/ts/erc20.ts
+++ b/src/tasks/ts/erc20.ts
@@ -1,0 +1,35 @@
+import { BigNumber, Contract } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+export interface TokenDetails {
+  contract: Contract;
+  symbol: string | null;
+  decimals: number | null;
+  address: string;
+}
+
+export async function tokenDetails(
+  address: string,
+  hre: HardhatRuntimeEnvironment,
+): Promise<TokenDetails> {
+  const IERC20 = await hre.artifacts.readArtifact(
+    "src/contracts/interfaces/IERC20.sol:IERC20",
+  );
+  const contract = new Contract(address, IERC20.abi, hre.ethers.provider);
+  const [symbol, decimals] = await Promise.all([
+    contract
+      .symbol()
+      .then((s: unknown) => (typeof s !== "string" ? null : s))
+      .catch(() => null),
+    contract
+      .decimals()
+      .then((s: unknown) => BigNumber.from(s))
+      .catch(() => null),
+  ]);
+  return {
+    contract,
+    symbol,
+    decimals,
+    address,
+  };
+}

--- a/src/tasks/ts/table.ts
+++ b/src/tasks/ts/table.ts
@@ -1,0 +1,77 @@
+import chalk from "chalk";
+
+export enum Align {
+  Left,
+  Right,
+}
+
+interface ColumnOptions {
+  align?: Align;
+  maxWidth?: number;
+}
+
+function cellText(text: string, size: number, align = Align.Left): string {
+  let inner;
+  if (text.length > size - 2) {
+    inner = text.slice(0, size - 5) + "...";
+  } else {
+    if (align == Align.Right) {
+      inner = text.padStart(size - 2, " ");
+    } else {
+      inner = text.padEnd(size - 2, " ");
+    }
+  }
+
+  return " " + inner + " ";
+}
+
+// shrinks column sizes to fit the content
+function columnWidths<Key extends string>(
+  header: Record<Key, string>,
+  entries: Record<Key, string>[],
+  maxWidth: Partial<Record<Key, Pick<ColumnOptions, "maxWidth">>> = {},
+): Record<Key, number> {
+  const longestEntryLenght = (key: Key) =>
+    entries.reduce((longest, entry) => Math.max(longest, entry[key].length), 0);
+  const width: Partial<Record<Key, number>> = {};
+  for (const key in header) {
+    // pad with a space left and right (+2)
+    width[key] =
+      Math.min(
+        Math.max(header[key].length, longestEntryLenght(key)),
+        maxWidth[key]?.maxWidth === undefined
+          ? Infinity
+          : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            maxWidth[key]!.maxWidth!,
+      ) + 2;
+  }
+  return width as Record<Key, number>;
+}
+
+export function displayTable<Key extends string>(
+  header: Record<Key, string>,
+  entries: Record<Key, string>[],
+  order: Key[] | readonly Key[],
+  keyOptions: Partial<Record<Key, ColumnOptions>> = {},
+): void {
+  const width = columnWidths(header, entries, keyOptions);
+  console.log(
+    order
+      .map((key: Key) =>
+        chalk.cyan(cellText(header[key], width[key], Align.Left)),
+      )
+      .join(chalk.gray("|")),
+  );
+  console.log(
+    chalk.gray(order.map((key: Key) => "-".repeat(width[key])).join("+")),
+  );
+  for (const entry of entries) {
+    console.log(
+      order
+        .map((key: Key) =>
+          cellText(entry[key], width[key], keyOptions[key]?.align),
+        )
+        .join(chalk.gray("|")),
+    );
+  }
+}

--- a/src/tasks/withdraw.ts
+++ b/src/tasks/withdraw.ts
@@ -1,0 +1,467 @@
+import "@nomiclabs/hardhat-ethers";
+
+import readline from "readline";
+
+import axios from "axios";
+import chalk from "chalk";
+import { BigNumber, utils, constants, Contract } from "ethers";
+import { task, types } from "hardhat/config";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+import { BUY_ETH_ADDRESS, SettlementEncoder } from "../ts";
+
+import { getDeployedContract } from "./ts/deployment";
+import { TokenDetails, tokenDetails } from "./ts/erc20";
+import { Align, displayTable } from "./ts/table";
+
+const MAINNET_DAI = "0x6b175474e89094c44da98b954eedeac495271d0f";
+const ONEINCH_ETH_FLAG = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+const DAI_DECIMALS = 18;
+
+interface Withdrawal {
+  token: PricedToken;
+  amount: BigNumber;
+  amountUsd: BigNumber;
+  balance: BigNumber;
+  balanceUsd: BigNumber;
+}
+
+interface DisplayWithdrawal {
+  symbol: string;
+  balance: string;
+  amount: string;
+  value: string;
+  address: string;
+}
+
+interface PricedToken extends TokenDetails {
+  // Overrides existing field in TokenDetails. The number of decimals must be
+  // known to estimate the price
+  decimals: number;
+  // Amount of DAI wei equivalent to one unit of this token (10**decimals)
+  usdValue: BigNumber;
+}
+
+// https://api.1inch.exchange/swagger/ethereum/#/Tokens/TokensController_getTokens
+type OneinchTokenList = Record<
+  string,
+  { symbol: string; decimals: number; address: string }
+>;
+const ONEINCH_TOKENS: Promise<OneinchTokenList> = axios
+  .get("https://api.1inch.exchange/v3.0/1/tokens")
+  .then((response) => response.data.tokens)
+  .catch(() => {
+    console.warn("Warning: unable to recover token list from 1inch");
+    return {};
+  });
+
+async function fastTokenDetails(
+  address: string,
+  hre: HardhatRuntimeEnvironment,
+): Promise<TokenDetails> {
+  const oneinchTokens = await ONEINCH_TOKENS;
+  if (
+    hre.network.name === "mainnet" &&
+    oneinchTokens[address.toLowerCase()] !== undefined
+  ) {
+    const IERC20 = await hre.artifacts.readArtifact(
+      "src/contracts/interfaces/IERC20.sol:IERC20",
+    );
+    const contract = new Contract(address, IERC20.abi, hre.ethers.provider);
+    return { ...oneinchTokens[address.toLowerCase()], contract };
+  }
+  return tokenDetails(address, hre);
+}
+
+// Recovers mainnet address from token symbol. Useful to get prices out of xdai
+// and rinkeby tokens.
+async function addressFromSymbol(
+  symbol: string,
+  network: string,
+): Promise<string | null> {
+  const oneinchTokens = await ONEINCH_TOKENS;
+  const tokensFromSymbol = Object.entries(oneinchTokens).filter(
+    ([, token]) => token.symbol.toLowerCase() === symbol.toLowerCase(),
+  );
+  let result = tokensFromSymbol.length == 0 ? null : tokensFromSymbol[0][0];
+  if (tokensFromSymbol.length > 1) {
+    // More than one token available. Using the most valued token to be safe.
+    const tokenValues = await Promise.all(
+      tokensFromSymbol.map(([, token]) =>
+        oneinchUsdValue(token, BigNumber.from(10).pow(15), network),
+      ),
+    );
+    const mostValued = tokenValues.reduce(
+      (max, value, i) => (value.gt(tokenValues[max]) ? i : max),
+      0,
+    );
+    result = tokensFromSymbol[mostValued][0];
+  }
+  return result;
+}
+
+// https://api.1inch.exchange/swagger/ethereum/#/Swap/SwapController_getQuote
+const oneinchUsdValue = async function (
+  token: Pick<TokenDetails, "symbol" | "address">,
+  amount: BigNumber,
+  network: string,
+): Promise<BigNumber> {
+  let fromTokenAddress: string;
+  if (Object.keys(await ONEINCH_TOKENS).includes(token.address.toLowerCase())) {
+    // Assumption: if a mainnet token has value, it's supported by 1inch.
+    // If it's not on mainnet, then either it was deployed to the same address
+    // on mainnet (and is the same token, i.e., same value), or its address is
+    // overwhelmingly likely not to be in the 1inch list.
+    fromTokenAddress = token.address;
+  } else if (network === "mainnet" || token.symbol === null) {
+    // Assumption: a token with no name has no value.
+    return constants.Zero;
+  } else {
+    // Assumption: if the token has value on xdai, then a token with the same
+    // name and approximately the same value exists on mainnet. WXDAI is the
+    // only exception.
+    // There will be false positives, but on Rinkeby and xdai the low gas prices
+    // make it an acceptable loss.
+    const symbol =
+      token.symbol.toLowerCase() === "wxdai" ? "DAI" : token.symbol;
+    const address = await addressFromSymbol(symbol, network);
+    if (address === null) {
+      return constants.Zero;
+    }
+    fromTokenAddress = address;
+  }
+
+  const toTokenAddress = MAINNET_DAI;
+  // Note: 1inch API calls fail if from and to addresses are the same
+  if (fromTokenAddress === toTokenAddress) {
+    return amount;
+  }
+
+  try {
+    const response = await axios.get(
+      "https://api.1inch.exchange/v3.0/1/quote",
+      {
+        params: {
+          fromTokenAddress,
+          toTokenAddress,
+          amount: amount.toString(),
+        },
+      },
+    );
+    // Note: in principle 1inch could use less than the provided input amount.
+    // In this case, we assume that the token has no more value that what is
+    // available from the available liquidity.
+    return BigNumber.from(response.data.toTokenAmount);
+  } catch (e) {
+    console.warn(
+      `Warning: 1inch price retrieval failed for token ${token.symbol} (${token.address}). Token will be ignored.`,
+    );
+    return constants.Zero;
+  }
+};
+
+async function appraise(
+  token: TokenDetails,
+  network: string,
+): Promise<PricedToken> {
+  const decimals = token.decimals ?? DAI_DECIMALS;
+  const usdValue = await oneinchUsdValue(
+    token,
+    BigNumber.from(10).pow(decimals),
+    network,
+  );
+  return { ...token, usdValue, decimals };
+}
+
+async function getAllTradedTokens(settlement: Contract): Promise<string[]> {
+  const trades = await settlement.queryFilter(settlement.filters.Trade());
+  const tokens = new Set(
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    trades.map((trade) => [trade.args!.sellToken, trade.args!.buyToken]).flat(),
+  );
+  tokens.delete(BUY_ETH_ADDRESS);
+  return Array.from(tokens).sort((lhs, rhs) =>
+    lhs.toLowerCase() < rhs.toLowerCase() ? -1 : lhs === rhs ? 0 : 1,
+  );
+}
+
+function clearLine() {
+  if (
+    process.stdout.clearLine !== undefined &&
+    process.stdout.cursorTo !== undefined
+  ) {
+    process.stdout.clearLine(0);
+    process.stdout.cursorTo(0);
+  }
+}
+
+async function getWithdrawals(
+  tokens: string[],
+  settlement: Contract,
+  minValue: string,
+  leftover: string,
+  hre: HardhatRuntimeEnvironment,
+): Promise<Withdrawal[]> {
+  const withdrawals = [];
+  const minValueWei = utils.parseUnits(minValue, DAI_DECIMALS);
+  const leftoverWei = utils.parseUnits(leftover, DAI_DECIMALS);
+  for (let i = 0; i < tokens.length; i++) {
+    const address = tokens[i];
+    clearLine();
+    process.stdout.write(`Processing token ${i + 1}/${tokens.length}...`);
+    const token = await fastTokenDetails(address, hre);
+    const balance = await token.contract.balanceOf(settlement.address);
+    if (balance.eq(0)) {
+      continue;
+    }
+    const pricedToken = await appraise(token, hre.network.name);
+    const balanceUsd = pricedToken.usdValue
+      .mul(balance)
+      .div(BigNumber.from(10).pow(pricedToken.decimals));
+    clearLine();
+    // Note: if balanceUsd is zero, then setting either minValue or leftoverWei
+    // to a nonzero value means that nothing should be withdrawn. If neither
+    // flag is set, then whether to withdraw does not depend on the USD value.
+    if (
+      balanceUsd.lt(minValueWei.add(leftoverWei)) ||
+      (balanceUsd.isZero() && !(minValueWei.isZero() && leftoverWei.isZero()))
+    ) {
+      console.warn(
+        `Ignored ${utils.formatUnits(balance, pricedToken.decimals)} units of ${
+          token.symbol ?? "unknown token"
+        } (${token.address}) with value ${formatUsdValue(balanceUsd)} USD`,
+      );
+      continue;
+    }
+    let amount;
+    let amountUsd;
+    if (balanceUsd.isZero()) {
+      // Note: minValueWei and leftoverWei are zero. Everything should be
+      // withdrawn.
+      amount = balance;
+      amountUsd = balanceUsd;
+    } else {
+      amount = balance.mul(balanceUsd.sub(leftoverWei)).div(balanceUsd);
+      amountUsd = balanceUsd.sub(leftoverWei);
+    }
+    withdrawals.push({
+      token: pricedToken,
+      amount,
+      amountUsd,
+      balance,
+      balanceUsd,
+    });
+  }
+  clearLine();
+  return withdrawals;
+}
+
+// Format amount so that it has exactly a fixed amount of decimals.
+function formatTokenValue(
+  amount: BigNumber,
+  actualDecimals: number,
+  targetDecimals: number,
+): string {
+  const normalized =
+    targetDecimals <= actualDecimals
+      ? amount.div(BigNumber.from(10).pow(actualDecimals - targetDecimals))
+      : amount.mul(BigNumber.from(10).pow(-actualDecimals + targetDecimals));
+  const powDecimals = BigNumber.from(10).pow(targetDecimals);
+  return `${normalized.div(powDecimals).toString()}.${normalized
+    .mod(powDecimals)
+    .toString()
+    .padStart(targetDecimals, "0")}`;
+}
+
+function formatUsdValue(amount: BigNumber): string {
+  return formatTokenValue(amount, DAI_DECIMALS, 2);
+}
+
+function formatWithdrawal(withdrawal: Withdrawal): DisplayWithdrawal {
+  return {
+    address: withdrawal.token.address,
+    value: formatUsdValue(withdrawal.balanceUsd),
+    balance: formatTokenValue(
+      withdrawal.balance,
+      withdrawal.token.decimals,
+      18,
+    ),
+    amount: formatTokenValue(withdrawal.amount, withdrawal.token.decimals, 18),
+    symbol: withdrawal.token.symbol ?? "unknown token",
+  };
+}
+
+function displayWithdrawals(withdrawals: Withdrawal[]) {
+  const formattedWithdtrawals = withdrawals.map(formatWithdrawal);
+  const order = ["address", "value", "balance", "amount", "symbol"] as const;
+  const header = {
+    address: "address",
+    value: "balance (usd)",
+    balance: "balance",
+    amount: "withdrawn amount",
+    symbol: "symbol",
+  };
+  console.log(chalk.bold("Amounts to withdraw:"));
+  displayTable(header, formattedWithdtrawals, order, {
+    value: { align: Align.Right },
+    balance: { align: Align.Right, maxWidth: 30 },
+    amount: { align: Align.Right, maxWidth: 30 },
+    symbol: { maxWidth: 20 },
+  });
+  console.log();
+}
+
+async function formatGasCost(
+  amount: BigNumber,
+  network: string,
+): Promise<string> {
+  switch (network) {
+    case "mainnet": {
+      const value = await oneinchUsdValue(
+        { symbol: "ETH", address: ONEINCH_ETH_FLAG },
+        amount,
+        "mainnet",
+      );
+      return `${utils.formatEther(amount)} ETH (${formatUsdValue(value)} USD)`;
+    }
+    case "xdai":
+      return `${utils.formatEther(amount)} XDAI`;
+    default:
+      return `${utils.formatEther(amount)} ETH`;
+  }
+}
+
+async function prompt(message: string) {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  const response = await new Promise<string>((resolve) =>
+    rl.question(`${message} (y/N) `, (response) => resolve(response)),
+  );
+  return "y" === response.toLowerCase();
+}
+
+const setupWithdrawTask: () => void = () =>
+  task("withdraw", "Withdraw funds from the settlement contract")
+    .addOptionalParam(
+      "minValue",
+      "If specified, sets a minimum USD value required to withdraw the balance of a token.",
+      "0",
+      types.string,
+    )
+    .addOptionalParam(
+      "leftover",
+      "If specified, withdrawing leaves an amount of each token of USD value specified with this flag.",
+      "0",
+      types.string,
+    )
+    .addParam("receiver", "The address receiving the withdrawn tokens.")
+    .addFlag(
+      "dryRun",
+      "Just simulate the settlement instead of executing the transaction on the blockchain.",
+    )
+    .addOptionalVariadicPositionalParam(
+      "tokens",
+      "An optional subset of tokens to consider for withdraw (otherwise all traded tokens will be queried).",
+    )
+    .setAction(
+      async (
+        { minValue, dryRun, leftover, receiver: inputReceiver, tokens },
+        hre: HardhatRuntimeEnvironment,
+      ) => {
+        const receiver = utils.getAddress(inputReceiver);
+        const [authenticator, settlement, [solver]] = await Promise.all([
+          getDeployedContract("GPv2AllowListAuthentication", hre),
+          getDeployedContract("GPv2Settlement", hre),
+          hre.ethers.getSigners(),
+        ]);
+
+        if (!(await authenticator.isSolver(solver.address))) {
+          const message =
+            "Current account is not a solver. Only a solver can withdraw funds from the settlement contract.";
+          if (!dryRun) {
+            throw Error(message);
+          } else {
+            console.warn(message);
+          }
+        }
+
+        if (tokens === undefined) {
+          tokens = await getAllTradedTokens(settlement);
+        }
+
+        // TODO: add eth withdrawal
+        // TODO: split large transaction in batches
+        const withdrawals = await getWithdrawals(
+          tokens,
+          settlement,
+          minValue,
+          leftover,
+          hre,
+        );
+        withdrawals.sort((lhs, rhs) => {
+          const diff = lhs.balanceUsd.sub(rhs.balanceUsd);
+          return diff.isZero() ? 0 : diff.isNegative() ? -1 : 1;
+        });
+
+        displayWithdrawals(withdrawals);
+
+        if (withdrawals.length === 0) {
+          console.log("No tokens to withdraw.");
+          process.exit(0);
+        }
+
+        const encoder = new SettlementEncoder({});
+        withdrawals.forEach(({ token, amount }) =>
+          encoder.encodeInteraction({
+            target: token.address,
+            callData: token.contract.interface.encodeFunctionData("transfer", [
+              receiver,
+              amount,
+            ]),
+          }),
+        );
+
+        const finalSettlement = encoder.encodedSettlement({});
+        // TODO: use the address of a solver as the from address in dry run so
+        // that the price can always be estimated
+        const [gas, gasPrice] = await Promise.all([
+          settlement.estimateGas.settle(...finalSettlement),
+          hre.ethers.provider.getGasPrice(),
+        ]);
+        const amount = gas.mul(gasPrice);
+        const totalValue = withdrawals.reduce(
+          (sum, { amountUsd }) => sum.add(amountUsd),
+          constants.Zero,
+        );
+        console.log(
+          `The transaction will cost approximately ${await formatGasCost(
+            amount,
+            hre.network.name,
+          )} and will withdraw the balance of ${
+            withdrawals.length
+          } tokens for an estimated total value of ${formatUsdValue(
+            totalValue,
+          )} USD. All withdrawn funds will be sent to ${receiver}.`,
+        );
+
+        if (!dryRun && (await prompt("Submit?"))) {
+          console.log(
+            "Executing the withdraw transaction on the blockchain...",
+          );
+          const response = await settlement
+            .connect(solver)
+            .settle(...finalSettlement);
+          console.log(
+            "Transaction submitted to the blockchain. Waiting for acceptance in a block...",
+          );
+          const receipt = await response.wait();
+          console.log(
+            `Transaction successfully executed. Transaction hash: ${receipt.transactionHash}`,
+          );
+        }
+      },
+    );
+
+export { setupWithdrawTask };


### PR DESCRIPTION
Copies the current contract code to withdraw tokens in the contract to the alpha version of the contract.
In this way, we can always rely on the `v0.0.1` branch to withdraw funds from the old contract.

The code is coped from `main`. The only differences are those required to work around the lack of some helper functions.

### Recommendations on how to review

Check how the changes compare to current `main`.
<details><summary>$ git diff main v0.0.1-withdraw-script $(git whatchanged v0.0.1...v0.0.1-withdraw-script | grep '^:' | awk '{print $6}')</summary>

```
diff --git a/src/tasks/index.ts b/src/tasks/index.ts
index 06bba9e..584d111 100644
--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -1,12 +1,10 @@
 import { setupCopyArtifactsTask } from "./artifacts";
-import { setupDecodeTask } from "./decode";
 import { setupSolversTask } from "./solvers";
 import { setupTenderlyTask } from "./tenderly";
 import { setupWithdrawTask } from "./withdraw";
 
 export function setupTasks(): void {
   setupCopyArtifactsTask();
-  setupDecodeTask();
   setupSolversTask();
   setupTenderlyTask();
   setupWithdrawTask();
diff --git a/src/tasks/withdraw.ts b/src/tasks/withdraw.ts
index 354a9f1..6042b2d 100644
--- a/src/tasks/withdraw.ts
+++ b/src/tasks/withdraw.ts
@@ -412,16 +412,18 @@ const setupWithdrawTask: () => void = () =>
           process.exit(0);
         }
 
-        const finalSettlement = SettlementEncoder.encodedSetup(
-          ...withdrawals.map(({ token, amount }) => ({
+        const encoder = new SettlementEncoder({});
+        withdrawals.forEach(({ token, amount }) =>
+          encoder.encodeInteraction({
             target: token.address,
             callData: token.contract.interface.encodeFunctionData("transfer", [
               receiver,
               amount,
             ]),
-          })),
+          }),
         );
 
+        const finalSettlement = encoder.encodedSettlement({});
         // TODO: use the address of a solver as the from address in dry run so
         // that the price can always be estimated
         const [gas, gasPrice] = await Promise.all([
```
</details>

### Test plan

See transaction [0x4c7f8a2d6449c72311ac2ac1b3fc3bf1d8276fae55e98b9a1b75fae8184272ee](https://rinkeby.etherscan.io/tx/0x4c7f8a2d6449c72311ac2ac1b3fc3bf1d8276fae55e98b9a1b75fae8184272ee).
```
$ yarn hardhat withdraw --network rinkeby  --receiver 0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf 0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea
yarn run v1.22.10
$ /path/oba-contracts/node_modules/.bin/hardhat withdraw --network rinkeby --receiver 0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf 0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea
Amounts to withdraw:
 address                                    | balance (usd) | balance                | withdrawn amount       | symbol 
--------------------------------------------+---------------+------------------------+------------------------+--------
 0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea |        261.78 | 261.788605198303829367 | 261.788605198303829367 | DAI    

The transaction will cost approximately 0.000063573 ETH and will withdraw the balance of 1 tokens for an estimated total value of 261.78 USD. All withdrawn funds will be sent to 0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf.
Submit? (y/N) y
Executing the withdraw transaction on the blockchain...
Transaction submitted to the blockchain. Waiting for acceptance in a block...
Transaction successfully executed. Transaction hash: 0x4c7f8a2d6449c72311ac2ac1b3fc3bf1d8276fae55e98b9a1b75fae8184272ee
Done in 36.08s.
```