### PR TITLE
Bump to v1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v2-contracts",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "LGPL-3.0-or-later",
   "scripts": {
     "deploy": "hardhat deploy",


### PR DESCRIPTION
Bump the package version in order to include #768 needed in the FE.
