### PR TITLE
[v0.0.1] Isolate task functions

### DIFF
--- a/src/tasks/dump.ts
+++ b/src/tasks/dump.ts
@@ -1,9 +1,11 @@
 import readline from "readline";
 
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import chalk from "chalk";
 import {
   BigNumber,
   constants,
+  Contract,
   ContractTransaction,
   Signer,
   utils,
@@ -28,6 +30,7 @@ import {
   SupportedNetwork,
 } from "./ts/deployment";
 import { promiseAllWithRateLimit } from "./ts/rate_limits";
+import { sleep } from "./ts/sleep";
 import { Align, displayTable } from "./ts/table";
 import {
   isNativeToken,
@@ -43,7 +46,7 @@ import {
 import { formatTokenValue } from "./ts/value";
 
 const MAX_LATEST_BLOCK_DELAY_SECONDS = 2 * 60;
-const MAX_ORDER_VALIDITY_SECONDS = 24 * 3600;
+export const MAX_ORDER_VALIDITY_SECONDS = 24 * 3600;
 
 const keccak = utils.id;
 const APP_DATA = keccak("GPv2 dump script");
@@ -325,10 +328,6 @@ async function prompt(message: string) {
   return "y" === response.toLowerCase();
 }
 
-async function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 async function createAllowances(
   allowances: Erc20Token[],
   signer: Signer,
@@ -416,6 +415,143 @@ async function transferSameTokenToReceiver(
   }
 }
 
+interface DumpInput {
+  validity: number;
+  maxFeePercent: number;
+  dumpedTokens: string[];
+  toToken: string;
+  settlement: Contract;
+  signer: SignerWithAddress;
+  receiver: string | undefined;
+  network: SupportedNetwork;
+  hre: HardhatRuntimeEnvironment;
+  api: Api;
+  dryRun: boolean;
+  doNotPrompt?: boolean | undefined;
+}
+export async function dump({
+  validity,
+  maxFeePercent,
+  dumpedTokens,
+  toToken: toTokenAddress,
+  settlement,
+  signer,
+  receiver: inputReceiver,
+  network,
+  hre,
+  api,
+  dryRun,
+  doNotPrompt,
+}: DumpInput): Promise<void> {
+  const { ethers } = hre;
+  if (validity > MAX_ORDER_VALIDITY_SECONDS) {
+    throw new Error("Order validity too large");
+  }
+  const [chainId, allowanceManager] = await Promise.all([
+    ethers.provider.getNetwork().then((n) => n.chainId),
+    (await settlement.allowanceManager()) as string,
+  ]);
+  const domainSeparator = domain(chainId, settlement.address);
+  const receiver: string = inputReceiver ?? signer.address;
+  const hasCustomReceiver = receiver !== signer.address;
+
+  // todo: when sending ETH to a contract will be supported by the
+  // services, remove this check.
+  if (
+    (toTokenAddress === undefined || toTokenAddress === BUY_ETH_ADDRESS) &&
+    hasCustomReceiver
+  ) {
+    throw new Error("Receiver is not supported when buying ETH");
+  }
+
+  const {
+    instructions,
+    toToken,
+    transferToReceiver,
+  } = await getDumpInstructions({
+    dumpedTokens,
+    toTokenAddress,
+    user: signer.address,
+    allowanceManager,
+    maxFeePercent,
+    hasCustomReceiver,
+    hre,
+    network,
+    api,
+  });
+  if (instructions.length === 0) {
+    console.log("No token can be sold");
+    return;
+  }
+
+  displayOperations(instructions, toToken);
+
+  let sumReceived = instructions.reduce(
+    (sum, inst) => sum.add(inst.receivedAmount),
+    constants.Zero,
+  );
+  const needAllowances = instructions
+    .filter(({ needsAllowance }) => needsAllowance)
+    .map(({ token }) => token);
+  if (needAllowances.length !== 0) {
+    console.log(
+      `Before creating the orders, a total of ${needAllowances.length} allowances will be granted to the allowance manager.`,
+    );
+  }
+  const toTokenName = isNativeToken(toToken)
+    ? toToken.symbol
+    : toToken.symbol ?? `units of token ${toToken.address}`;
+  if (transferToReceiver !== undefined) {
+    console.log(
+      `Moreover, ${utils.formatUnits(
+        transferToReceiver.amount,
+        transferToReceiver.token.decimals ?? 0,
+      )} ${toTokenName} will be transfered to the receiver address ${receiver}.`,
+    );
+    sumReceived = sumReceived.add(transferToReceiver.amount);
+  }
+  console.log(
+    `${
+      hasCustomReceiver
+        ? `The receiver address ${receiver}`
+        : `Your address (${signer.address})`
+    } will receive at least ${utils.formatUnits(
+      sumReceived,
+      toToken.decimals ?? 0,
+    )} ${toTokenName} from selling the tokens listed above.`,
+  );
+  if (!dryRun && (doNotPrompt || (await prompt("Submit?")))) {
+    await createAllowances(needAllowances, signer, allowanceManager);
+
+    // If the services don't register the allowance before the order,
+    // then creating a new order with the API returns an error.
+    // Moreover, there is no distinction in the error between a missing
+    // allowance and a failed order creation, which could occur for
+    // valid reasons.
+    await sleep(5000);
+
+    await createOrders(
+      instructions,
+      toToken,
+      signer,
+      receiver,
+      hasCustomReceiver,
+      domainSeparator,
+      validity,
+      ethers,
+      api,
+    );
+
+    if (transferToReceiver !== undefined) {
+      await transferSameTokenToReceiver(transferToReceiver, signer, receiver);
+    }
+
+    console.log(
+      `Done! The orders will expire in the next ${validity / 60} minutes.`,
+    );
+  }
+}
+
 const setupDumpTask: () => void = () =>
   task("dump")
     .addOptionalParam(
@@ -453,150 +589,51 @@ const setupDumpTask: () => void = () =>
     .setAction(
       async (
         {
-          origin: inputOrigin,
-          toToken: toTokenAddress,
+          origin,
+          toToken,
           dumpedTokens,
           maxFeePercent,
           dryRun,
-          receiver: inputReceiver,
+          receiver,
           validity,
         },
         hre,
       ) => {
-        const { ethers } = hre;
         const network = hre.network.name;
         if (!isSupportedNetwork(network)) {
           throw new Error(`Unsupported network ${hre.network.name}`);
         }
-        if (validity > MAX_ORDER_VALIDITY_SECONDS) {
-          throw new Error("Order validity too large");
-        }
-
         const api = new Api(network, Environment.Prod);
-        const [signers, settlement, chainId] = await Promise.all([
-          ethers.getSigners(),
+        const [signers, settlement] = await Promise.all([
+          hre.ethers.getSigners(),
           getDeployedContract("GPv2Settlement", hre),
-          ethers.provider.getNetwork().then((n) => n.chainId),
         ]);
-        const allowanceManager: string = await settlement.allowanceManager();
-        const domainSeparator = domain(chainId, settlement.address);
         const signer =
-          inputOrigin === undefined
+          origin === undefined
             ? signers[0]
-            : signers.find((signer) => signer.address === inputOrigin);
+            : signers.find((signer) => signer.address === origin);
         if (signer === undefined) {
           throw new Error(
             `No signer found${
-              inputOrigin === undefined ? "" : ` for address ${inputOrigin}`
+              origin === undefined ? "" : ` for address ${origin}`
             }. Did you export a valid private key?`,
           );
         }
-        const receiver: string = inputReceiver ?? signer.address;
-        const hasCustomReceiver = receiver !== signer.address;
-
         console.log(`Using account ${signer.address}`);
-        // todo: when sending ETH to a contract will be supported by the
-        // services, remove this check.
-        if (
-          (toTokenAddress === undefined ||
-            toTokenAddress === BUY_ETH_ADDRESS) &&
-          hasCustomReceiver
-        ) {
-          throw new Error("Receiver is not supported when buying ETH");
-        }
 
-        const {
-          instructions,
-          toToken,
-          transferToReceiver,
-        } = await getDumpInstructions({
-          dumpedTokens,
-          toTokenAddress,
-          user: signer.address,
-          allowanceManager,
+        await dump({
+          validity,
           maxFeePercent,
-          hasCustomReceiver,
-          hre,
+          dumpedTokens,
+          toToken,
+          settlement,
+          signer,
+          receiver,
           network,
+          hre,
           api,
+          dryRun,
         });
-        if (instructions.length === 0) {
-          console.log("No token can be sold");
-          return;
-        }
-
-        displayOperations(instructions, toToken);
-
-        let sumReceived = instructions.reduce(
-          (sum, inst) => sum.add(inst.receivedAmount),
-          constants.Zero,
-        );
-        const needAllowances = instructions
-          .filter(({ needsAllowance }) => needsAllowance)
-          .map(({ token }) => token);
-        if (needAllowances.length !== 0) {
-          console.log(
-            `Before creating the orders, a total of ${needAllowances.length} allowances will be granted to the allowance manager.`,
-          );
-        }
-        const toTokenName = isNativeToken(toToken)
-          ? toToken.symbol
-          : toToken.symbol ?? `units of token ${toToken.address}`;
-        if (transferToReceiver !== undefined) {
-          console.log(
-            `Moreover, ${utils.formatUnits(
-              transferToReceiver.amount,
-              transferToReceiver.token.decimals ?? 0,
-            )} ${toTokenName} will be transfered to the receiver address ${receiver}.`,
-          );
-          sumReceived = sumReceived.add(transferToReceiver.amount);
-        }
-        console.log(
-          `${
-            hasCustomReceiver
-              ? `The receiver address ${receiver}`
-              : `Your address (${signer.address})`
-          } will receive at least ${utils.formatUnits(
-            sumReceived,
-            toToken.decimals ?? 0,
-          )} ${toTokenName} from selling the tokens listed above.`,
-        );
-        if (!dryRun && (await prompt("Submit?"))) {
-          await createAllowances(needAllowances, signer, allowanceManager);
-
-          // If the services don't register the allowance before the order,
-          // then creating a new order with the API returns an error.
-          // Moreover, there is no distinction in the error between a missing
-          // allowance and a failed order creation, which could occur for
-          // valid reasons.
-          await sleep(5000);
-
-          await createOrders(
-            instructions,
-            toToken,
-            signer,
-            receiver,
-            hasCustomReceiver,
-            domainSeparator,
-            validity,
-            ethers,
-            api,
-          );
-
-          if (transferToReceiver !== undefined) {
-            await transferSameTokenToReceiver(
-              transferToReceiver,
-              signer,
-              receiver,
-            );
-          }
-
-          console.log(
-            `Done! The orders will expire in the next ${
-              validity / 60
-            } minutes.`,
-          );
-        }
       },
     );
 

--- a/src/tasks/dump.ts
+++ b/src/tasks/dump.ts
@@ -30,7 +30,6 @@ import {
   SupportedNetwork,
 } from "./ts/deployment";
 import { promiseAllWithRateLimit } from "./ts/rate_limits";
-import { sleepMillis } from "./ts/sleep";
 import { Align, displayTable } from "./ts/table";
 import {
   isNativeToken,
@@ -328,21 +327,30 @@ async function prompt(message: string) {
   return "y" === response.toLowerCase();
 }
 
+interface CreateAllowancesOptions {
+  requiredConfirmations?: number | undefined;
+}
 async function createAllowances(
   allowances: Erc20Token[],
   signer: Signer,
   allowanceManager: string,
+  { requiredConfirmations }: CreateAllowancesOptions = {},
 ) {
-  if (allowances.length !== 0) {
-    for (const token of allowances) {
-      console.log(
-        `Approving allowance manager to trade token ${displayName(token)}...`,
-      );
-      const result: ContractTransaction = await token.contract
-        .connect(signer)
-        .approve(allowanceManager, constants.MaxUint256);
-      await result.wait();
-    }
+  let lastTransaction: ContractTransaction | undefined = undefined;
+  for (const token of allowances) {
+    console.log(
+      `Approving allowance manager to trade token ${displayName(token)}...`,
+    );
+    lastTransaction = (await token.contract
+      .connect(signer)
+      .approve(allowanceManager, constants.MaxUint256)) as ContractTransaction;
+    await lastTransaction.wait();
+  }
+  if (lastTransaction !== undefined) {
+    // note: the last approval is (excluded reorgs) the last that is included
+    // in a block, so awaiting it for confirmations means that also all others
+    // have at least this number of confirmations.
+    await lastTransaction.wait(requiredConfirmations);
   }
 }
 
@@ -521,14 +529,14 @@ export async function dump({
     )} ${toTokenName} from selling the tokens listed above.`,
   );
   if (!dryRun && (doNotPrompt || (await prompt("Submit?")))) {
-    await createAllowances(needAllowances, signer, allowanceManager);
-
-    // If the services don't register the allowance before the order,
-    // then creating a new order with the API returns an error.
-    // Moreover, there is no distinction in the error between a missing
-    // allowance and a failed order creation, which could occur for
-    // valid reasons.
-    await sleepMillis(5000);
+    await createAllowances(needAllowances, signer, allowanceManager, {
+      // If the services don't register the allowance before the order,
+      // then creating a new order with the API returns an error.
+      // Moreover, there is no distinction in the error between a missing
+      // allowance and a failed order creation, which could occur for
+      // valid reasons.
+      requiredConfirmations: 2,
+    });
 
     await createOrders(
       instructions,

--- a/src/tasks/dump.ts
+++ b/src/tasks/dump.ts
@@ -30,7 +30,7 @@ import {
   SupportedNetwork,
 } from "./ts/deployment";
 import { promiseAllWithRateLimit } from "./ts/rate_limits";
-import { sleep } from "./ts/sleep";
+import { sleepMillis } from "./ts/sleep";
 import { Align, displayTable } from "./ts/table";
 import {
   isNativeToken,
@@ -528,7 +528,7 @@ export async function dump({
     // Moreover, there is no distinction in the error between a missing
     // allowance and a failed order creation, which could occur for
     // valid reasons.
-    await sleep(5000);
+    await sleepMillis(5000);
 
     await createOrders(
       instructions,

--- a/src/tasks/ts/sleep.ts
+++ b/src/tasks/ts/sleep.ts
@@ -1,0 +1,3 @@
+export async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/tasks/ts/sleep.ts
+++ b/src/tasks/ts/sleep.ts
@@ -1,3 +1,0 @@
-export async function sleepMillis(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}

--- a/src/tasks/ts/sleep.ts
+++ b/src/tasks/ts/sleep.ts
@@ -1,3 +1,3 @@
-export async function sleep(ms: number): Promise<void> {
+export async function sleepMillis(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/tasks/withdraw/traded_tokens.ts
+++ b/src/tasks/withdraw/traded_tokens.ts
@@ -1,0 +1,62 @@
+import { Contract } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+import { BUY_ETH_ADDRESS } from "../../ts";
+
+function isErrorTooManyEvents(error: Error): boolean {
+  return /query returned more than \d* results/.test(error.message);
+}
+
+/// Lists all tokens that were traded by the settlement contract in the range
+/// specified by the two input blocks. Range bounds are both inclusive.
+export async function getAllTradedTokens(
+  settlement: Contract,
+  fromBlock: number,
+  toBlock: number,
+  hre: HardhatRuntimeEnvironment,
+): Promise<string[]> {
+  let trades = null;
+  try {
+    trades = await hre.ethers.provider.getLogs({
+      topics: [settlement.interface.getEventTopic("Trade")],
+      address: settlement.address,
+      fromBlock,
+      toBlock,
+    });
+  } catch (error) {
+    if (!isErrorTooManyEvents(error)) {
+      throw error;
+    }
+  }
+
+  let tokens;
+  if (trades === null) {
+    if (fromBlock === toBlock) {
+      throw new Error("Too many events in the same block");
+    }
+    const mid = Math.floor((toBlock + fromBlock) / 2);
+    tokens = (
+      await Promise.all([
+        getAllTradedTokens(settlement, fromBlock, mid, hre),
+        getAllTradedTokens(settlement, mid + 1, toBlock, hre), // note: mid+1 is not larger than toBlock thanks to flooring
+      ])
+    ).flat();
+  } else {
+    tokens = trades
+      .map((trade) => {
+        const decodedTrade = settlement.interface.decodeEventLog(
+          "Trade",
+          trade.data,
+          trade.topics,
+        );
+        return [decodedTrade.sellToken, decodedTrade.buyToken];
+      })
+      .flat();
+  }
+
+  tokens = new Set(tokens);
+  tokens.delete(BUY_ETH_ADDRESS);
+  return Array.from(tokens).sort((lhs, rhs) =>
+    lhs.toLowerCase() < rhs.toLowerCase() ? -1 : lhs === rhs ? 0 : 1,
+  );
+}


### PR DESCRIPTION
Isolates the withdraw and dump scripts to their own function, as well as some reusable components.

The separation has two purposes:
1. easier testing of each component
2. easier to reuse in the combined withdraw+dump script

The code is mostly unchanged except for what is needed to separate the functions.
Since it was a very small change, I also introduced the flag `doNotPrompt`: if set to `true`, executes without asking the user for confirmation. Currently unused, however it will be needed for the withdraw service.


### Test Plan

Manual test of the two scripts.
<details><summary>withdraw</summary>

```
$ npx hardhat withdraw --network rinkeby --receiver 0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf --min-value 10000 --leftover 500 Using account 0x00D374731083492b38A66ef5a1157cD378d020fc
Recovering list of traded tokens...
Ignored 5.163587 units of TUSDC (0xA6Cc591f2Fd8784DD789De34Ae7307d223Ca3dDc) with value 9384.39 USD
Ignored 0.214992379233100659 units of MTC (0x6ED8111cA8779935d5e65A5dCB61872A386BE4A7) with value 5366.20 USD
Ignored 200.888388738342340752 units of TUSD (0x0000000000085d4780B73119b644AE5ecd22b376) with value 588.11 USD
Ignored 4.335121309672900026 units of LINK (0x01BE23585060835E02B77ef475b0Cc51aA1e0709) with value 1669.28 USD
Ignored 67.753530850843037265 units of USDT (0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02) with value 5.31 USD
Ignored 0.000008571496231121 units of REP (0x6e894660985207feb7cf89Faf048998c71E8EE89) with value 0.00 USD
Ignored 561.217587 units of USDC (0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b) with value 438.46 USD
Ignored 2.811062 units of cDAI (0x6D7F0754FFeb405d23C51CE938289d4835bE3b14) with value 0.00 USD
Ignored 0.00000392 units of cBAT (0xEBf1A11532b93a529b5bC942B4bAA98647913002) with value 0.00 USD
Ignored 0.000347449890582275 units of ZRX (0xddea378A6dDC8AfeC82C36E9b0078826bf9e68B6) with value 307.09 USD
Ignored 0.005746405988050388 units of SCM (0xe4b9895E638f54C3beE2a3A78d6A297Cc03e0353) with value 3550.27 USD
Amounts to withdraw:
 address                                    | balance (usd) | balance                        | withdrawn amount               | symbol 
--------------------------------------------+---------------+--------------------------------+--------------------------------+--------
 0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85 |      42754.50 |           0.001213132597247560 |           0.001198945406193659 | MKR    
 0xbF7A7169562078c96f0eC1A8aFD6aE50f12e5A99 |      48249.11 |          42.013668545107774439 |          41.578285714752051518 | BAT    
 0xa7D1C04fAF998F9161fC9F800a99A809b84cfc9D |      83978.89 |          38.512148432293939421 |          38.282851837107672058 | OWL    
 0xBD6A9921504fae42EaD2024F43305A8ED3890F6f |      84380.20 |           0.501472124184972503 |           0.498500620930016963 | PAX    
 0x577D296678535e4903D59A4C929B718e1D575e0A |      89329.52 |           0.474687190000000000 |           0.472030240000000000 | WBTC   
 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984 |     140596.79 |           0.015780422765536926 |           0.015724303338200879 | UNI    
 0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa |     287552.97 |      287552.975459880815142583 |      287052.975459880815142583 | DAI    
 0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c |     776923.19 |         273.427400004339913844 |         273.251431901975063405 | GNO    
 0xc778417E063141139Fce010982780140Aa0cD5Ab |    5826572.89 |           1.163019198892340911 |           1.162919395867517183 | WETH   
 0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735 |   19110765.35 | 1321085133988.7416493323461... | 1321050570089.5652095379377... | DAI    

The transaction will cost approximately 0.000213287001706296 ETH and will withdraw the balance of 10 tokens for an estimated total value of 26486103.45 USD. All withdrawn funds will be sent to 0x3328f5f2cEcAF00a2443082B657CedEAf70bfAEf.
Submit? (y/N)
```
</details>

<details><summary>dump</summary>

```
$ npx hardhat dump --network rinkeby --to-token 0xc778417e063141139fce010982780140aa0cd5ab --receiver 0xcB1FF0c484a2267E39e19a82A8c313E633C106C6 0x577D296678535e4903D59A4C929B718e1D575e0A 0xbF7A7169562078c96f0eC1A8aFD6aE50f12e5A99 0x6ED8111cA8779935d5e65A5dCB61872A386BE4A7 0xA6Cc591f2Fd8784DD789De34Ae7307d223Ca3dDc 0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02 0x01BE23585060835E02B77ef475b0Cc51aA1e0709 0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b 0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa 0xa7D1C04fAF998F9161fC9F800a99A809b84cfc9D 0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c 0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984 0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735 0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735  --max-fee-percent 20 Using account 0x627306090abaB3A6e1400e9345bC60c78a8BEf57
Dump request skipped for token WBTC (0x577D296678535e4903D59A4C929B718e1D575e0A). No balance for that token is available.
Dump request skipped for token BAT (0xbF7A7169562078c96f0eC1A8aFD6aE50f12e5A99). No balance for that token is available.
Dump request skipped for token MTC (0x6ED8111cA8779935d5e65A5dCB61872A386BE4A7). No balance for that token is available.
Dump request skipped for token TUSDC (0xA6Cc591f2Fd8784DD789De34Ae7307d223Ca3dDc). No balance for that token is available.
Dump request skipped for token USDT (0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02). No balance for that token is available.
Dump request skipped for token USDC (0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b). The trading fee is larger than the dumped amount.
Dump request skipped for token OWL (0xa7D1C04fAF998F9161fC9F800a99A809b84cfc9D). The trading fee is too large compared to the balance (30.34%).
Dump request skipped for token DAI (0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa). The trading fee is larger than the dumped amount.
Dump request skipped for token MKR (0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85). No balance for that token is available.
Dump request skipped for token UNI (0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984). No balance for that token is available.
Dump request skipped for token DAI (0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735). The trading fee is larger than the dumped amount.
List of dumped tokens:
 token address                              | symbol | needs allowance? | received amount (WETH) | dumped amount          | fee % 
--------------------------------------------+--------+------------------+------------------------+------------------------+-------
 0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c | GNO    | yes              |   0.002098838130900941 |   5.000000000000000000 | 13.94 
 0x01BE23585060835E02B77ef475b0Cc51aA1e0709 | LINK   | yes              |   0.012680147355236495 | 200.703740896883991048 | 2.56  

Before creating the orders, a total of 2 allowances will be granted to the allowance manager.
The receiver address 0xcB1FF0c484a2267E39e19a82A8c313E633C106C6 will receive at least 0.014778985486137436 WETH from selling the tokens listed above.
Submit? (y/N) n
```
</details>