### PR TITLE
Forward port dump task

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,318 @@
+import { BigNumber, BigNumberish } from "ethers";
+import fetch, { RequestInit } from "node-fetch";
+
+import {
+  normalizeOrder,
+  Order,
+  OrderKind,
+  Signature,
+  SigningScheme,
+  encodeSignatureData,
+} from "../ts";
+
+export enum Environment {
+  Dev,
+  Prod,
+}
+
+interface ApiCall {
+  network: string;
+  environment: Environment;
+}
+
+interface GetFeeQuery {
+  sellToken: string;
+  buyToken: string;
+  kind: OrderKind;
+  amount: BigNumberish;
+}
+interface EstimateTradeAmountQuery {
+  sellToken: string;
+  buyToken: string;
+  kind: OrderKind;
+  amount: BigNumberish;
+}
+export interface PlaceOrderQuery {
+  order: Order;
+  signature: Signature;
+}
+interface GetExecutedSellAmountQuery {
+  uid: string;
+}
+interface GetFeeAndQuoteSellQuery {
+  sellToken: string;
+  buyToken: string;
+  sellAmountBeforeFee: BigNumberish;
+}
+interface GetFeeAndQuoteBuyQuery {
+  sellToken: string;
+  buyToken: string;
+  buyAmountAfterFee: BigNumberish;
+}
+
+interface OrderDetailResponse {
+  // Other fields are omitted until needed
+  executedSellAmount: string;
+}
+interface GetFeeResponse {
+  amount: string;
+  expirationDate: Date;
+}
+interface EstimateAmountResponse {
+  amount: string;
+  token: string;
+}
+interface GetFeeAndQuoteSellResponse {
+  fee: GetFeeResponse;
+  buyAmountAfterFee: BigNumberish;
+}
+interface GetFeeAndQuoteBuyResponse {
+  fee: GetFeeResponse;
+  sellAmountBeforeFee: BigNumberish;
+}
+
+export interface GetFeeAndQuoteSellOutput {
+  feeAmount: BigNumber;
+  buyAmountAfterFee: BigNumber;
+}
+export interface GetFeeAndQuoteBuyOutput {
+  feeAmount: BigNumber;
+  sellAmountBeforeFee: BigNumber;
+}
+
+export interface ApiError {
+  errorType: string;
+  description: string;
+}
+export interface CallError extends Error {
+  apiError?: ApiError;
+}
+
+export enum GetFeeAndQuoteSellErrorType {
+  SellAmountDoesNotCoverFee = "SellAmountDoesNotCoverFee",
+  // other errors are added when necessary
+}
+
+function apiKind(kind: OrderKind): string {
+  switch (kind) {
+    case OrderKind.SELL:
+      return "sell";
+    case OrderKind.BUY:
+      return "buy";
+    default:
+      throw new Error(`Unsupported kind ${kind}`);
+  }
+}
+
+function apiSigningScheme(scheme: SigningScheme): string {
+  switch (scheme) {
+    case SigningScheme.EIP712:
+      return "eip712";
+    case SigningScheme.ETHSIGN:
+      return "ethsign";
+    case SigningScheme.EIP1271:
+      return "eip1271";
+    case SigningScheme.PRESIGN:
+      return "presign";
+    default:
+      throw new Error(`Unsupported signing scheme ${scheme}`);
+  }
+}
+
+async function call<T>(
+  route: string,
+  network: string,
+  environment: Environment,
+  init?: RequestInit,
+): Promise<T> {
+  let baseUrl: string;
+  switch (environment) {
+    case Environment.Dev:
+      baseUrl = `https://protocol-${network}.dev.gnosisdev.com`;
+      break;
+    case Environment.Prod:
+      baseUrl = `https://protocol-${network}.gnosis.io`;
+      break;
+  }
+  const url = `${baseUrl}/api/v1/${route}`;
+  const response = await fetch(url, init);
+  const body = await response.text();
+  if (!response.ok) {
+    const error: CallError = new Error(
+      `Calling "${url} ${JSON.stringify(init)} failed with ${
+        response.status
+      }: ${body}`,
+    );
+    try {
+      error.apiError = JSON.parse(body);
+    } catch {
+      // no api error
+    }
+    throw error;
+  }
+  return JSON.parse(body);
+}
+
+async function getFee({
+  sellToken,
+  buyToken,
+  kind,
+  amount,
+  network,
+  environment,
+}: GetFeeQuery & ApiCall): Promise<BigNumber> {
+  const response: GetFeeResponse = await call(
+    `fee?sellToken=${sellToken}&buyToken=${buyToken}&amount=${BigNumber.from(
+      amount,
+    ).toString()}&kind=${apiKind(kind)}`,
+    network,
+    environment,
+  );
+  return BigNumber.from(response.amount);
+}
+
+async function estimateTradeAmount({
+  network,
+  sellToken,
+  buyToken,
+  kind,
+  amount,
+  environment,
+}: EstimateTradeAmountQuery & ApiCall): Promise<BigNumber> {
+  const response: EstimateAmountResponse = await call(
+    `markets/${sellToken}-${buyToken}/${apiKind(kind)}/${BigNumber.from(
+      amount,
+    ).toString()}`,
+    network,
+    environment,
+  );
+  // The services return the quote token used for the price. The quote token
+  // is checked to make sure that the returned price meets our expectations.
+  if (response.token.toLowerCase() !== buyToken.toLowerCase()) {
+    throw new Error(
+      `Price returned for sell token ${sellToken} uses an incorrect quote token (${response.token.toLowerCase()} instead of ${buyToken.toLowerCase()})`,
+    );
+  }
+  return BigNumber.from(response.amount);
+}
+
+async function placeOrder({
+  order,
+  signature,
+  network,
+  environment,
+}: PlaceOrderQuery & ApiCall): Promise<string> {
+  const normalizedOrder = normalizeOrder(order);
+  return await call("orders", network, environment, {
+    method: "post",
+    body: JSON.stringify({
+      sellToken: normalizedOrder.sellToken,
+      buyToken: normalizedOrder.buyToken,
+      sellAmount: BigNumber.from(normalizedOrder.sellAmount).toString(),
+      buyAmount: BigNumber.from(normalizedOrder.buyAmount).toString(),
+      validTo: normalizedOrder.validTo,
+      appData: normalizedOrder.appData,
+      feeAmount: BigNumber.from(normalizedOrder.feeAmount).toString(),
+      kind: apiKind(order.kind),
+      partiallyFillable: normalizedOrder.partiallyFillable,
+      signature: encodeSignatureData(signature),
+      signingScheme: apiSigningScheme(signature.scheme),
+      receiver: normalizedOrder.receiver,
+    }),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function getExecutedSellAmount({
+  uid,
+  network,
+  environment,
+}: GetExecutedSellAmountQuery & ApiCall): Promise<BigNumber> {
+  const response: OrderDetailResponse = await call(
+    `orders/${uid}`,
+    network,
+    environment,
+  );
+  return BigNumber.from(response.executedSellAmount);
+}
+
+async function getFeeAndQuoteSell({
+  sellToken,
+  buyToken,
+  sellAmountBeforeFee,
+  network,
+  environment,
+}: GetFeeAndQuoteSellQuery & ApiCall): Promise<GetFeeAndQuoteSellOutput> {
+  const response: GetFeeAndQuoteSellResponse = await call(
+    `feeAndQuote/sell?sellToken=${sellToken}&buyToken=${buyToken}&sellAmountBeforeFee=${BigNumber.from(
+      sellAmountBeforeFee,
+    ).toString()}`,
+    network,
+    environment,
+  );
+  return {
+    feeAmount: BigNumber.from(response.fee.amount),
+    buyAmountAfterFee: BigNumber.from(response.buyAmountAfterFee),
+  };
+}
+
+async function getFeeAndQuoteBuy({
+  sellToken,
+  buyToken,
+  buyAmountAfterFee,
+  network,
+  environment,
+}: GetFeeAndQuoteBuyQuery & ApiCall): Promise<GetFeeAndQuoteBuyOutput> {
+  const response: GetFeeAndQuoteBuyResponse = await call(
+    `feeAndQuote/buy?sellToken=${sellToken}&buyToken=${buyToken}&buyAmountAfterFee=${BigNumber.from(
+      buyAmountAfterFee,
+    ).toString()}`,
+    network,
+    environment,
+  );
+  return {
+    feeAmount: BigNumber.from(response.fee.amount),
+    sellAmountBeforeFee: BigNumber.from(response.sellAmountBeforeFee),
+  };
+}
+
+export class Api {
+  network: string;
+  environment: Environment;
+
+  constructor(network: string, environment: Environment) {
+    this.network = network;
+    this.environment = environment;
+  }
+
+  private apiCallParams() {
+    return { network: this.network, environment: this.environment };
+  }
+
+  async getFee(query: GetFeeQuery): Promise<BigNumber> {
+    return getFee({ ...this.apiCallParams(), ...query });
+  }
+  async estimateTradeAmount(
+    query: EstimateTradeAmountQuery,
+  ): Promise<BigNumber> {
+    return estimateTradeAmount({ ...this.apiCallParams(), ...query });
+  }
+  async placeOrder(query: PlaceOrderQuery): Promise<string> {
+    return placeOrder({ ...this.apiCallParams(), ...query });
+  }
+  async getExecutedSellAmount(
+    query: GetExecutedSellAmountQuery,
+  ): Promise<BigNumber> {
+    return getExecutedSellAmount({ ...this.apiCallParams(), ...query });
+  }
+  async getFeeAndQuoteSell(
+    query: GetFeeAndQuoteSellQuery,
+  ): Promise<GetFeeAndQuoteSellOutput> {
+    return getFeeAndQuoteSell({ ...this.apiCallParams(), ...query });
+  }
+  async getFeeAndQuoteBuy(
+    query: GetFeeAndQuoteBuyQuery,
+  ): Promise<GetFeeAndQuoteBuyOutput> {
+    return getFeeAndQuoteBuy({ ...this.apiCallParams(), ...query });
+  }
+}

--- a/src/tasks/dump.ts
+++ b/src/tasks/dump.ts
@@ -1,0 +1,648 @@
+import readline from "readline";
+
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import chalk from "chalk";
+import {
+  BigNumber,
+  constants,
+  Contract,
+  ContractTransaction,
+  Signer,
+  utils,
+} from "ethers";
+import { task, types } from "hardhat/config";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+import { Api, CallError, Environment } from "../services/api";
+import {
+  BUY_ETH_ADDRESS,
+  domain,
+  Order,
+  OrderKind,
+  SigningScheme,
+  signOrder,
+  TypedDataDomain,
+} from "../ts";
+
+import {
+  getDeployedContract,
+  isSupportedNetwork,
+  SupportedNetwork,
+} from "./ts/deployment";
+import { promiseAllWithRateLimit } from "./ts/rate_limits";
+import { Align, displayTable } from "./ts/table";
+import {
+  isNativeToken,
+  nativeToken,
+  NativeToken,
+  erc20Token,
+  Erc20Token,
+  WRAPPED_NATIVE_TOKEN_ADDRESS,
+  balanceOf,
+  transfer,
+  displayName,
+} from "./ts/tokens";
+import { formatTokenValue } from "./ts/value";
+
+const MAX_LATEST_BLOCK_DELAY_SECONDS = 2 * 60;
+export const MAX_ORDER_VALIDITY_SECONDS = 24 * 3600;
+
+const keccak = utils.id;
+const APP_DATA = keccak("GPv2 dump script");
+
+interface DumpInstruction {
+  token: Erc20Token;
+  amountWithoutFee: BigNumber;
+  receivedAmount: BigNumber;
+  balance: BigNumber;
+  fee: BigNumber;
+  needsAllowance: boolean;
+}
+
+interface DisplayDumpInstruction {
+  fromSymbol: string;
+  fromAddress: string;
+  balance: string;
+  needsAllowance: "yes" | "";
+  receivedAmount: string;
+  feePercent: string;
+}
+
+interface TransferToReceiver {
+  token: Erc20Token | NativeToken;
+  amount: BigNumber;
+}
+
+interface DumpInstructions {
+  instructions: DumpInstruction[];
+  toToken: Erc20Token | NativeToken;
+  // Amount of toToken that will be transfered to the receiver address with a
+  // standard erc20 transfer. This is only set if there is a receiver and the
+  // specified toToken is also a token to be dumped.
+  transferToReceiver?: TransferToReceiver;
+}
+
+export interface GetDumpInstructionInput {
+  dumpedTokens: string[];
+  toTokenAddress: string | undefined; // undefined defaults to native token (e.g., ETH)
+  user: string;
+  allowanceManager: string;
+  maxFeePercent: number;
+  hasCustomReceiver: boolean;
+  hre: HardhatRuntimeEnvironment;
+  network: SupportedNetwork;
+  api: Api;
+}
+/**
+ * This function recovers all information needed to dump the input list of
+ * tokens into toToken with GPv2. It returns structured information on all
+ * operations to execute, sorted so that the last operation is the one
+ * recovering the largest amount of toToken.
+ *
+ * Information on operations to perform include that needed for creating orders,
+ * setting allowances and, if needed, transfering tokens.
+ *
+ * Note that this function is not supposed to execute any state-changing
+ * operation (either onchain or in the backend).
+ *
+ * Care is taken in handling the following logic:
+ * - handling the case where the receiver is not the signer address
+ * - handling ETH buy addresses (especially with a custom receiver)
+ * - rejecting dump requests for tokens for which the fee to pay is larger than
+ *   a given threshold
+ */
+export async function getDumpInstructions({
+  dumpedTokens: inputDumpedTokens,
+  toTokenAddress,
+  user,
+  allowanceManager,
+  maxFeePercent,
+  hasCustomReceiver,
+  hre,
+  network,
+  api,
+}: GetDumpInstructionInput): Promise<DumpInstructions> {
+  // todo: support dumping ETH by wrapping them
+  if (inputDumpedTokens.includes(BUY_ETH_ADDRESS)) {
+    throw new Error(
+      `Dumping the native token is not supported. Remove the ETH flag address ${BUY_ETH_ADDRESS} from the list of tokens to dump.`,
+    );
+  }
+
+  let toToken: Erc20Token | NativeToken;
+  if (toTokenAddress === undefined || toTokenAddress === BUY_ETH_ADDRESS) {
+    toToken = nativeToken(hre);
+  } else {
+    const erc20 = await erc20Token(toTokenAddress, hre);
+    if (erc20 === null) {
+      throw new Error(
+        `Input toToken at address ${toTokenAddress} is not a valid Erc20 token.`,
+      );
+    }
+    toToken = erc20;
+  }
+
+  let transferToReceiver: TransferToReceiver | undefined = undefined;
+  const dumpedTokens = Array.from(new Set(inputDumpedTokens)).filter(
+    (token) => token !== (toTokenAddress ?? BUY_ETH_ADDRESS),
+  );
+  if (
+    hasCustomReceiver &&
+    inputDumpedTokens.includes(toTokenAddress ?? BUY_ETH_ADDRESS)
+  ) {
+    transferToReceiver = {
+      token: toToken,
+      amount: await balanceOf(toToken, user),
+    };
+  }
+
+  const computedInstructions: (DumpInstruction | null)[] = (
+    await promiseAllWithRateLimit(
+      dumpedTokens.map((tokenAddress) => async ({ consoleWarn }) => {
+        const token = await erc20Token(tokenAddress, hre);
+        if (token === null) {
+          consoleWarn(
+            `Dump request skipped for invalid ERC-20 token at address ${tokenAddress}.`,
+          );
+          return null;
+        }
+        const [balance, approvedAmount]: [BigNumber, BigNumber] =
+          await Promise.all([
+            token.contract.balanceOf(user).then(BigNumber.from),
+            token.contract
+              .allowance(user, allowanceManager)
+              .then(BigNumber.from),
+          ]);
+        const needsAllowance = approvedAmount.lt(balance);
+        if (balance.isZero()) {
+          consoleWarn(
+            `Dump request skipped for token ${displayName(
+              token,
+            )}. No balance for that token is available.`,
+          );
+          return null;
+        }
+        const sellToken = token.address;
+        const buyToken = isNativeToken(toToken)
+          ? WRAPPED_NATIVE_TOKEN_ADDRESS[network] // todo: replace WETH address with BUY_ETH_ADDRESS when services support ETH estimates
+          : toToken.address;
+        let fee, buyAmountAfterFee;
+        try {
+          const feeAndQuote = await api.getFeeAndQuoteSell({
+            sellToken,
+            buyToken,
+            sellAmountBeforeFee: balance,
+          });
+          fee = feeAndQuote.feeAmount;
+          buyAmountAfterFee = feeAndQuote.buyAmountAfterFee;
+        } catch (e) {
+          if (
+            (e as CallError)?.apiError?.errorType ===
+            "SellAmountDoesNotCoverFee"
+          ) {
+            consoleWarn(
+              `Dump request skipped for token ${displayName(
+                token,
+              )}. The trading fee is larger than the dumped amount.`,
+            );
+            return null;
+          } else {
+            throw e;
+          }
+        }
+        const amountWithoutFee = balance.sub(fee);
+        const approxBalance = Number(balance.toString());
+        const approxFee = Number(fee.toString());
+        const feePercent = (100 * approxFee) / approxBalance;
+        if (feePercent > maxFeePercent) {
+          consoleWarn(
+            `Dump request skipped for token ${displayName(
+              token,
+            )}. The trading fee is too large compared to the balance (${feePercent.toFixed(
+              2,
+            )}%).`,
+          );
+          return null;
+        }
+        return {
+          token,
+          balance,
+          amountWithoutFee,
+          receivedAmount: buyAmountAfterFee,
+          fee,
+          needsAllowance,
+        };
+      }),
+      { rateLimit: 10 },
+    )
+  ).filter((inst) => inst !== null);
+  // note: null entries have already been filtered out
+  const instructions = computedInstructions as DumpInstruction[];
+  instructions.sort((lhs, rhs) =>
+    lhs.receivedAmount.eq(rhs.receivedAmount)
+      ? 0
+      : lhs.receivedAmount.lt(rhs.receivedAmount)
+      ? -1
+      : 1,
+  );
+
+  return { instructions, toToken, transferToReceiver };
+}
+
+function formatInstruction(
+  {
+    token: fromToken,
+    balance,
+    receivedAmount,
+    fee,
+    needsAllowance: inputNeedsAllowance,
+  }: DumpInstruction,
+  toToken: Erc20Token | NativeToken,
+): DisplayDumpInstruction {
+  const fromSymbol = fromToken.symbol ?? "! unknown symbol !";
+  const fromAddress = fromToken.address;
+  const fromDecimals = fromToken.decimals ?? 0;
+  const needsAllowance = inputNeedsAllowance ? "yes" : "";
+  const feePercent = fee.mul(10000).div(balance).lt(1)
+    ? "<0.01"
+    : utils.formatUnits(fee.mul(10000).div(balance), 2);
+  return {
+    fromSymbol,
+    fromAddress,
+    needsAllowance,
+    balance: formatTokenValue(balance, fromDecimals, 18),
+    receivedAmount: formatTokenValue(receivedAmount, toToken.decimals ?? 0, 18),
+    feePercent,
+  };
+}
+
+function displayOperations(
+  instructions: DumpInstruction[],
+  toToken: Erc20Token | NativeToken,
+) {
+  const formattedInstructions = instructions.map((inst) =>
+    formatInstruction(inst, toToken),
+  );
+  const orderWithoutAllowances = [
+    "fromAddress",
+    "fromSymbol",
+    "receivedAmount",
+    "balance",
+    "feePercent",
+  ] as const;
+  const order = instructions.some(({ needsAllowance }) => needsAllowance)
+    ? ([
+        ...orderWithoutAllowances.slice(0, 2),
+        "needsAllowance",
+        ...orderWithoutAllowances.slice(2),
+      ] as const)
+    : orderWithoutAllowances;
+  const header = {
+    fromAddress: "token address",
+    fromSymbol: "symbol",
+    balance: "dumped amount",
+    feePercent: "fee %",
+    receivedAmount: `received amount${
+      toToken.symbol ? ` (${toToken.symbol})` : ""
+    }`,
+    needsAllowance: "needs allowance?",
+  };
+  console.log(chalk.bold("List of dumped tokens:"));
+  displayTable(header, formattedInstructions, order, {
+    balance: { align: Align.Right, maxWidth: 30 },
+    receivedAmount: { align: Align.Right, maxWidth: 30 },
+    fromSymbol: { maxWidth: 20 },
+  });
+  console.log();
+}
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+async function prompt(message: string) {
+  const response = await new Promise<string>((resolve) =>
+    rl.question(`${message} (y/N) `, (response) => resolve(response)),
+  );
+  return "y" === response.toLowerCase();
+}
+
+interface CreateAllowancesOptions {
+  requiredConfirmations?: number | undefined;
+}
+async function createAllowances(
+  allowances: Erc20Token[],
+  signer: Signer,
+  allowanceManager: string,
+  { requiredConfirmations }: CreateAllowancesOptions = {},
+) {
+  let lastTransaction: ContractTransaction | undefined = undefined;
+  for (const token of allowances) {
+    console.log(
+      `Approving allowance manager to trade token ${displayName(token)}...`,
+    );
+    lastTransaction = (await token.contract
+      .connect(signer)
+      .approve(allowanceManager, constants.MaxUint256)) as ContractTransaction;
+    await lastTransaction.wait();
+  }
+  if (lastTransaction !== undefined) {
+    // note: the last approval is (excluded reorgs) the last that is included
+    // in a block, so awaiting it for confirmations means that also all others
+    // have at least this number of confirmations.
+    await lastTransaction.wait(requiredConfirmations);
+  }
+}
+
+async function createOrders(
+  instructions: DumpInstruction[],
+  toToken: Erc20Token | NativeToken,
+  signer: Signer,
+  receiver: string,
+  hasCustomReceiver: boolean,
+  domainSeparator: TypedDataDomain,
+  validity: number,
+  ethers: HardhatRuntimeEnvironment["ethers"],
+  api: Api,
+) {
+  const blockTimestamp = (await ethers.provider.getBlock("latest")).timestamp;
+  // Check that the local time is consistent with that of the blockchain
+  // to avoid signing orders that are valid for too long
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - blockTimestamp) > MAX_LATEST_BLOCK_DELAY_SECONDS) {
+    throw new Error("Blockchain time is not consistent with local time.");
+  }
+
+  for (const inst of instructions) {
+    const order: Order = {
+      sellToken: inst.token.address,
+      buyToken: isNativeToken(toToken) ? BUY_ETH_ADDRESS : toToken.address,
+      sellAmount: inst.amountWithoutFee,
+      buyAmount: inst.receivedAmount,
+      feeAmount: inst.fee,
+      kind: OrderKind.SELL,
+      appData: APP_DATA,
+      // todo: switch to true when partially fillable orders will be
+      // supported by the services
+      partiallyFillable: false,
+      validTo: now + validity,
+      receiver: hasCustomReceiver ? receiver : undefined,
+    };
+    const signature = await signOrder(
+      domainSeparator,
+      order,
+      signer,
+      SigningScheme.ETHSIGN,
+    );
+
+    console.log(
+      `Creating order selling ${inst.token.symbol ?? inst.token.address}...`,
+    );
+    await api.placeOrder({
+      order,
+      signature,
+    });
+  }
+}
+async function transferSameTokenToReceiver(
+  transferToReceiver: TransferToReceiver,
+  signer: Signer,
+  receiver: string,
+) {
+  if (transferToReceiver !== undefined) {
+    console.log(
+      `Transfering token ${transferToReceiver.token.symbol} to receiver...`,
+    );
+    const receipt = await transfer(
+      transferToReceiver.token,
+      signer,
+      receiver,
+      transferToReceiver.amount,
+    );
+    await receipt.wait();
+  }
+}
+
+interface DumpInput {
+  validity: number;
+  maxFeePercent: number;
+  dumpedTokens: string[];
+  toToken: string;
+  settlement: Contract;
+  signer: SignerWithAddress;
+  receiver: string | undefined;
+  network: SupportedNetwork;
+  hre: HardhatRuntimeEnvironment;
+  api: Api;
+  dryRun: boolean;
+  doNotPrompt?: boolean | undefined;
+  confirmationsAfterApproval?: number | undefined;
+}
+export async function dump({
+  validity,
+  maxFeePercent,
+  dumpedTokens,
+  toToken: toTokenAddress,
+  settlement,
+  signer,
+  receiver: inputReceiver,
+  network,
+  hre,
+  api,
+  dryRun,
+  doNotPrompt,
+  confirmationsAfterApproval,
+}: DumpInput): Promise<void> {
+  const { ethers } = hre;
+  if (validity > MAX_ORDER_VALIDITY_SECONDS) {
+    throw new Error("Order validity too large");
+  }
+  const [chainId, allowanceManager] = await Promise.all([
+    ethers.provider.getNetwork().then((n) => n.chainId),
+    (await settlement.vaultRelayer()) as string,
+  ]);
+  const domainSeparator = domain(chainId, settlement.address);
+  const receiver: string = inputReceiver ?? signer.address;
+  const hasCustomReceiver = receiver !== signer.address;
+
+  // todo: when sending ETH to a contract will be supported by the
+  // services, remove this check.
+  if (
+    (toTokenAddress === undefined || toTokenAddress === BUY_ETH_ADDRESS) &&
+    hasCustomReceiver
+  ) {
+    throw new Error("Receiver is not supported when buying ETH");
+  }
+
+  const { instructions, toToken, transferToReceiver } =
+    await getDumpInstructions({
+      dumpedTokens,
+      toTokenAddress,
+      user: signer.address,
+      allowanceManager,
+      maxFeePercent,
+      hasCustomReceiver,
+      hre,
+      network,
+      api,
+    });
+  if (instructions.length === 0) {
+    console.log("No token can be sold");
+    return;
+  }
+
+  displayOperations(instructions, toToken);
+
+  let sumReceived = instructions.reduce(
+    (sum, inst) => sum.add(inst.receivedAmount),
+    constants.Zero,
+  );
+  const needAllowances = instructions
+    .filter(({ needsAllowance }) => needsAllowance)
+    .map(({ token }) => token);
+  if (needAllowances.length !== 0) {
+    console.log(
+      `Before creating the orders, a total of ${needAllowances.length} allowances will be granted to the allowance manager.`,
+    );
+  }
+  const toTokenName = isNativeToken(toToken)
+    ? toToken.symbol
+    : toToken.symbol ?? `units of token ${toToken.address}`;
+  if (transferToReceiver !== undefined) {
+    console.log(
+      `Moreover, ${utils.formatUnits(
+        transferToReceiver.amount,
+        transferToReceiver.token.decimals ?? 0,
+      )} ${toTokenName} will be transfered to the receiver address ${receiver}.`,
+    );
+    sumReceived = sumReceived.add(transferToReceiver.amount);
+  }
+  console.log(
+    `${
+      hasCustomReceiver
+        ? `The receiver address ${receiver}`
+        : `Your address (${signer.address})`
+    } will receive at least ${utils.formatUnits(
+      sumReceived,
+      toToken.decimals ?? 0,
+    )} ${toTokenName} from selling the tokens listed above.`,
+  );
+  if (!dryRun && (doNotPrompt || (await prompt("Submit?")))) {
+    await createAllowances(needAllowances, signer, allowanceManager, {
+      // If the services don't register the allowance before the order,
+      // then creating a new order with the API returns an error.
+      // Moreover, there is no distinction in the error between a missing
+      // allowance and a failed order creation, which could occur for
+      // valid reasons.
+      requiredConfirmations: confirmationsAfterApproval,
+    });
+
+    await createOrders(
+      instructions,
+      toToken,
+      signer,
+      receiver,
+      hasCustomReceiver,
+      domainSeparator,
+      validity,
+      ethers,
+      api,
+    );
+
+    if (transferToReceiver !== undefined) {
+      await transferSameTokenToReceiver(transferToReceiver, signer, receiver);
+    }
+
+    console.log(
+      `Done! The orders will expire in the next ${validity / 60} minutes.`,
+    );
+  }
+}
+
+const setupDumpTask: () => void = () =>
+  task("dump")
+    .addOptionalParam(
+      "origin",
+      "Address from which to withdraw. If not specified, it defaults to the first provided account",
+    )
+    .addOptionalParam(
+      "toToken",
+      "All input tokens will be dumped to this token. If not specified, it defaults to the network's native token (e.g., ETH)",
+    )
+    .addOptionalParam(
+      "receiver",
+      "The address that will receive the funds obtained from dumping the token. Defaults to the origin address",
+    )
+    .addOptionalParam(
+      "validity",
+      `How long the sell orders will be valid after their creation in seconds. It cannot be larger than ${MAX_ORDER_VALIDITY_SECONDS}`,
+      20 * 60,
+      types.int,
+    )
+    .addOptionalParam(
+      "maxFeePercent",
+      "If, for any token, the amount of fee to be paid is larger than this percent of the traded amount, that token is not traded",
+      5,
+      types.float,
+    )
+    .addFlag(
+      "dryRun",
+      "Just simulate the result instead of executing the transaction on the blockchain.",
+    )
+    .addVariadicPositionalParam(
+      "dumpedTokens",
+      "List of tokens that will be dumped in exchange for toToken. Multiple tokens are separated by spaces",
+    )
+    .setAction(
+      async (
+        {
+          origin,
+          toToken,
+          dumpedTokens,
+          maxFeePercent,
+          dryRun,
+          receiver,
+          validity,
+        },
+        hre,
+      ) => {
+        const network = hre.network.name;
+        if (!isSupportedNetwork(network)) {
+          throw new Error(`Unsupported network ${hre.network.name}`);
+        }
+        const api = new Api(network, Environment.Prod);
+        const [signers, settlement] = await Promise.all([
+          hre.ethers.getSigners(),
+          getDeployedContract("GPv2Settlement", hre),
+        ]);
+        const signer =
+          origin === undefined
+            ? signers[0]
+            : signers.find((signer) => signer.address === origin);
+        if (signer === undefined) {
+          throw new Error(
+            `No signer found${
+              origin === undefined ? "" : ` for address ${origin}`
+            }. Did you export a valid private key?`,
+          );
+        }
+        console.log(`Using account ${signer.address}`);
+
+        await dump({
+          validity,
+          maxFeePercent,
+          dumpedTokens,
+          toToken,
+          settlement,
+          signer,
+          receiver,
+          network,
+          hre,
+          api,
+          dryRun,
+          confirmationsAfterApproval: 2,
+        });
+      },
+    );
+
+export { setupDumpTask };

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -1,5 +1,6 @@
 import { setupCopyArtifactsTask } from "./artifacts";
 import { setupDecodeTask } from "./decode";
+import { setupDumpTask } from "./dump";
 import { setupSolversTask } from "./solvers";
 import { setupTenderlyTask } from "./tenderly";
 import { setupWithdrawTask } from "./withdraw";
@@ -7,6 +8,7 @@ import { setupWithdrawTask } from "./withdraw";
 export function setupTasks(): void {
   setupCopyArtifactsTask();
   setupDecodeTask();
+  setupDumpTask();
   setupSolversTask();
   setupTenderlyTask();
   setupWithdrawTask();

--- a/src/tasks/ts/deployment.ts
+++ b/src/tasks/ts/deployment.ts
@@ -13,3 +13,11 @@ export async function getDeployedContract(
     ethers.provider,
   );
 }
+
+export type SupportedNetwork = "mainnet" | "rinkeby" | "xdai";
+
+export function isSupportedNetwork(
+  network: string,
+): network is SupportedNetwork {
+  return network === "xdai";
+}

--- a/src/tasks/ts/rate_limits.ts
+++ b/src/tasks/ts/rate_limits.ts
@@ -1,0 +1,78 @@
+const MAX_PARALLEL_INSTRUCTIONS = 20;
+
+const LINE_CLEARING_ENABLED =
+  process.stdout.isTTY &&
+  process.stdout.clearLine !== undefined &&
+  process.stdout.cursorTo !== undefined;
+
+export interface DisappearingLogFunctions {
+  consoleWarn: typeof console.warn;
+}
+
+interface VanishingProgressMessage {
+  message: string;
+}
+
+interface RateLimitOptionalParameters {
+  message?: string;
+  rateLimit?: number;
+}
+
+function createDisappearingLogFunctions(
+  vanishingProgressMessage: VanishingProgressMessage,
+): DisappearingLogFunctions {
+  const consoleWarn: typeof console.warn = (...args: unknown[]) => {
+    if (LINE_CLEARING_ENABLED) {
+      process.stdout.clearLine(0);
+    }
+    console.warn(...args);
+    if (LINE_CLEARING_ENABLED) {
+      process.stdout.write(vanishingProgressMessage.message);
+      process.stdout.cursorTo(0);
+    }
+  };
+
+  return { consoleWarn };
+}
+
+export async function promiseAllWithRateLimit<T>(
+  instructions: ((logFunctions: DisappearingLogFunctions) => Promise<T>)[],
+  { rateLimit: rateLimitInput, message }: RateLimitOptionalParameters = {},
+): Promise<T[]> {
+  const rateLimit = Math.floor(rateLimitInput ?? MAX_PARALLEL_INSTRUCTIONS);
+  if (rateLimit < 1) {
+    throw new Error(`Rate limit must be one or larger, found ${rateLimit}`);
+  }
+  const output: T[] = [];
+  const vanishingProgressMessage = { message: "" };
+  const disappearingLogFunctions = createDisappearingLogFunctions(
+    vanishingProgressMessage,
+  );
+  for (let step = 0; step < instructions.length / rateLimit; step++) {
+    const remainingInstructions = instructions.length - rateLimit * step;
+    const instructionsInBatch =
+      remainingInstructions >= rateLimit ? rateLimit : remainingInstructions;
+    vanishingProgressMessage.message = `Processing steps ${
+      step * rateLimit + 1
+    } to ${step * rateLimit + instructionsInBatch} of ${instructions.length}${
+      message !== undefined ? ` (${message})` : ""
+    }...`;
+    if (LINE_CLEARING_ENABLED) {
+      process.stdout.write(vanishingProgressMessage.message);
+      process.stdout.cursorTo(0);
+    }
+    output.push(
+      ...(await Promise.all(
+        Array(instructionsInBatch)
+          .fill(undefined)
+          .map((_, i) =>
+            instructions[step * rateLimit + i](disappearingLogFunctions),
+          ),
+      )),
+    );
+  }
+  if (LINE_CLEARING_ENABLED) {
+    process.stdout.clearLine(0);
+  }
+  return output;
+}

--- a/src/tasks/ts/tokens.ts
+++ b/src/tasks/ts/tokens.ts
@@ -1,0 +1,130 @@
+import WethNetworks from "canonical-weth/networks.json";
+import {
+  BigNumber,
+  BigNumberish,
+  Contract,
+  ContractTransaction,
+  providers,
+  Signer,
+} from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+import { SupportedNetwork, isSupportedNetwork } from "./deployment";
+
+export interface Erc20Token {
+  contract: Contract;
+  symbol?: string;
+  decimals?: number;
+  address: string;
+}
+
+export interface NativeToken {
+  symbol: string;
+  decimals: number;
+  provider: providers.JsonRpcProvider;
+}
+
+export const NATIVE_TOKEN_SYMBOL: Record<
+  SupportedNetwork | "hardhat",
+  string
+> = {
+  hardhat: "ETH",
+  mainnet: "ETH",
+  rinkeby: "ETH",
+  xdai: "xDAI",
+};
+
+export const WRAPPED_NATIVE_TOKEN_ADDRESS: Record<SupportedNetwork, string> = {
+  mainnet: WethNetworks.WETH9[1].address,
+  rinkeby: WethNetworks.WETH9[4].address,
+  xdai: "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
+};
+
+export function isNativeToken(
+  token: Erc20Token | NativeToken,
+): token is NativeToken {
+  return (token as Erc20Token).contract === undefined;
+}
+
+export function displayName(token: Erc20Token | NativeToken): string {
+  if (isNativeToken(token)) {
+    return token.symbol;
+  } else {
+    return token.symbol ? `${token.symbol} (${token.address})` : token.address;
+  }
+}
+
+export async function balanceOf(
+  token: Erc20Token | NativeToken,
+  user: string,
+): Promise<BigNumber> {
+  const balanceFunction = isNativeToken(token)
+    ? token.provider.getBalance
+    : token.contract.balanceOf;
+  return BigNumber.from(await balanceFunction(user));
+}
+
+export async function transfer(
+  token: Erc20Token | NativeToken,
+  from: Signer,
+  to: string,
+  amount: BigNumberish,
+): Promise<ContractTransaction | providers.TransactionResponse> {
+  const transferFunction: (
+    to: string,
+    amount: BigNumberish,
+  ) => ContractTransaction | providers.TransactionResponse = isNativeToken(
+    token,
+  )
+    ? (to, value) => from.sendTransaction({ to, value })
+    : token.contract.connect(from).transfer;
+  return await transferFunction(to, amount);
+}
+
+export function nativeToken({
+  ethers,
+  network,
+}: HardhatRuntimeEnvironment): NativeToken {
+  if (network.name !== "hardhat" && !isSupportedNetwork(network.name)) {
+    throw new Error(
+      `Cannot retrieve native token for unsupported network ${network.name}`,
+    );
+  }
+  return {
+    symbol: NATIVE_TOKEN_SYMBOL[network.name],
+    decimals: 18, // assumption: every network supported by our protocol uses an 18-decimal native token
+    provider: ethers.provider,
+  };
+}
+
+export async function erc20Token(
+  address: string,
+  hre: HardhatRuntimeEnvironment,
+): Promise<Erc20Token | null> {
+  const IERC20 = await hre.artifacts.readArtifact(
+    "src/contracts/interfaces/IERC20.sol:IERC20",
+  );
+  const contract = new Contract(address, IERC20.abi, hre.ethers.provider);
+  const [symbol, decimals] = await Promise.all([
+    contract
+      .symbol()
+      .then((s: unknown) => (typeof s !== "string" ? null : s))
+      .catch(() => null),
+    contract
+      .decimals()
+      .then((s: unknown) => BigNumber.from(s))
+      .catch(() => null),
+  ]);
+  if (symbol === null || decimals === null) {
+    const code = await hre.ethers.provider.getCode(address);
+    if (code === "0x") {
+      return null;
+    }
+  }
+  return {
+    contract,
+    symbol,
+    decimals,
+    address,
+  };
+}

--- a/src/tasks/ts/value.ts
+++ b/src/tasks/ts/value.ts
@@ -1,0 +1,103 @@
+import { BigNumber, constants } from "ethers";
+
+import { Api, ApiError } from "../../services/api";
+import { OrderKind } from "../../ts";
+import { SupportedNetwork } from "../ts/deployment";
+import { Erc20Token, WRAPPED_NATIVE_TOKEN_ADDRESS } from "../ts/tokens";
+
+interface PricedToken extends Erc20Token {
+  // Overrides existing field in TokenDetails. The number of decimals must be
+  // known to estimate the price
+  decimals: number;
+  // Amount of DAI wei equivalent to one unit of this token (10**decimals)
+  usdValue: BigNumber;
+}
+
+export interface ReferenceToken {
+  symbol: string;
+  decimals: number;
+  address: string;
+}
+export const REFERENCE_TOKEN: Record<SupportedNetwork, ReferenceToken> = {
+  rinkeby: {
+    symbol: "DAI",
+    decimals: 18,
+    address: "0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea",
+  },
+  mainnet: {
+    symbol: "DAI",
+    decimals: 18,
+    address: "0x6b175474e89094c44da98b954eedeac495271d0f",
+  },
+  xdai: {
+    // todo: replace with XDAI when native token price queries will be supported
+    // by the services.
+    symbol: "WXDAI",
+    decimals: 18,
+    address: WRAPPED_NATIVE_TOKEN_ADDRESS.xdai,
+  },
+} as const;
+
+export const usdValue = async function (
+  token: Pick<Erc20Token, "symbol" | "address">,
+  amount: BigNumber,
+  referenceToken: ReferenceToken,
+  api: Api,
+): Promise<BigNumber> {
+  try {
+    return await api.estimateTradeAmount({
+      sellToken: token.address,
+      buyToken: referenceToken.address,
+      amount,
+      kind: OrderKind.SELL,
+    });
+  } catch (e) {
+    const errorData: ApiError = e.apiError ?? {
+      errorType: "script internal error",
+      description: e?.message ?? "no details",
+    };
+    console.warn(
+      `Warning: price retrieval failed for token ${token.symbol} (${token.address}): ${errorData.errorType} (${errorData.description})`,
+    );
+    return constants.Zero;
+  }
+};
+
+// Format amount so that it has exactly a fixed amount of decimals.
+export function formatTokenValue(
+  amount: BigNumber,
+  actualDecimals: number,
+  targetDecimals: number,
+): string {
+  const normalized =
+    targetDecimals <= actualDecimals
+      ? amount.div(BigNumber.from(10).pow(actualDecimals - targetDecimals))
+      : amount.mul(BigNumber.from(10).pow(-actualDecimals + targetDecimals));
+  const powDecimals = BigNumber.from(10).pow(targetDecimals);
+  return `${normalized.div(powDecimals).toString()}.${normalized
+    .mod(powDecimals)
+    .toString()
+    .padStart(targetDecimals, "0")}`;
+}
+
+export function formatUsdValue(
+  amount: BigNumber,
+  usdReference: ReferenceToken,
+): string {
+  return formatTokenValue(amount, usdReference.decimals, 2);
+}
+
+export async function appraise(
+  token: Erc20Token,
+  usdReference: ReferenceToken,
+  api: Api,
+): Promise<PricedToken> {
+  const decimals = token.decimals ?? 18;
+  const usd = await usdValue(
+    token,
+    BigNumber.from(10).pow(decimals),
+    usdReference,
+    api,
+  );
+  return { ...token, usdValue: usd, decimals };
+}

--- a/src/ts/settlement.ts
+++ b/src/ts/settlement.ts
@@ -306,7 +306,7 @@ export function decodeTradeFlags(flags: BigNumberish): TradeFlags {
   };
 }
 
-function encodeSignatureData(sig: Signature): string {
+export function encodeSignatureData(sig: Signature): string {
   switch (sig.scheme) {
     case SigningScheme.EIP712:
     case SigningScheme.ETHSIGN:


### PR DESCRIPTION
This **draft** PR just contained the changes needed in order to forward port the `dump.ts` task to `main` from `v0.0.1` branch. This was used to use GPv2 in order to swap tokens collected from fees for WETH.

The script was ported in a hacky way, just putting it here so we don't lose the required changes in case we need to run it again.
