### PR TITLE
Added `IntChainIdTypedDataV4Signer` forcing chainId as a number (Forward-port #692)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prepack": "yarn build"
   },
   "peerDependencies": {
-    "ethers": "~5.0.18"
+    "ethers": "~5.4.0"
   },
   "devDependencies": {
     "@0x/contract-artifacts-v2": "npm:@0x/contract-artifacts@^2.2.2",

--- a/src/ts/signers.ts
+++ b/src/ts/signers.ts
@@ -130,3 +130,128 @@ export class TypedDataV3Signer implements TypedDataSigner {
 
   // --- end boilerplate proxy methods ---
 }
+
+/**
+ * Wrapper around a TypedDataSigner Signer object that implements `_signTypedData` using
+ * `eth_signTypedData_v4` as usual.
+ * The difference here is that the domain `chainId` is transformed to a `number`.
+ * That's done to circumvent a bug introduced in the latest Metamask version (9.6.0)
+ * that no longer accepts a string for domain `chainId`.
+ * See for more details https://github.com/MetaMask/metamask-extension/issues/11308.
+ *
+ * Takes a Signer instance on creation.
+ * All other Signer methods are proxied to initial instance.
+ */
+export class IntChainIdTypedDataV4Signer implements TypedDataSigner {
+  signer: Signer;
+  provider: JsonRpcProvider;
+  _isSigner = true;
+
+  constructor(signer: Signer) {
+    this.signer = signer;
+
+    if (!signer.provider) {
+      throw new Error("Signer does not have a provider set");
+    }
+    if (!isJsonRpcProvider(signer.provider)) {
+      throw new Error("Provider must be of type JsonRpcProvider");
+    }
+
+    this.provider = signer.provider;
+  }
+
+  async _signTypedData(
+    domain: TypedDataDomain,
+    types: TypedDataTypes,
+    data: Record<string, unknown>,
+  ): Promise<string> {
+    const populated = await _TypedDataEncoder.resolveNames(
+      domain,
+      types,
+      data,
+      (name: string) => {
+        return this.provider.resolveName(name);
+      },
+    );
+
+    const payload = _TypedDataEncoder.getPayload(
+      populated.domain,
+      types,
+      populated.value,
+    );
+    // Making `chainId` an int since Latest Metamask version (9.6.0) breaks otherwise
+    payload.domain.chainId = parseInt(payload.domain.chainId, 10);
+    const msg = JSON.stringify(payload);
+
+    const address = await this.getAddress();
+
+    // Actual signing
+    return (await this.provider.send("eth_signTypedData_v4", [
+      address.toLowerCase(),
+      msg,
+    ])) as string;
+  }
+
+  // --- start boilerplate proxy methods ---
+
+  getAddress(): Promise<string> {
+    return this.signer.getAddress();
+  }
+  signMessage(message: string | ethers.utils.Bytes): Promise<string> {
+    return this.signer.signMessage(message);
+  }
+  signTransaction(
+    transaction: ethers.utils.Deferrable<ethers.providers.TransactionRequest>,
+  ): Promise<string> {
+    return this.signer.signTransaction(transaction);
+  }
+  connect(provider: ethers.providers.Provider): ethers.Signer {
+    return this.signer.connect(provider);
+  }
+  getBalance(blockTag?: ethers.providers.BlockTag): Promise<ethers.BigNumber> {
+    return this.signer.getBalance(blockTag);
+  }
+  getTransactionCount(blockTag?: ethers.providers.BlockTag): Promise<number> {
+    return this.signer.getTransactionCount(blockTag);
+  }
+  estimateGas(
+    transaction: ethers.utils.Deferrable<ethers.providers.TransactionRequest>,
+  ): Promise<ethers.BigNumber> {
+    return this.signer.estimateGas(transaction);
+  }
+  call(
+    transaction: ethers.utils.Deferrable<ethers.providers.TransactionRequest>,
+    blockTag?: ethers.providers.BlockTag,
+  ): Promise<string> {
+    return this.signer.call(transaction, blockTag);
+  }
+  sendTransaction(
+    transaction: ethers.utils.Deferrable<ethers.providers.TransactionRequest>,
+  ): Promise<ethers.providers.TransactionResponse> {
+    return this.signer.sendTransaction(transaction);
+  }
+  getChainId(): Promise<number> {
+    return this.signer.getChainId();
+  }
+  getGasPrice(): Promise<ethers.BigNumber> {
+    return this.signer.getGasPrice();
+  }
+  resolveName(name: string): Promise<string> {
+    return this.signer.resolveName(name);
+  }
+  checkTransaction(
+    transaction: ethers.utils.Deferrable<ethers.providers.TransactionRequest>,
+  ): ethers.utils.Deferrable<ethers.providers.TransactionRequest> {
+    return this.signer.checkTransaction(transaction);
+  }
+  populateTransaction(
+    transaction: ethers.utils.Deferrable<ethers.providers.TransactionRequest>,
+  ): Promise<ethers.providers.TransactionRequest> {
+    return this.signer.populateTransaction(transaction);
+  }
+  _checkProvider(operation?: string): void {
+    return this.signer._checkProvider(operation);
+  }
+
+  // --- end boilerplate proxy methods ---
+}

--- a/src/ts/signers.ts
+++ b/src/ts/signers.ts
@@ -236,6 +236,9 @@ export class IntChainIdTypedDataV4Signer implements TypedDataSigner {
   getGasPrice(): Promise<ethers.BigNumber> {
     return this.signer.getGasPrice();
   }
+  getFeeData(): Promise<ethers.providers.FeeData> {
+    return this.signer.getFeeData();
+  }
   resolveName(name: string): Promise<string> {
     return this.signer.resolveName(name);
   }


### PR DESCRIPTION
This PR is a forward-port of #692 and was created by cherry-picking the merge commit:
```
$ git log -1 --pretty=oneline 23e324ffa90124090e6aed27c2547fb4977d5f4f
23e324ffa90124090e6aed27c2547fb4977d5f4f Added `IntChainIdTypedDataV4Signer` forcing chainId as a number (#692)
$ git cherry-pick 23e324ffa90124090e6aed27c2547fb4977d5f4f
Auto-merging src/ts/signers.ts
[forwardport-692 46e26d8] Added `IntChainIdTypedDataV4Signer` forcing chainId as a number (#692)
 Author: Leandro Boscariol <alfetopito@users.noreply.github.com>
 Date: Tue Jun 15 10:47:22 2021 -0700
 1 file changed, 125 insertions(+)
```

Some additional manual fixes were also required. Specifically:
```diff
diff --git a/package.json b/package.json
index 2d5598f..688da49 100644
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prepack": "yarn build"
   },
   "peerDependencies": {
-    "ethers": "~5.0.18"
+    "ethers": "~5.4.0"
   },
   "devDependencies": {
     "@0x/contract-artifacts-v2": "npm:@0x/contract-artifacts@^2.2.2",
diff --git a/src/ts/signers.ts b/src/ts/signers.ts
index 2e421fc..2d0c344 100644
--- a/src/ts/signers.ts
+++ b/src/ts/signers.ts
@@ -236,6 +236,9 @@ export class IntChainIdTypedDataV4Signer implements TypedDataSigner {
   getGasPrice(): Promise<ethers.BigNumber> {
     return this.signer.getGasPrice();
   }
+  getFeeData(): Promise<ethers.providers.FeeData> {
+    return this.signer.getFeeData();
+  }
   resolveName(name: string): Promise<string> {
     return this.signer.resolveName(name);
   }
```

This is required because `getFeeData` is now an abstract `Signer` method that must be implemented. The `ethers` dependency version bump was needed because `getFeeData` was added to `v5.4.0` so `~5.0.18` is no longer valid for the package.
