### PR TITLE
List existing solvers

### DIFF
--- a/src/tasks/solvers.ts
+++ b/src/tasks/solvers.ts
@@ -6,8 +6,9 @@ import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 import { getDeployedContract } from "./ts/deployment";
 import { getNamedSigner } from "./ts/signers";
+import { getSolvers } from "./ts/solver";
 
-const solversTaskList = ["add", "check", "remove"] as const;
+const solversTaskList = ["add", "check", "remove", "list"] as const;
 type SolversTasks = typeof solversTaskList[number];
 
 async function addSolver(solver: string, hre: HardhatRuntimeEnvironment) {
@@ -46,6 +47,15 @@ const isSolver = async (solver: string, hre: HardhatRuntimeEnvironment) => {
     }a solver.`,
   );
 };
+
+async function listSolvers(hre: HardhatRuntimeEnvironment) {
+  const authenticator = await getDeployedContract(
+    "GPv2AllowListAuthentication",
+    hre,
+  );
+
+  console.log((await getSolvers(authenticator)).join("\n"));
+}
 
 const setupSolversTask: () => void = () => {
   task("solvers", "Reads and changes the list of allowed solvers in GPv2.")
@@ -103,6 +113,13 @@ const setupSolversTask: () => void = () => {
       );
     }
     await isSolver(args[0], hardhatRuntime);
+  });
+
+  subtask(
+    "solvers-list",
+    "List all currently registered solvers of GPv2.",
+  ).setAction(async (_, hardhatRuntime) => {
+    await listSolvers(hardhatRuntime);
   });
 };
 

--- a/src/tasks/ts/solver.ts
+++ b/src/tasks/ts/solver.ts
@@ -1,0 +1,15 @@
+import { Contract } from "ethers";
+
+export async function getSolvers(authenticator: Contract): Promise<string[]> {
+  const addedSolvers: string[] = (
+    await authenticator.queryFilter(authenticator.filters.SolverAdded())
+  ).map((log) => {
+    // "SolverAdded" always has the argument "solver"
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return log.args!.solver;
+  });
+  const isSolver = await Promise.all(
+    addedSolvers.map((solver) => authenticator.isSolver(solver)),
+  );
+  return addedSolvers.filter((_, i) => isSolver[i]);
+}

--- a/test/tasks/ts/solver.test.ts
+++ b/test/tasks/ts/solver.test.ts
@@ -9,7 +9,7 @@ let wallets: Wallet[];
 
 let authenticator: Contract;
 
-describe("getSolvers", () => {
+describe("Task helper: getSolvers", () => {
   beforeEach(async () => {
     const deployment = await deployTestContracts();
 

--- a/test/tasks/ts/solver.test.ts
+++ b/test/tasks/ts/solver.test.ts
@@ -1,0 +1,34 @@
+import { expect } from "chai";
+import { Contract, Wallet } from "ethers";
+
+import { getSolvers } from "../../../src/tasks/ts/solver";
+import { deployTestContracts } from "../../e2e/fixture";
+
+let manager: Wallet;
+let wallets: Wallet[];
+
+let authenticator: Contract;
+
+describe("getSolvers", () => {
+  beforeEach(async () => {
+    const deployment = await deployTestContracts();
+
+    ({ manager, authenticator, wallets } = deployment);
+  });
+
+  it("lists solvers", async () => {
+    await authenticator.connect(manager).addSolver(wallets[0].address);
+    await authenticator.connect(manager).addSolver(wallets[1].address);
+    const list = await getSolvers(authenticator);
+    expect(list).to.have.length(2);
+    expect(list).to.include(wallets[0].address);
+    expect(list).to.include(wallets[1].address);
+  });
+
+  it("does not show removed solvers", async () => {
+    await authenticator.connect(manager).addSolver(wallets[0].address);
+    await authenticator.connect(manager).removeSolver(wallets[0].address);
+    const list = await getSolvers(authenticator);
+    expect(list).to.have.length(0);
+  });
+});


### PR DESCRIPTION
Add subtask `solvers list` which lists all current solvers.

This function is used in the dry run of the withdraw script to simulate the withdraw transaction in case the key of a solver is not exported during testing.

### Test Plan

```
$ yarn --silent solvers list --network mainnet
0x6C2999B6B1fAD608ECEA71B926D68Ee6c62BeEf8
0xa6DDBD0dE6B310819b49f680F65871beE85f517e
0x0798540EE03a8c2E68Cef19C56d1FAa86271d5cf
$ yarn --silent solvers list --network xdai
0x97d69672E8FE5be64D7D5BbbA438ae9b08187667
0xd8da60bDe22461D7Aa11540C338dC56a0E546b0D
0xAd426eef53dD1C130EDebEcf7cB72FC88D9F4BE9
$ yarn --silent solvers list --network rinkeby | xargs -I % yarn --silent solvers check % --network rinkeby
0x0e1401b7037163764b161fd989BDCf224bB5dcc4 is a solver.
0x8C502216a83be0698f79194993Ef8B4CC9C771Cc is a solver.
0x00D374731083492b38A66ef5a1157cD378d020fc is a solver.
0xAB11B7c9A53d3FaB382d3ac0e3B912544377F49E is a solver.
0xABa2f3dB5Db52F316441254A349C25cfe35d4389 is a solver.
0x282FB931E3D96414547E961D7F4A6bc044eDA864 is a solver.
0xd3d78980423CE0a54345c103f90574cc69B52dB2 is a solver.
```

<details><summary>Dry run now doesn't error when running with a non-solver account</summary>

```
$ npx hardhat withdraw --network rinkeby --receiver 0x6c642cafcbd9d8383250bb25f67ae409147f78b2 --dry-run 
Using account 0x627306090abaB3A6e1400e9345bC60c78a8BEf57
Current account is not a solver. Only a solver can withdraw funds from the settlement contract.
Recovering list of traded tokens...
Amounts to withdraw:
 address                                    | balance (usd) | balance                        | withdrawn amount               | symbol 
--------------------------------------------+---------------+--------------------------------+--------------------------------+--------
 0x577D296678535e4903D59A4C929B718e1D575e0A |          0.27 |           0.000006240000000000 |           0.000006240000000000 | WBTC   
 0x01BE23585060835E02B77ef475b0Cc51aA1e0709 |        558.26 |           2.310703800406999947 |           2.310703800406999947 | LINK   
 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984 |        898.86 |           0.003391612833545067 |           0.003391612833545067 | UNI    
 0xbF7A7169562078c96f0eC1A8aFD6aE50f12e5A99 |       1079.58 |         100.404698642819030599 |         100.404698642819030599 | BAT    
 0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85 |       1262.48 |           0.000135622472783980 |           0.000135622472783980 | MKR    
 0x0000000000085d4780B73119b644AE5ecd22b376 |       1815.51 |          39.417151203603236644 |          39.417151203603236644 | TUSD   
 0xBD6A9921504fae42EaD2024F43305A8ED3890F6f |       2756.36 |           3.762700080979104354 |           3.762700080979104354 | PAX    
 0xa7D1C04fAF998F9161fC9F800a99A809b84cfc9D |       8480.17 |          53.318138980426767962 |          53.318138980426767962 | OWL    
 0xddea378A6dDC8AfeC82C36E9b0078826bf9e68B6 |      18979.12 |           0.022091551110410854 |           0.022091551110410854 | ZRX    
 0xcFc99E8139Ae41FF6Db9E521f9e7cEaC8BDC9cbC |     109028.68 |           0.999911820374250438 |           0.999911820374250438 | TKIn   
 0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735 |     134740.41 | 4537021950645.6211348111093... | 4537021950645.6211348111093... | DAI    
 0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c |     183642.75 |         191.227087667127634936 |         191.227087667127634936 | GNO    
 0xc778417E063141139Fce010982780140Aa0cD5Ab |     462381.14 |           2.138113800296030986 |           2.138113800296030986 | WETH   
 0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa |    2237759.19 |     2237759.198784785245693949 |     2237759.198784785245693949 | DAI    
 0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b |   21934427.30 |      295743.017216000000000000 |      295743.017216000000000000 | USDC   

The transaction will cost approximately 0.00063976201599405 ETH and will withdraw the balance of 15 tokens for an estimated total value of 25097810.16 USD. All withdrawn funds will be sent to 0x6C642caFCbd9d8383250bb25F67aE409147f78b2.
```
</details>