### PR TITLE
[v0.0.1] Set endpoint in api

### DIFF
--- a/src/tasks/withdraw/value.ts
+++ b/src/tasks/withdraw/value.ts
@@ -1,7 +1,7 @@
 import WethNetworks from "canonical-weth/networks.json";
 import { BigNumber, constants } from "ethers";
 
-import { ApiError, estimateTradeAmount } from "../../services/api";
+import { ApiError, Endpoint, estimateTradeAmount } from "../../services/api";
 import { OrderKind } from "../../ts";
 import { SupportedNetwork } from "../ts/deployment";
 import { TokenDetails } from "../ts/erc20";
@@ -69,6 +69,7 @@ export const usdValue = async function (
       amount,
       kind: OrderKind.SELL,
       network,
+      endpoint: Endpoint.Dev,
     });
   } catch (e) {
     const errorData: ApiError = e.apiError ?? {

--- a/src/tasks/withdraw/value.ts
+++ b/src/tasks/withdraw/value.ts
@@ -1,7 +1,7 @@
 import WethNetworks from "canonical-weth/networks.json";
 import { BigNumber, constants } from "ethers";
 
-import { ApiError, Endpoint, estimateTradeAmount } from "../../services/api";
+import { ApiError, Environment, estimateTradeAmount } from "../../services/api";
 import { OrderKind } from "../../ts";
 import { SupportedNetwork } from "../ts/deployment";
 import { TokenDetails } from "../ts/erc20";
@@ -69,7 +69,7 @@ export const usdValue = async function (
       amount,
       kind: OrderKind.SELL,
       network,
-      endpoint: Endpoint.Dev,
+      environment: Environment.Dev,
     });
   } catch (e) {
     const errorData: ApiError = e.apiError ?? {


### PR DESCRIPTION
Adds the option to specify the endpoint (prod or dev) in the API.

### Test Plan

Same test plan as in the PR introducing the API. Create a file:
<details><summary>./buyAll.ts</summary>

```
import { BigNumber, utils } from "ethers";
import hre from "hardhat";

import {
  Endpoint,
  estimateTradeAmount,
  getFee,
  placeOrder,
} from "./src/services/api";
import { getDeployedContract } from "./src/tasks/ts/deployment";
import { domain, Order, OrderKind, SigningScheme, signOrder } from "./src/ts";

const sellToken = "0xc778417e063141139fce010982780140aa0cd5ab"; // weth

let tokens = "0x577D296678535e4903D59A4C929B718e1D575e0A 0xbF7A7169562078c96f0eC1A8aFD6aE50f12e5A99 0x6ED8111cA8779935d5e65A5dCB61872A386BE4A7 0xA6Cc591f2Fd8784DD789De34Ae7307d223Ca3dDc 0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02 0x01BE23585060835E02B77ef475b0Cc51aA1e0709 0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b 0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa 0xa7D1C04fAF998F9161fC9F800a99A809b84cfc9D 0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c 0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984 0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735".split(
  " ",
);
tokens = ["0xbadbadbadbadbadbadbadbadbadbadbadbadbadd", sellToken, ...tokens];

const kind = OrderKind.SELL;
const network = "rinkeby";
const chainId = 4;
if (hre.network.name !== network) {
  throw new Error("Bad network");
}

async function main() {
  const endpoint = Endpoint.Dev;
  console.log(`endpoint: ${endpoint}`);
  for (const buyToken of tokens) {
    console.log(`Token ${buyToken}`);
    const maxRand = 2000;
    const random = Math.floor(Math.random() * maxRand);
    const soldWeth = BigNumber.from(maxRand + random).mul(
      BigNumber.from(10).pow(18 - 6),
    );
    console.log(`Dumping ${utils.formatEther(soldWeth)} WETH`);
    let fee;
    try {
      fee = await getFee({
        sellToken,
        buyToken,
        kind,
        amount: soldWeth,
        network,
        endpoint,
      });
    } catch (e) {
      console.log("Error fee:", e.apiError);
      continue;
    }
    if (fee.gte(soldWeth)) {
      console.log("skipped");
      continue;
    }
    const receivedAmount = await estimateTradeAmount({
      sellToken,
      buyToken,
      amount: soldWeth.sub(fee),
      kind,
      network,
      endpoint,
    });
    const now = Math.floor(Date.now() / 1000);
    const order: Order = {
      sellToken,
      buyToken,
      sellAmount: soldWeth.sub(fee),
      buyAmount: receivedAmount,
      feeAmount: fee,
      kind: OrderKind.SELL,
      appData: "0x",
      validTo: now + 5 * 60,
      partiallyFillable: false,
    };

    const settlement = await getDeployedContract("GPv2Settlement", hre);
    const signer = (await hre.ethers.getSigners())[0];
    const domainSeparator = domain(chainId, settlement.address);
    const signature = await signOrder(
      domainSeparator,
      order,
      signer,
      SigningScheme.ETHSIGN,
    );

    console.log(`Creating order...`);
    try {
      console.log(
        "New order API returns:",
        await placeOrder({
          order,
          signature,
          network,
          endpoint,
        }),
      );
    } catch (e) {
      console.log("Error create:", e.apiError);
      continue;
    }
  }
}

main()
  .then(() => process.exit(0))
  .catch((error: any) => {
    console.error(error);
    process.exit(1);
  });
```
</details>

Try it with both:
```
  const endpoint = Endpoint.Prod;
```
```
  const endpoint = Endpoint.Dev;
```

Result:
<details><summary>output</summary>

```
$ npx hardhat run ./buyAll.ts --network rinkeby
endpoint: 1
Token 0xbadbadbadbadbadbadbadbadbadbadbadbadbadd
Dumping 0.002513 WETH
Error fee: { errorType: 'NotFound', description: 'Token was not found' }
Token 0xc778417e063141139fce010982780140aa0cd5ab
Dumping 0.002277 WETH
Creating order...
Error create: {
  errorType: 'SameBuyAndSellToken',
  description: 'Buy token is the same as the sell token.'
}
Token 0x577D296678535e4903D59A4C929B718e1D575e0A
Dumping 0.002827 WETH
Creating order...
New order API returns: 0x64dd21701b33d430541c9a231c6fc4bfa09e43ebc69acbbeb498e5427b393d6a59552a04d9f0c184cfce5f951fe36a01a2b4add960f81380
Token 0xbF7A7169562078c96f0eC1A8aFD6aE50f12e5A99
Dumping 0.003159 WETH
Creating order...
New order API returns: 0x676acd00c976ad854350102c55ae67bbea5a8137c1dc18e1485c8776213d5b9a59552a04d9f0c184cfce5f951fe36a01a2b4add960f81381
Token 0x6ED8111cA8779935d5e65A5dCB61872A386BE4A7
Dumping 0.002605 WETH
Creating order...
New order API returns: 0xbe8d64f4fab73fc6c70fef5fce114708dd9a47b4d51d70eb67624fedd4f8cdf559552a04d9f0c184cfce5f951fe36a01a2b4add960f81381
Token 0xA6Cc591f2Fd8784DD789De34Ae7307d223Ca3dDc
Dumping 0.003013 WETH
Creating order...
New order API returns: 0xb11271a149b2c922be04b98627d69065b34bc0284905a7305b3a11fdfb06684759552a04d9f0c184cfce5f951fe36a01a2b4add960f81382
Token 0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02
Dumping 0.002283 WETH
Creating order...
New order API returns: 0x0a8517dbdc92e1fa2115a5761cafc28087d33dc4357315cb0dc27b997aec2da759552a04d9f0c184cfce5f951fe36a01a2b4add960f81382
Token 0x01BE23585060835E02B77ef475b0Cc51aA1e0709
Dumping 0.00368 WETH
Creating order...
New order API returns: 0x33819c5c68a95ffbcfd4da06ca43ac914d73f84662f5e5c24e34956bc4fc4aa859552a04d9f0c184cfce5f951fe36a01a2b4add960f81383
Token 0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b
Dumping 0.00385 WETH
Creating order...
New order API returns: 0xcfbe9b33e53baca8a7e027023c1b3505cda9740e37c7a4c069fe4dc33af37c5a59552a04d9f0c184cfce5f951fe36a01a2b4add960f81383
Token 0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa
Dumping 0.002029 WETH
Creating order...
New order API returns: 0xbdf2b017a48719ee1b543ef432a8e5cd4c2229cc5fd7314023a8a68d4f65b09859552a04d9f0c184cfce5f951fe36a01a2b4add960f81384
Token 0xa7D1C04fAF998F9161fC9F800a99A809b84cfc9D
Dumping 0.003972 WETH
Creating order...
New order API returns: 0x42539f7d54d8d0400a7e5ade9c47b87f4e9ad6ce6dcca022c86219709ede08ae59552a04d9f0c184cfce5f951fe36a01a2b4add960f81385
Token 0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c
Dumping 0.002749 WETH
Creating order...
New order API returns: 0xbbb40548c50faee60fd0baf2b4a75aea8b882cf87a9ff91da7ae06d0ecdf43d959552a04d9f0c184cfce5f951fe36a01a2b4add960f81385
Token 0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85
Dumping 0.0035 WETH
Creating order...
New order API returns: 0xe624175ac66342b839a7d63c7c7f180a4eb700678a857318f607716c8b0dc1a159552a04d9f0c184cfce5f951fe36a01a2b4add960f81386
Token 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984
Dumping 0.002985 WETH
Creating order...
New order API returns: 0x6980e94db691bf826bdef13995073500055411f9c1d559e2a96a6c255595b6a759552a04d9f0c184cfce5f951fe36a01a2b4add960f81387
Token 0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735
Dumping 0.002009 WETH
Creating order...
New order API returns: 0x7f8acc88645e963eb42cce9536def5be83d0a0418ed1097a9b2253304cd8f13159552a04d9f0c184cfce5f951fe36a01a2b4add960f81387
$ npx hardhat run ./buyAll.ts --network rinkeby
endpoint: 0
Token 0xbadbadbadbadbadbadbadbadbadbadbadbadbadd
Dumping 0.002129 WETH
Error fee: { errorType: 'NotFound', description: 'Token was not found' }
Token 0xc778417e063141139fce010982780140aa0cd5ab
Dumping 0.003127 WETH
Creating order...
Error create: {
  errorType: 'SameBuyAndSellToken',
  description: 'Buy token is the same as the sell token.'
}
Token 0x577D296678535e4903D59A4C929B718e1D575e0A
Dumping 0.00273 WETH
Creating order...
New order API returns: 0x2794c2dbc6e9a08fd043aacdc1fcfb09386e68214d3fc75047767bae9a03568859552a04d9f0c184cfce5f951fe36a01a2b4add960f81398
Token 0xbF7A7169562078c96f0eC1A8aFD6aE50f12e5A99
Dumping 0.003437 WETH
Creating order...
New order API returns: 0xbe93c094128e7ba2f8bb25127e7fefd9365eafc1e6846c4c3b35cbae19c0671059552a04d9f0c184cfce5f951fe36a01a2b4add960f81398
Token 0x6ED8111cA8779935d5e65A5dCB61872A386BE4A7
Dumping 0.002245 WETH
Creating order...
New order API returns: 0xaadf69b8b11297e1c90b65a326bdeb3a987081827233142fe748f9fc3ea54f8759552a04d9f0c184cfce5f951fe36a01a2b4add960f81399
Token 0xA6Cc591f2Fd8784DD789De34Ae7307d223Ca3dDc
Dumping 0.002714 WETH
Creating order...
New order API returns: 0xaa6d5b1d7d21db730611352902a9e69b937e28627ae54f7f1d9d3bfe3b1f037359552a04d9f0c184cfce5f951fe36a01a2b4add960f8139a
Token 0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02
Dumping 0.002795 WETH
Creating order...
New order API returns: 0x98bd0c60676c3aaa087a52d7ce9a9d7820fc2bec7225bf6c5ea118fe3dc2c0db59552a04d9f0c184cfce5f951fe36a01a2b4add960f8139a
Token 0x01BE23585060835E02B77ef475b0Cc51aA1e0709
Dumping 0.002305 WETH
Creating order...
New order API returns: 0xdf05070907e0f582fb085f239aa94308c0571fc4328613d02dc7227d1617e6b759552a04d9f0c184cfce5f951fe36a01a2b4add960f8139b
Token 0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b
Dumping 0.002456 WETH
Creating order...
New order API returns: 0x8cbd219cc9915f0bbc63853dccfa9f8d6358f42da9a6db997d1f0fac852938a059552a04d9f0c184cfce5f951fe36a01a2b4add960f8139b
Token 0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa
Dumping 0.002931 WETH
Creating order...
New order API returns: 0xaf7ef3abce28b3bdc9298bf3d307ddc69d087f2edc95e342d707e568f78c0cca59552a04d9f0c184cfce5f951fe36a01a2b4add960f8139c
Token 0xa7D1C04fAF998F9161fC9F800a99A809b84cfc9D
Dumping 0.00398 WETH
Creating order...
New order API returns: 0xa0d800d629af24771cfbb6ef5be22f9ff47c9429dc769fc0604975c993bd3d9a59552a04d9f0c184cfce5f951fe36a01a2b4add960f8139d
Token 0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c
Dumping 0.002693 WETH
Creating order...
New order API returns: 0x89d07da6956a85b4d4b0e7ca2cf8123ed4e3a52c612e134e6498f7e06820a3e859552a04d9f0c184cfce5f951fe36a01a2b4add960f8139d
Token 0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85
Dumping 0.002859 WETH
Creating order...
New order API returns: 0x6f86052e5c8e2aa9db8f5451d2e703b721812e8f153e9041c2d83bdfd599569f59552a04d9f0c184cfce5f951fe36a01a2b4add960f8139e
Token 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984
Dumping 0.002636 WETH
Creating order...
New order API returns: 0x4b01bce5e24edc5605cb41f650cb42b299a5562b2203bcd6cbbc4a0d19c47ef759552a04d9f0c184cfce5f951fe36a01a2b4add960f8139f
Token 0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735
Dumping 0.002468 WETH
Creating order...
New order API returns: 0xb7415a80f1a74c08b23305da7efe3d1e588f1165f22e34829d54f492a85e3e3659552a04d9f0c184cfce5f951fe36a01a2b4add960f8139f
```
</details>