### PR TITLE
Better error message on failed order creation

### DIFF
--- a/src/tasks/dump.ts
+++ b/src/tasks/dump.ts
@@ -384,11 +384,30 @@ async function createOrders(
     console.log(
       `Creating order selling ${inst.token.symbol ?? inst.token.address}...`,
     );
-    const orderUid = await api.placeOrder({
-      order,
-      signature,
-    });
-    console.log(`Successfully created order with uid ${orderUid}`);
+    try {
+      const orderUid = await api.placeOrder({
+        order,
+        signature,
+      });
+      console.log(`Successfully created order with uid ${orderUid}`);
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        (error as CallError)?.apiError !== undefined
+      ) {
+        // not null because of the condition in the if statement above
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const { errorType, description } = (error as CallError).apiError!;
+        console.error(
+          `Failed submitting order selling ${
+            inst.token.symbol ?? inst.token.address
+          }, the server returns ${errorType} (${description})`,
+        );
+        console.error(`Order details: ${JSON.stringify(order)}`);
+      } else {
+        throw error;
+      }
+    }
   }
 }
 async function transferSameTokenToReceiver(


### PR DESCRIPTION
Better error message if creating orders fails with the dump script. Also, failing one order does not prevent the script from creating the other ones.

### Test Plan

I triggered the error by making the API send the same sell and buy token in the code.

```
$ npx hardhat dump --network rinkeby --to-token 0xc778417e063141139fce010982780140aa0cd5ab --receiver 0xd9395aeE9141a3Efeb6d16057c8f67fBE296734c   0xc7ad46e0b8a400bb3c915120d284aafba8fc4735 --max-fee-percent 20 
Using account 0x59552a04D9f0c184CFce5f951fe36a01A2b4aDD9
List of dumped tokens:
 token address                              | symbol | received amount (WETH) | dumped amount                  | fee % 
--------------------------------------------+--------+------------------------+--------------------------------+-------
 0xc7ad46e0b8a400bb3c915120d284aafba8fc4735 | DAI    |   0.075589594771580892 | 1000000000000.0000000000000... | 0.65  

The receiver address 0xd9395aeE9141a3Efeb6d16057c8f67fBE296734c will receive at least 0.075589594771580892 WETH from selling the tokens listed above.
Submit? (y/N) y
Creating order selling DAI...
Failed submitting order selling DAI, the server returns SameBuyAndSellToken (Buy token is the same as the sell token.)
Order details: {"sellToken":"0xc7ad46e0b8a400bb3c915120d284aafba8fc4735","buyToken":"0xc778417e063141139fce010982780140aa0cd5ab","sellAmount":{"type":"BigNumber","hex":"0x0c89f4dfc44ef953ea40000000"},"buyAmount":{"type":"BigNumber","hex":"0x010c8c56011367dc"},"feeAmount":{"type":"BigNumber","hex":"0x1537bd0bf77b9a0000000000"},"kind":"sell","appData":"0x2947be33ebfa25686ec204857135dd1c676f35d6c252eb066fffaf9b493a01b4","partiallyFillable":false,"validTo":1632316033,"receiver":"0xd9395aeE9141a3Efeb6d16057c8f67fBE296734c"}
Done! The orders will expire in the next 20 minutes.
```

