### PR TITLE
Ignore coverage folder when linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,13 @@ module.exports = {
     "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended",
   ],
-  ignorePatterns: ["build/", "node_modules/", "!.prettierrc.js", "lib/"],
+  ignorePatterns: [
+    "build/",
+    "node_modules/",
+    "coverage/",
+    "!.prettierrc.js",
+    "lib/",
+  ],
   rules: {
     "import/order": [
       "error",


### PR DESCRIPTION
`yarn lint:ts` does not appear to terminate if ran after `yarn coverage`. This PR fixes this issue.

### Test Plan

```
$ yarn coverage
$ timeout 60 yarn lint:ts || echo "Timeout"
yarn run v1.22.10
$ eslint --max-warnings 0 .
Done in 6.02s.
```