### PR TITLE
[v0.0.1] Explicit network type in tasks (and related bugfix)

### DIFF
--- a/src/tasks/ts/deployment.ts
+++ b/src/tasks/ts/deployment.ts
@@ -3,6 +3,14 @@ import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 import { ContractName } from "../../ts";
 
+const supportedNetworks = ["rinkeby", "xdai", "mainnet"] as const;
+export type SupportedNetwork = typeof supportedNetworks[number];
+export function isSupportedNetwork(
+  network: string,
+): network is SupportedNetwork {
+  return (supportedNetworks as readonly string[]).includes(network);
+}
+
 export async function getDeployedContract(
   name: ContractName,
   { ethers, deployments }: HardhatRuntimeEnvironment,

--- a/src/tasks/withdraw.ts
+++ b/src/tasks/withdraw.ts
@@ -97,6 +97,7 @@ async function getAllTradedTokens(
   try {
     trades = await hre.ethers.provider.getLogs({
       topics: [settlement.interface.getEventTopic("Trade")],
+      address: settlement.address,
       fromBlock,
       toBlock,
     });

--- a/src/tasks/withdraw.ts
+++ b/src/tasks/withdraw.ts
@@ -10,7 +10,11 @@ import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 import { BUY_ETH_ADDRESS, SettlementEncoder } from "../ts";
 
-import { getDeployedContract } from "./ts/deployment";
+import {
+  getDeployedContract,
+  isSupportedNetwork,
+  SupportedNetwork,
+} from "./ts/deployment";
 import { TokenDetails, tokenDetails } from "./ts/erc20";
 import { Align, displayTable } from "./ts/table";
 import {
@@ -20,7 +24,6 @@ import {
   appraise,
 } from "./withdraw/value";
 
-const ONEINCH_ETH_FLAG = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 const DAI_DECIMALS = 18;
 const RATE_LIMIT_MAX_PARALLEL_WITHDRAWALS = 20;
 
@@ -146,6 +149,7 @@ async function getWithdrawals(
   minValue: string,
   leftover: string,
   hre: HardhatRuntimeEnvironment,
+  network: SupportedNetwork,
 ): Promise<Withdrawal[]> {
   const withdrawals: Withdrawal[] = [];
   const minValueWei = utils.parseUnits(minValue, DAI_DECIMALS);
@@ -158,7 +162,7 @@ async function getWithdrawals(
     if (balance.eq(0)) {
       return;
     }
-    const pricedToken = await appraise(token, hre.network.name);
+    const pricedToken = await appraise(token, network);
     const balanceUsd = pricedToken.usdValue
       .mul(balance)
       .div(BigNumber.from(10).pow(pricedToken.decimals));
@@ -177,7 +181,7 @@ async function getWithdrawals(
           token.symbol ?? "unknown token"
         } (${token.address}) with value ${formatUsdValue(
           balanceUsd,
-          hre.network.name,
+          network,
         )} USD`,
       );
       if (LINE_CLEARING_ENABLED) {
@@ -241,7 +245,7 @@ async function getWithdrawals(
 
 function formatWithdrawal(
   withdrawal: Withdrawal,
-  network: string,
+  network: SupportedNetwork,
 ): DisplayWithdrawal {
   return {
     address: withdrawal.token.address,
@@ -256,7 +260,10 @@ function formatWithdrawal(
   };
 }
 
-function displayWithdrawals(withdrawals: Withdrawal[], network: string) {
+function displayWithdrawals(
+  withdrawals: Withdrawal[],
+  network: SupportedNetwork,
+) {
   const formattedWithdtrawals = withdrawals.map((w) =>
     formatWithdrawal(w, network),
   );
@@ -280,15 +287,11 @@ function displayWithdrawals(withdrawals: Withdrawal[], network: string) {
 
 async function formatGasCost(
   amount: BigNumber,
-  network: string,
+  network: SupportedNetwork,
 ): Promise<string> {
   switch (network) {
     case "mainnet": {
-      const value = await usdValue(
-        { symbol: "ETH", address: ONEINCH_ETH_FLAG },
-        amount,
-        "mainnet",
-      );
+      const value = await usdValue("native token", amount, "mainnet");
       return `${utils.formatEther(amount)} ETH (${formatUsdValue(
         value,
         network,
@@ -341,6 +344,10 @@ const setupWithdrawTask: () => void = () =>
         hre: HardhatRuntimeEnvironment,
       ) => {
         const receiver = utils.getAddress(inputReceiver);
+        if (!isSupportedNetwork(hre.network.name)) {
+          throw new Error(`Unsupported network ${hre.network.name}`);
+        }
+        const network = hre.network.name;
         const [
           authenticator,
           settlementDeployment,
@@ -386,13 +393,14 @@ const setupWithdrawTask: () => void = () =>
           minValue,
           leftover,
           hre,
+          network,
         );
         withdrawals.sort((lhs, rhs) => {
           const diff = lhs.balanceUsd.sub(rhs.balanceUsd);
           return diff.isZero() ? 0 : diff.isNegative() ? -1 : 1;
         });
 
-        displayWithdrawals(withdrawals, hre.network.name);
+        displayWithdrawals(withdrawals, network);
 
         if (withdrawals.length === 0) {
           console.log("No tokens to withdraw.");

--- a/src/tasks/withdraw/value.ts
+++ b/src/tasks/withdraw/value.ts
@@ -1,14 +1,10 @@
 import axios from "axios";
+import WethNetworks from "canonical-weth/networks.json";
 import { BigNumber, constants } from "ethers";
 
 import { OrderKind } from "../../ts";
 import { SupportedNetwork } from "../ts/deployment";
 import { TokenDetails } from "../ts/erc20";
-
-// canonical-weth is not typed
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const wrappedNativeTokenByNetworkId = require("canonical-weth")
-  .networks as Record<string, { address: string }>;
 
 interface ApiTradeQuery {
   network: string;
@@ -33,8 +29,8 @@ const NATIVE_TOKEN_SYMBOL: Record<SupportedNetwork, string> = {
 };
 
 const WRAPPED_NATIVE_TOKEN_ADDRESS: Record<SupportedNetwork, string> = {
-  mainnet: wrappedNativeTokenByNetworkId[1].address,
-  rinkeby: wrappedNativeTokenByNetworkId[4].address,
+  mainnet: WethNetworks.WETH9[1].address,
+  rinkeby: WethNetworks.WETH9[4].address,
   xdai: "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
 };
 

--- a/src/tasks/withdraw/value.ts
+++ b/src/tasks/withdraw/value.ts
@@ -2,7 +2,13 @@ import axios from "axios";
 import { BigNumber, constants } from "ethers";
 
 import { OrderKind } from "../../ts";
+import { SupportedNetwork } from "../ts/deployment";
 import { TokenDetails } from "../ts/erc20";
+
+// canonical-weth is not typed
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const wrappedNativeTokenByNetworkId = require("canonical-weth")
+  .networks as Record<string, { address: string }>;
 
 interface ApiTradeQuery {
   network: string;
@@ -20,8 +26,20 @@ interface PricedToken extends TokenDetails {
   usdValue: BigNumber;
 }
 
+const NATIVE_TOKEN_SYMBOL: Record<SupportedNetwork, string> = {
+  mainnet: "ETH",
+  rinkeby: "ETH",
+  xdai: "xDAI",
+};
+
+const WRAPPED_NATIVE_TOKEN_ADDRESS: Record<SupportedNetwork, string> = {
+  mainnet: wrappedNativeTokenByNetworkId[1].address,
+  rinkeby: wrappedNativeTokenByNetworkId[4].address,
+  xdai: "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
+};
+
 const REFERENCE_TOKEN: Record<
-  string,
+  SupportedNetwork,
   { symbol: string; decimals: number; address: string }
 > = {
   rinkeby: {
@@ -39,7 +57,7 @@ const REFERENCE_TOKEN: Record<
     // by the services.
     symbol: "WXDAI",
     decimals: 18,
-    address: "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
+    address: WRAPPED_NATIVE_TOKEN_ADDRESS.xdai,
   },
 } as const;
 
@@ -55,12 +73,17 @@ function apiPriceUrl({
 }
 
 export const usdValue = async function (
-  token: Pick<TokenDetails, "symbol" | "address">,
+  token: Pick<TokenDetails, "symbol" | "address"> | "native token",
   amount: BigNumber,
-  network: string,
+  network: SupportedNetwork,
 ): Promise<BigNumber> {
-  if (!(network in REFERENCE_TOKEN)) {
-    throw new Error("Unsupported network for computing USD value");
+  if (token === "native token") {
+    // Note: using wrapped token since the API does not support sell orders in
+    // native tokens.
+    token = {
+      symbol: NATIVE_TOKEN_SYMBOL[network],
+      address: WRAPPED_NATIVE_TOKEN_ADDRESS[network],
+    };
   }
   try {
     const response = await axios.get(
@@ -113,16 +136,16 @@ export function formatTokenValue(
     .padStart(targetDecimals, "0")}`;
 }
 
-export function formatUsdValue(amount: BigNumber, network: string): string {
-  if (!(network in REFERENCE_TOKEN)) {
-    throw new Error("Network not supported");
-  }
+export function formatUsdValue(
+  amount: BigNumber,
+  network: SupportedNetwork,
+): string {
   return formatTokenValue(amount, REFERENCE_TOKEN[network].decimals, 2);
 }
 
 export async function appraise(
   token: TokenDetails,
-  network: string,
+  network: SupportedNetwork,
 ): Promise<PricedToken> {
   const decimals = token.decimals ?? 18;
   const usd = await usdValue(token, BigNumber.from(10).pow(decimals), network);


### PR DESCRIPTION
Explicitly name supported network in scripts, so that we can check at compile time that all constants that depend on a network are defined for every network.

The bug that was fixed is related to the price estimation for the ETH native token. Before this PR, the script tried to query the backend for the address `0xee...ee` for estimating the cost of the gas in the transaction. This would fail, since the backend does not support the ETH placeholder token as the sell token (unlike 1inch).

In this PR I also fixed an unrelated issue since it was a one-line change: retrieving trade events from the blockchain was not limited to the settlement contract, but would retrieve all events matching the `Trade(...)` topic. Now it also filters by contract address.

### Test Plan

Run after exporting the mainnet solver public key:
```
$ npx hardhat withdraw --network mainnet --receiver 0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf --dry-run 0x6b175474e89094c44da98b954eedeac495271d0f
<snip>
The transaction will cost approximately 0.0084 ETH (19.26 USD) and will withdraw the balance of 1 tokens for an estimated total value of 646.75 USD. All withdrawn funds will be sent to 0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf.
```

Compare with output without this PR:
```
$ npx hardhat withdraw --network mainnet --receiver 0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf --dry-run 0x6b175474e89094c44da98b954eedeac495271d0f
<snip>
Warning: price retrieval failed for token ETH (0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE): NotFound (No price estimate found)
The transaction will cost approximately 0.0086 ETH (0.00 USD) and will withdraw the balance of 1 tokens for an estimated total value of 646.75 USD. All withdrawn funds will be sent to 0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf.
```