### PR TITLE
Check node chain id on start

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -109,14 +109,17 @@ export default {
     mainnet: {
       url: `https://mainnet.infura.io/v3/${INFURA_KEY}`,
       ...sharedNetworkConfig,
+      chainId: 1,
     },
     rinkeby: {
       url: `https://rinkeby.infura.io/v3/${INFURA_KEY}`,
       ...sharedNetworkConfig,
+      chainId: 4,
     },
     xdai: {
       url: "https://xdai.poanetwork.dev",
       ...sharedNetworkConfig,
+      chainId: 100,
     },
   },
   namedAccounts: {


### PR DESCRIPTION
In a recent PR we started accepting node url from an env variable.
This means that we could be using a mainnet node when running with `--network rinkeby`.
This PR adds chain id validation for the node. 

### Test Plan

```
$ export NODE_URL="https://rinkeby.infura.io/v3/$INFURA_KEY"
$ yarn --silent solvers check 0xAd426eef53dD1C130EDebEcf7cB72FC88D9F4BE9 --network mainnet
failed to get chainId, falling back on net_version...
Error HH101: Hardhat was set to use chain id 1, but connected to a chain with id 4.
```