### PR TITLE
[informational] Enable London for hardhat network

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -90,6 +90,8 @@ export default {
   },
   networks: {
     hardhat: {
+      hardfork: "london",
+      gasPrice: "auto",
       blockGasLimit: 12.5e6,
     },
     mainnet: {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -43,6 +43,7 @@ if (["rinkeby", "mainnet"].includes(argv.network) && INFURA_KEY === undefined) {
 }
 
 const mocha: MochaOptions = {};
+let initialBaseFeePerGas: number | undefined = undefined;
 switch (MOCHA_CONF) {
   case undefined:
     break;
@@ -53,6 +54,9 @@ switch (MOCHA_CONF) {
     // - coverage compiles without optimizer and, unlike Waffle, hardhat-deploy
     //   strictly enforces the contract size limits from EIP-170
     mocha.grep = /^(?!E2E|Task)/;
+    // Note: unit is Wei, not GWei. This is a workaround to make the coverage
+    // tool work with the London hardfork.
+    initialBaseFeePerGas = 1;
     break;
   case "ignored in coverage":
     mocha.grep = /^E2E|Task/;
@@ -92,6 +96,7 @@ export default {
     hardhat: {
       hardfork: "london",
       gasPrice: "auto",
+      initialBaseFeePerGas,
       blockGasLimit: 12.5e6,
     },
     mainnet: {

--- a/test/e2e/orderRefunds.test.ts
+++ b/test/e2e/orderRefunds.test.ts
@@ -1,7 +1,7 @@
 import ERC20 from "@openzeppelin/contracts/build/contracts/ERC20PresetMinterPauser.json";
 import { expect } from "chai";
 import Debug from "debug";
-import { Contract, Wallet } from "ethers";
+import { BigNumber, Contract, Wallet } from "ethers";
 import { ethers, waffle } from "hardhat";
 
 import {
@@ -167,6 +167,6 @@ describe("E2E: Expired Order Gas Refunds", () => {
       );
     debug(`Gas savings per refund: ${gasSavingsPerRefund}`);
 
-    expect(gasSavingsPerRefund.gt(4000)).to.be.true;
+    expect(gasSavingsPerRefund.lt(BigNumber.from(-5000))).to.be.true;
   });
 });


### PR DESCRIPTION
[Hardhat v2.5.0](https://github.com/nomiclabs/hardhat/releases/tag/hardhat-core-v2.5.0) comes with support for the London hardfork. It's not enabled by default until version v2.6.0.

Here I enabled the fork and run the tests again. No surprises, the only failing test is expected: gas refunds are not meaningful anymore and the test fails because we don't save gas by using refunds.

This PR is not expected to be merged, it's for information purposes only.

I also successfully ran the same tests for v0.0.1.