### PR TITLE
[v0.0.1] Add decoder for erc20 interactions

### DIFF
--- a/src/tasks/decode.ts
+++ b/src/tasks/decode.ts
@@ -396,7 +396,9 @@ const setupDecodeTask: () => void = () => {
             await Promise.all(
               interactionGroup.map(async (i) => ({
                 ...i,
-                decoded: await decodeInteraction(i),
+                decoded: await decodeInteraction(i, hre, {
+                  settlementContractAddress: deployment?.address,
+                }),
               })),
             ),
         ),

--- a/src/tasks/decode/interaction.ts
+++ b/src/tasks/decode/interaction.ts
@@ -1,5 +1,8 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
 import { Interaction } from "../../ts";
 
+import { Erc20Decoder } from "./interaction/erc20";
 import { InteractionDecoder } from "./interaction/template";
 
 // For reference, here is a list of contracts supported by the backend:
@@ -21,16 +24,15 @@ export interface DecodedInteraction {
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface DecodingTools {
-  // Used to pass in objects needed for decoding
+  settlementContractAddress?: string;
 }
 
 export async function decode(
   interaction: Interaction,
+  hre: HardhatRuntimeEnvironment,
   decodingTools: DecodingTools = {},
 ): Promise<DecodedInteraction | null> {
-  const decoders: InteractionDecoder[] = [
-    /* new decoders should be added here */
-  ];
+  const decoders: InteractionDecoder[] = [new Erc20Decoder(hre)];
 
   try {
     // TODO: use Promise.any when better supported by our tooling

--- a/src/tasks/decode/interaction/erc20.ts
+++ b/src/tasks/decode/interaction/erc20.ts
@@ -1,0 +1,147 @@
+import IERC20 from "@openzeppelin/contracts/build/contracts/IERC20.json";
+import { utils, BytesLike } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+import { Interaction } from "../../../ts";
+import { tokenDetails } from "../../ts/erc20";
+import {
+  DecodedInteraction,
+  DecodedInteractionCall,
+  DecodingTools,
+} from "../interaction";
+
+import { InteractionDecoder } from "./template";
+
+const erc20Interface = new utils.Interface(IERC20.abi);
+
+export class Erc20Decoder extends InteractionDecoder {
+  private hre: HardhatRuntimeEnvironment;
+
+  constructor(hre: HardhatRuntimeEnvironment) {
+    super();
+    this.hre = hre;
+  }
+
+  public get name(): string {
+    return "erc20";
+  }
+
+  private formatCalldata(
+    calldata: BytesLike,
+    symbol: string,
+    decimals: number,
+    settlementContractAddress: string,
+  ): DecodedInteractionCall | null {
+    const selector = utils.hexlify(utils.arrayify(calldata).slice(0, 4));
+
+    let functionName: string;
+    let args: Map<string, string> | null = null;
+    switch (selector) {
+      case erc20Interface.getSighash("approve"):
+        functionName = "approve";
+        try {
+          const { spender, amount } = erc20Interface.decodeFunctionData(
+            functionName,
+            calldata,
+          );
+          args = new Map();
+          args.set(
+            "spender",
+            spender === settlementContractAddress
+              ? "settlement contract"
+              : spender,
+          );
+          args.set(
+            "amount",
+            `${utils.formatUnits(amount, decimals)} ${symbol}`,
+          );
+        } catch {
+          // unable to decode arguments, `args` is null
+        }
+        break;
+      case erc20Interface.getSighash("transfer"):
+        functionName = "transfer";
+        try {
+          const { recipient, amount } = erc20Interface.decodeFunctionData(
+            functionName,
+            calldata,
+          );
+          args = new Map();
+          args.set(
+            "recipient",
+            recipient === settlementContractAddress
+              ? "settlement contract"
+              : recipient,
+          );
+          args.set(
+            "amount",
+            `${utils.formatUnits(amount, decimals)} ${symbol}`,
+          );
+        } catch {
+          // unable to decode arguments, `args` is null
+        }
+        break;
+      case erc20Interface.getSighash("transferFrom"):
+        functionName = "transferFrom";
+        try {
+          const {
+            sender,
+            recipient,
+            amount,
+          } = erc20Interface.decodeFunctionData(functionName, calldata);
+          args = new Map();
+          args.set(
+            "sender",
+            sender === settlementContractAddress
+              ? "settlement contract"
+              : sender,
+          );
+          args.set(
+            "recipient",
+            recipient === settlementContractAddress
+              ? "settlement contract"
+              : recipient,
+          );
+          args.set(
+            "amount",
+            `${utils.formatUnits(amount, decimals)} ${symbol}`,
+          );
+        } catch {
+          // unable to decode arguments, `args` is null
+        }
+        break;
+      default:
+        return null;
+    }
+
+    return { functionName, args };
+  }
+
+  public async decode(
+    interaction: Interaction,
+    decodingTools: DecodingTools = {},
+  ): Promise<DecodedInteraction | null> {
+    const { settlementContractAddress } = decodingTools;
+    const { symbol, decimals } = await tokenDetails(
+      interaction.target,
+      this.hre,
+    );
+    // Assumption: it's a token if and only if it has both a symbol and
+    // decimals. In theory there could be false positives and negatives, in
+    // practice all meaningful tokens have both.
+    if (symbol === null || decimals === null) {
+      return null;
+    }
+
+    const targetName = `erc20 token: ${symbol}`;
+    return {
+      targetName,
+      call: this.formatCalldata(
+        interaction.callData,
+        symbol,
+        decimals,
+        settlementContractAddress ?? "",
+      ),
+    };
+  }
+}


### PR DESCRIPTION
Adds a decoder for ERC20 interactions to the settlement decoder.
It depends on PR #715 for the definition of a decoder and how it's used.

### Test Plan

```
$ npx hardhat decode --network mainnet --txhash 0x2e70ff6f3be7c198db8e05c5331a7ef3151303cc27da91fbd368504dec01d280
=== Tokens ===
 address | index | symbol | price 
---------+-------+--------+-------

=== Trades ===
------------------------------------------------------------------------------------------------------------------------
=== Interactions ===
------------------------------------------------------------------------------------------------------------------------
  --- Pre-interactions ---

 ┌--- Intra-interactions ---
 ├───  Interaction: target address 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 (erc20 token: USDC)
 │     function: transfer
 │      - recipient: 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
 │      - amount: 1039.780579 USDC
 │     calldata: 0xa9059cbb0000000000000000000000006c642cafcbd9d8383250bb25f67ae409147f78b2000000000000000000000000000000000000000000000000000000003df9cae3
 ├───  Interaction: target address 0xdAC17F958D2ee523a2206206994597C13D831ec7 (erc20 token: USDT)
 │     function: transfer
 │      - recipient: 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
 │      - amount: 1365.202328 USDT
 │     calldata: 0xa9059cbb0000000000000000000000006c642cafcbd9d8383250bb25f67ae409147f78b200000000000000000000000000000000000000000000000000000000515f5598
 └───  Interaction: target address 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 (erc20 token: WETH)
       function: transfer
        - recipient: 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
        - amount: 9.170261307061743731 WETH
       calldata: 0xa9059cbb0000000000000000000000006c642cafcbd9d8383250bb25f67ae409147f78b20000000000000000000000000000000000000000000000007f43501298ecb073

  --- Post-interactions ---
```
