### PR TITLE
[v0.0.1] Use getFeeAndQuote in dump script

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -71,11 +71,11 @@ interface GetFeeAndQuoteBuyResponse {
   sellAmountBeforeFee: BigNumberish;
 }
 
-interface GetFeeAndQuoteSellOutput {
+export interface GetFeeAndQuoteSellOutput {
   feeAmount: BigNumber;
   buyAmountAfterFee: BigNumber;
 }
-interface GetFeeAndQuoteBuyOutput {
+export interface GetFeeAndQuoteBuyOutput {
   feeAmount: BigNumber;
   sellAmountBeforeFee: BigNumber;
 }
@@ -86,6 +86,11 @@ export interface ApiError {
 }
 export interface CallError extends Error {
   apiError?: ApiError;
+}
+
+export enum GetFeeAndQuoteSellErrorType {
+  SellAmountDoesNotCoverFee = "SellAmountDoesNotCoverFee",
+  // other errors are added when necessary
 }
 
 function apiKind(kind: OrderKind): string {


### PR DESCRIPTION
Tackes [this comment](https://github.com/gnosis/gp-v2-contracts/pull/736#discussion_r675432851) from the PR introducing the dump script.

The number of API calls is reduced by using the `getFeeAndQuote` instead of separate fee and quote.

### Test Plan

Existing unit tests.

<details><summary>Test withdraw on Rinkeby</summary>

```
$ npx hardhat dump --network rinkeby --to-token 0xc778417e063141139fce010982780140aa0cd5ab --receiver 0xcB1FF0c484a2267E39e19a82A8c313E633C106C6 0x577D296678535e4903D59A4C929B718e1D575e0A 0xbF7A7169562078c96f0eC1A8aFD6aE50f12e5A99 0x6ED8111cA8779935d5e65A5dCB61872A386BE4A7 0xA6Cc591f2Fd8784DD789De34Ae7307d223Ca3dDc 0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02 0x01BE23585060835E02B77ef475b0Cc51aA1e0709 0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b 0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa 0xa7D1C04fAF998F9161fC9F800a99A809b84cfc9D 0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c 0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984 0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735 0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735  --max-fee-percent 17
Using account 0x59552a04D9f0c184CFce5f951fe36a01A2b4aDD9
Dump request skipped for token WBTC (0x577D296678535e4903D59A4C929B718e1D575e0A). No balance for that token is available.
Dump request skipped for token MTC (0x6ED8111cA8779935d5e65A5dCB61872A386BE4A7). No balance for that token is available.
Dump request skipped for token TUSDC (0xA6Cc591f2Fd8784DD789De34Ae7307d223Ca3dDc). The trading fee is larger than the dumped amount.
Dump request skipped for token BAT (0xbF7A7169562078c96f0eC1A8aFD6aE50f12e5A99). The trading fee is too large compared to the balance (32.84%).
Dump request skipped for token UNI (0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984). No balance for that token is available.
List of dumped tokens:
 token address                              | symbol | received amount (WETH) | dumped amount                  | fee % 
--------------------------------------------+--------+------------------------+--------------------------------+-------
 0xa7D1C04fAF998F9161fC9F800a99A809b84cfc9D | OWL    |   0.020598605028802742 |          55.536703711069335119 | 0.96  
 0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85 | MKR    |   0.025306853022187175 |           0.000028969107862954 | 0.78  
 0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c | GNO    |   0.027616990150419688 |          69.526173884147052235 | 0.71  
 0x01BE23585060835E02B77ef475b0Cc51aA1e0709 | LINK   |   0.032729721342693072 |         307.340432908677168236 | 0.58  
 0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa | DAI    |   0.039851120748450031 |     1414915.937553450561197964 | 0.34  
 0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735 | DAI    |   0.049400094641357967 | 633964963832.77354043771740... | 0.4   
 0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b | USDC   |   0.059068902467995566 |      110040.224568000000000000 | 0.31  
 0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02 | USDT   |   0.095907910220264470 |        8050.903171005847013879 | 0.2   

The receiver address 0xcB1FF0c484a2267E39e19a82A8c313E633C106C6 will receive at least 0.350480197622170711 WETH from selling the tokens listed above.
Submit? (y/N) y
Creating order selling OWL...
Creating order selling MKR...
Creating order selling GNO...
Creating order selling LINK...
Creating order selling DAI...
Creating order selling DAI...
Creating order selling USDC...
Creating order selling USDT...
Done! The orders will expire in the next 20 minutes.
```
</details>
