### PR TITLE
[v0.0.1] services api

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,4 +1,4 @@
-import { BigNumber, utils } from "ethers";
+import { BigNumber } from "ethers";
 import fetch, { RequestInit } from "node-fetch";
 
 import {
@@ -147,10 +147,6 @@ export async function placeOrder({
   network,
 }: PlaceOrderQuery & ApiCall): Promise<string> {
   const normalizedOrder = normalizeOrder(order);
-  // the api expects appData to always have length 32 bytes
-  const appData = utils.hexlify(
-    utils.hexZeroPad(utils.arrayify(normalizedOrder.appData), 32),
-  );
   return await call("orders", network, {
     method: "post",
     body: JSON.stringify({
@@ -159,7 +155,7 @@ export async function placeOrder({
       sellAmount: BigNumber.from(normalizedOrder.sellAmount).toString(),
       buyAmount: BigNumber.from(normalizedOrder.buyAmount).toString(),
       validTo: normalizedOrder.validTo,
-      appData,
+      appData: normalizedOrder.appData,
       feeAmount: BigNumber.from(normalizedOrder.feeAmount).toString(),
       kind: apiKind(order.kind),
       partiallyFillable: normalizedOrder.partiallyFillable,

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,6 +3,120 @@ import fetch, { RequestInit } from "node-fetch";
 
 import { Order, OrderKind, Signature } from "../ts";
 
+interface ApiCall {
+  network: string;
+}
+
+interface GetFeeQuery {
+  sellToken: string;
+  buyToken: string;
+  kind: OrderKind;
+  amount: BigNumber;
+}
+interface EstimateTradeAmountQuery {
+  sellToken: string;
+  buyToken: string;
+  kind: OrderKind;
+  amount: BigNumber;
+}
+interface PlaceOrderQuery {
+  order: Order;
+  signature: Signature;
+}
+interface GetExecutedSellAmountQuery {
+  uid: string;
+}
+
+interface OrderDetailResponse {
+  // Other fields are omitted until needed
+  executedSellAmount: string;
+}
+interface GetFeeResponse {
+  amount: string;
+  expirationDate: Date;
+}
+interface EstimateAmountResponse {
+  amount: string;
+  token: string;
+}
+
+async function call<T>(
+  route: string,
+  network: string,
+  init?: RequestInit,
+): Promise<T> {
+  const url = `https://protocol-${network}.dev.gnosisdev.com/api/v1/${route}`;
+  const response = await fetch(url, init);
+  const body = await response.text();
+  if (!response.ok) {
+    throw `Calling "${url} ${JSON.stringify(init)} failed with ${
+      response.status
+    }: ${body}`;
+  }
+  return JSON.parse(body);
+}
+
+export async function getFee({
+  sellToken,
+  buyToken,
+  kind,
+  amount,
+  network,
+}: GetFeeQuery & ApiCall): Promise<BigNumber> {
+  const response: GetFeeResponse = await call(
+    `fee?sellToken=${sellToken}&buyToken=${buyToken}&amount=${amount}&kind=${kind}`,
+    network,
+  );
+  return BigNumber.from(response.amount);
+}
+
+export async function estimateTradeAmount({
+  network,
+  sellToken,
+  buyToken,
+  kind,
+  amount,
+}: EstimateTradeAmountQuery & ApiCall): Promise<BigNumber> {
+  const response: EstimateAmountResponse = await call(
+    `markets/${sellToken}-${buyToken}/${kind}/${amount}`,
+    network,
+  );
+  return BigNumber.from(response.amount);
+}
+
+export async function placeOrder({
+  order,
+  signature,
+  network,
+}: PlaceOrderQuery & ApiCall): Promise<string> {
+  return await call("orders", network, {
+    method: "post",
+    body: JSON.stringify({
+      sellToken: order.sellToken,
+      buyToken: order.buyToken,
+      sellAmount: order.sellAmount.toString(),
+      buyAmount: order.buyAmount.toString(),
+      validTo: order.validTo,
+      appData: order.appData,
+      feeAmount: order.feeAmount.toString(),
+      kind: order.kind,
+      partiallyFillable: order.partiallyFillable,
+      signature: signature.data,
+      signingScheme: signature.scheme,
+      receiver: order.receiver,
+    }),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export async function getExecutedSellAmount({
+  uid,
+  network,
+}: GetExecutedSellAmountQuery & ApiCall): Promise<BigNumber> {
+  const response: OrderDetailResponse = await call(`orders/${uid}`, network);
+  return BigNumber.from(response.executedSellAmount);
+}
+
 export class Api {
   network: string;
 
@@ -10,80 +124,20 @@ export class Api {
     this.network = network;
   }
 
-  private async call<T>(route: string, init?: RequestInit): Promise<T> {
-    const url = `https://protocol-${this.network}.dev.gnosisdev.com/api/v1/${route}`;
-    const response = await fetch(url, init);
-    const body = await response.text();
-    if (!response.ok) {
-      throw `Calling "${url} ${JSON.stringify(init)} failed with ${
-        response.status
-      }: ${body}`;
-    }
-    return JSON.parse(body);
+  async getFee(query: GetFeeQuery): Promise<BigNumber> {
+    return getFee({ ...query, network: this.network });
   }
-
-  async getFee(
-    selToken: string,
-    buyToken: string,
-    amount: BigNumber,
-    kind: OrderKind,
-  ): Promise<BigNumber> {
-    const response: GetFeeResponse = await this.call(
-      `fee?sellToken=${selToken}&buyToken=${buyToken}&amount=${amount}&kind=${kind}`,
-    );
-    return BigNumber.from(response.amount);
-  }
-
   async estimateTradeAmount(
-    selToken: string,
-    buyToken: string,
-    amount: BigNumber,
-    kind: OrderKind,
+    query: EstimateTradeAmountQuery,
   ): Promise<BigNumber> {
-    const response: EstimateAmountResponse = await this.call(
-      `markets/${selToken}-${buyToken}/${kind}/${amount}`,
-    );
-    return BigNumber.from(response.amount);
+    return estimateTradeAmount({ ...query, network: this.network });
   }
-
-  async placeOrder(order: Order, signature: Signature): Promise<string> {
-    return await this.call("orders", {
-      method: "post",
-      body: JSON.stringify({
-        sellToken: order.sellToken,
-        buyToken: order.buyToken,
-        sellAmount: order.sellAmount.toString(),
-        buyAmount: order.buyAmount.toString(),
-        validTo: order.validTo,
-        appData: order.appData,
-        feeAmount: order.feeAmount.toString(),
-        kind: order.kind,
-        partiallyFillable: order.partiallyFillable,
-        signature: signature.data,
-        signingScheme: signature.scheme,
-        receiver: order.receiver,
-      }),
-      headers: { "Content-Type": "application/json" },
-    });
+  async placeOrder(query: PlaceOrderQuery): Promise<string> {
+    return placeOrder({ ...query, network: this.network });
   }
-
-  async getExecutedSellAmount(uid: string): Promise<BigNumber> {
-    const response: OrderDetailResponse = await this.call(`orders/${uid}`);
-    return BigNumber.from(response.executedSellAmount);
+  async getExecutedSellAmount(
+    query: GetExecutedSellAmountQuery,
+  ): Promise<BigNumber> {
+    return getExecutedSellAmount({ ...query, network: this.network });
   }
-}
-
-interface OrderDetailResponse {
-  // Other fields are omitted until needed
-  executedSellAmount: string;
-}
-
-interface GetFeeResponse {
-  amount: string;
-  expirationDate: Date;
-}
-
-interface EstimateAmountResponse {
-  amount: string;
-  token: string;
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,8 +1,7 @@
-import { Order, OrderKind } from "@gnosis.pm/gp-v2-contracts";
 import { BigNumber } from "ethers";
 import fetch, { RequestInit } from "node-fetch";
 
-import { Signature } from "./utils";
+import { Order, OrderKind, Signature } from "../ts";
 
 export class Api {
   network: string;
@@ -27,10 +26,10 @@ export class Api {
     selToken: string,
     buyToken: string,
     amount: BigNumber,
-    kind: OrderKind
+    kind: OrderKind,
   ): Promise<BigNumber> {
     const response: GetFeeResponse = await this.call(
-      `fee?sellToken=${selToken}&buyToken=${buyToken}&amount=${amount}&kind=${kind}`
+      `fee?sellToken=${selToken}&buyToken=${buyToken}&amount=${amount}&kind=${kind}`,
     );
     return BigNumber.from(response.amount);
   }
@@ -39,10 +38,10 @@ export class Api {
     selToken: string,
     buyToken: string,
     amount: BigNumber,
-    kind: OrderKind
+    kind: OrderKind,
   ): Promise<BigNumber> {
     const response: EstimateAmountResponse = await this.call(
-      `markets/${selToken}-${buyToken}/${kind}/${amount}`
+      `markets/${selToken}-${buyToken}/${kind}/${amount}`,
     );
     return BigNumber.from(response.amount);
   }
@@ -60,8 +59,8 @@ export class Api {
         feeAmount: order.feeAmount.toString(),
         kind: order.kind,
         partiallyFillable: order.partiallyFillable,
-        signature: signature.signature,
-        signingScheme: signature.signatureScheme,
+        signature: signature.data,
+        signingScheme: signature.scheme,
         receiver: order.receiver,
       }),
       headers: { "Content-Type": "application/json" },

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,90 @@
+import { Order, OrderKind } from "@gnosis.pm/gp-v2-contracts";
+import { BigNumber } from "ethers";
+import fetch, { RequestInit } from "node-fetch";
+
+import { Signature } from "./utils";
+
+export class Api {
+  network: string;
+
+  constructor(network: string) {
+    this.network = network;
+  }
+
+  private async call<T>(route: string, init?: RequestInit): Promise<T> {
+    const url = `https://protocol-${this.network}.dev.gnosisdev.com/api/v1/${route}`;
+    const response = await fetch(url, init);
+    const body = await response.text();
+    if (!response.ok) {
+      throw `Calling "${url} ${JSON.stringify(init)} failed with ${
+        response.status
+      }: ${body}`;
+    }
+    return JSON.parse(body);
+  }
+
+  async getFee(
+    selToken: string,
+    buyToken: string,
+    amount: BigNumber,
+    kind: OrderKind
+  ): Promise<BigNumber> {
+    const response: GetFeeResponse = await this.call(
+      `fee?sellToken=${selToken}&buyToken=${buyToken}&amount=${amount}&kind=${kind}`
+    );
+    return BigNumber.from(response.amount);
+  }
+
+  async estimateTradeAmount(
+    selToken: string,
+    buyToken: string,
+    amount: BigNumber,
+    kind: OrderKind
+  ): Promise<BigNumber> {
+    const response: EstimateAmountResponse = await this.call(
+      `markets/${selToken}-${buyToken}/${kind}/${amount}`
+    );
+    return BigNumber.from(response.amount);
+  }
+
+  async placeOrder(order: Order, signature: Signature): Promise<string> {
+    return await this.call("orders", {
+      method: "post",
+      body: JSON.stringify({
+        sellToken: order.sellToken,
+        buyToken: order.buyToken,
+        sellAmount: order.sellAmount.toString(),
+        buyAmount: order.buyAmount.toString(),
+        validTo: order.validTo,
+        appData: order.appData,
+        feeAmount: order.feeAmount.toString(),
+        kind: order.kind,
+        partiallyFillable: order.partiallyFillable,
+        signature: signature.signature,
+        signingScheme: signature.signatureScheme,
+        receiver: order.receiver,
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  async getExecutedSellAmount(uid: string): Promise<BigNumber> {
+    const response: OrderDetailResponse = await this.call(`orders/${uid}`);
+    return BigNumber.from(response.executedSellAmount);
+  }
+}
+
+interface OrderDetailResponse {
+  // Other fields are omitted until needed
+  executedSellAmount: string;
+}
+
+interface GetFeeResponse {
+  amount: string;
+  expirationDate: Date;
+}
+
+interface EstimateAmountResponse {
+  amount: string;
+  token: string;
+}

--- a/src/ts/settlement.ts
+++ b/src/ts/settlement.ts
@@ -260,7 +260,7 @@ export function decodeTradeFlags(flags: number): TradeFlags {
   };
 }
 
-function encodeSignatureData(sig: Signature): string {
+export function encodeSignatureData(sig: Signature): string {
   switch (sig.scheme) {
     case SigningScheme.EIP712:
     case SigningScheme.ETHSIGN:


### PR DESCRIPTION
Adds wrapper functions around the services API.

The logic is mostly copied from the [GPv2 trading bot](https://github.com/gnosis/gp-v2-trading-bot) and is structured so that the trading bot can replace its code with this with minimal work (cc @fleupold, I can do this eventually). I documented each change I made in its own commit in this PR.

It would be good to add unit tests, but I don't know how I can mock http requests. Do you have suggestions?

### Test Plan

The logic is copied from the trading bot, which has been running for a while. 

I created the following small script to buy tokens on Rinkeby based on the new code,  
<details><summary>script.ts</summary>

```
import { BigNumber, utils } from "ethers";
import hre from "hardhat";

import { estimateTradeAmount, getFee, placeOrder } from "./src/services/api";
import { getDeployedContract } from "./src/tasks/ts/deployment";
import { domain, Order, OrderKind, SigningScheme, signOrder } from "./src/ts";

const sellToken = "0xc778417e063141139fce010982780140aa0cd5ab"; // weth

let tokens = "0x577D296678535e4903D59A4C929B718e1D575e0A 0xbF7A7169562078c96f0eC1A8aFD6aE50f12e5A99 0x6ED8111cA8779935d5e65A5dCB61872A386BE4A7 0xA6Cc591f2Fd8784DD789De34Ae7307d223Ca3dDc 0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02 0x01BE23585060835E02B77ef475b0Cc51aA1e0709 0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b 0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa 0xa7D1C04fAF998F9161fC9F800a99A809b84cfc9D 0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c 0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984 0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735".split(
  " ",
);
tokens = ["0xbadbadbadbadbadbadbadbadbadbadbadbadbadd", sellToken, ...tokens];

const kind = OrderKind.SELL;
const network = "rinkeby";
const chainId = 4;
if (hre.network.name !== network) {
  throw new Error("Bad network");
}

async function main() {
  for (const buyToken of tokens) {
    console.log(`Token ${buyToken}`);
    const maxRand = 2000;
    const random = Math.floor(Math.random() * maxRand);
    const soldWeth = BigNumber.from(maxRand + random).mul(
      BigNumber.from(10).pow(18 - 6),
    );
    console.log(`Dumping ${utils.formatEther(soldWeth)} WETH`);
    let fee;
    try {
      fee = await getFee({
        sellToken,
        buyToken,
        kind,
        amount: soldWeth,
        network,
      });
    } catch (e) {
      console.log("Error fee:", e.apiError);
      continue;
    }
    if (fee.gte(soldWeth)) {
      console.log("skipped");
      continue;
    }
    const receivedAmount = await estimateTradeAmount({
      sellToken,
      buyToken,
      amount: soldWeth.sub(fee),
      kind,
      network,
    });
    const now = Math.floor(Date.now() / 1000);
    const order: Order = {
      sellToken,
      buyToken,
      sellAmount: soldWeth.sub(fee),
      buyAmount: receivedAmount,
      feeAmount: fee,
      kind: OrderKind.SELL,
      appData: "0x",
      validTo: now + 5 * 60,
      partiallyFillable: false,
    };

    const settlement = await getDeployedContract("GPv2Settlement", hre);
    const signer = (await hre.ethers.getSigners())[0];
    const domainSeparator = domain(chainId, settlement.address);
    const signature = await signOrder(
      domainSeparator,
      order,
      signer,
      SigningScheme.ETHSIGN,
    );

    console.log(`Creating order...`);
    try {
      console.log(
        "New order API returns:",
        await placeOrder({
          order,
          signature,
          network,
        }),
      );
    } catch (e) {
      console.log("Error create:", e.apiError);
      continue;
    }
  }
}

main()
  .then(() => process.exit(0))
  .catch((error: any) => {
    console.error(error);
    process.exit(1);
  });

```
</details>

Result:
```
$ npx hardhat run ./script.ts --network rinkeby
Token 0xbadbadbadbadbadbadbadbadbadbadbadbadbadd
Dumping 0.003367 WETH
Error fee: { errorType: 'NotFound', description: 'Token was not found' }
Token 0xc778417e063141139fce010982780140aa0cd5ab
Dumping 0.002146 WETH
Creating order...
Error create: {
  errorType: 'SameBuyAndSellToken',
  description: 'Buy token is the same as the sell token.'
}
Token 0x577D296678535e4903D59A4C929B718e1D575e0A
Dumping 0.002728 WETH
Creating order...
New order API returns: 0xf9392bfc948e33ad21ff17c38b055067af3b2219bdbf3a07ae53e0a7c0e7374e59552a04d9f0c184cfce5f951fe36a01a2b4add960e82e1b
Token 0xbF7A7169562078c96f0eC1A8aFD6aE50f12e5A99
Dumping 0.003404 WETH
Creating order...
New order API returns: 0x7af7a3e8364b1221da42e2662c6a7ddcebaa2881d03932585eb6d40bf1a19bbe59552a04d9f0c184cfce5f951fe36a01a2b4add960e82e1b
Token 0x6ED8111cA8779935d5e65A5dCB61872A386BE4A7
Dumping 0.002823 WETH
Creating order...
New order API returns: 0xf7f906fa3824aadf06a054a0c7f6eccd3fdbf879d5fa86a178a10990381b630559552a04d9f0c184cfce5f951fe36a01a2b4add960e82e1c
Token 0xA6Cc591f2Fd8784DD789De34Ae7307d223Ca3dDc
Dumping 0.003114 WETH
Creating order...
New order API returns: 0x2f0d17a39e458efff022e574f0429b243a60efcf1c57d94d82970ab84b75cf7b59552a04d9f0c184cfce5f951fe36a01a2b4add960e82e1c
Token 0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02
Dumping 0.003758 WETH
Creating order...
New order API returns: 0x861ce73b410f0cdc44439cd7d840340f7184162a2736301e32f6ed6bfd6ac57059552a04d9f0c184cfce5f951fe36a01a2b4add960e82e1d
Token 0x01BE23585060835E02B77ef475b0Cc51aA1e0709
Dumping 0.002428 WETH
Creating order...
New order API returns: 0x29a6283ab99e5094f58ad3e50dd0ab00a3991b4e38ee0172e4ed59e192558e5e59552a04d9f0c184cfce5f951fe36a01a2b4add960e82e1d
Token 0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b
Dumping 0.002959 WETH
Creating order...
New order API returns: 0x095416febbc9c065671e8d8cb748277df032af78b58bc8bee29ba94aa584bbca59552a04d9f0c184cfce5f951fe36a01a2b4add960e82e1e
Token 0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa
Dumping 0.002993 WETH
Creating order...
New order API returns: 0x35d1e60cd45645ca4c88ce475f0044e3fd6f703b146e79e57e18ee77345572d559552a04d9f0c184cfce5f951fe36a01a2b4add960e82e1f
Token 0xa7D1C04fAF998F9161fC9F800a99A809b84cfc9D
Dumping 0.002933 WETH
Creating order...
New order API returns: 0xb3e3c60af1f2788894ff12870f53bf56010ec313db08efb6b999873e71ea97ab59552a04d9f0c184cfce5f951fe36a01a2b4add960e82e1f
Token 0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c
Dumping 0.003943 WETH
Creating order...
New order API returns: 0x96c2c933d37bd8c17c92cd1031bda8b1d0dba2fd70dba91668d86a02764d827359552a04d9f0c184cfce5f951fe36a01a2b4add960e82e20
Token 0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85
Dumping 0.0036 WETH
Creating order...
New order API returns: 0xa02ca3ffcaa3373929b703fe0f3dadac39829ac23b04aea6a58e50c179a7edab59552a04d9f0c184cfce5f951fe36a01a2b4add960e82e20
Token 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984
Dumping 0.00281 WETH
Creating order...
New order API returns: 0x7670fa79e378d1a897fc4cb38e973c8647d7634fd1601f0c06b6f7a8e16c4cb559552a04d9f0c184cfce5f951fe36a01a2b4add960e82e21
Token 0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735
Dumping 0.003915 WETH
Creating order...
New order API returns: 0x7b02eae9afbf6ab0f9f32b14c7b89ca9f7cbd91b4e559f9aa5bf6def1ed5291059552a04d9f0c184cfce5f951fe36a01a2b4add960e82e21
```
