### PR TITLE
Add build artifacts to Docker image

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --no-cache tini git python3 linux-headers eudev-dev libusb-dev build
 # Tini is now available at /sbin/tini
 
 RUN yarn install --frozen
+RUN yarn build
 
 # Run Node app as child of tini
 # Signal handling for PID1 https://github.com/krallin/tini


### PR DESCRIPTION
Build artifacts are needed to run many of the available tasks. For this reason, the build artifacts are added when creating the Docker image.

### Test Plan

Run `$ bash src/docker/deploy.sh test`:
```
...
[4/4] Building fresh packages...
Done in 78.56s.
--> 1a33da4d6c8
STEP 6/7: RUN yarn build
yarn run v1.22.5
$ yarn build:sol && yarn build:ts
$ hardhat compile --force
Downloading compiler 0.7.6
Compiling 55 files with 0.7.6
Compilation finished successfully
$ tsc && tsc -p tsconfig.lib.esm.json && tsc -p tsconfig.lib.commonjs.json
Done in 48.30s.
--> 8234fd15c7e
STEP 7/7: ENTRYPOINT ["/sbin/tini", "--"]
COMMIT test
...
```