### PR TITLE
Account for price impact in withdraw script

### DIFF
--- a/src/tasks/ts/value.ts
+++ b/src/tasks/ts/value.ts
@@ -5,14 +5,6 @@ import { OrderKind } from "../../ts";
 import { SupportedNetwork } from "../ts/deployment";
 import { Erc20Token, WRAPPED_NATIVE_TOKEN_ADDRESS } from "../ts/tokens";
 
-interface PricedToken extends Erc20Token {
-  // Overrides existing field in TokenDetails. The number of decimals must be
-  // known to estimate the price
-  decimals: number;
-  // Amount of DAI wei equivalent to one unit of this token (10**decimals)
-  usdValue: BigNumber;
-}
-
 export interface ReferenceToken {
   symbol: string;
   decimals: number;
@@ -88,19 +80,4 @@ export function formatUsdValue(
   usdReference: ReferenceToken,
 ): string {
   return formatTokenValue(amount, usdReference.decimals, 2);
-}
-
-export async function appraise(
-  token: Erc20Token,
-  usdReference: ReferenceToken,
-  api: Api,
-): Promise<PricedToken> {
-  const decimals = token.decimals ?? 18;
-  const usd = await usdValue(
-    token,
-    BigNumber.from(10).pow(decimals),
-    usdReference,
-    api,
-  );
-  return { ...token, usdValue: usd, decimals };
 }

--- a/src/tasks/withdraw.ts
+++ b/src/tasks/withdraw.ts
@@ -115,13 +115,18 @@ async function getWithdrawals(
           (balanceUsd.isZero() &&
             !(minValueWei.isZero() && leftoverWei.isZero()))
         ) {
+          const decimals = token.decimals ?? 18;
           consoleLog(
-            `Ignored ${utils.formatUnits(
-              balance,
-              token.decimals ?? 18,
-            )} units of ${token.symbol ?? "unknown token"} (${
-              token.address
-            }) with value ${formatUsdValue(balanceUsd, usdReference)} USD`,
+            `Ignored ${utils.formatUnits(balance, decimals)} units of ${
+              token.symbol ?? "unknown token"
+            } (${token.address}) with value ${formatUsdValue(
+              balanceUsd,
+              usdReference,
+            )} USD${
+              token.decimals === undefined
+                ? ` (the token has no decimals specified in the contract, assuming ${decimals})`
+                : ""
+            }`,
           );
           return null;
         }

--- a/test/tasks/withdraw.test.ts
+++ b/test/tasks/withdraw.test.ts
@@ -1,6 +1,6 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { expect } from "chai";
-import { constants, Contract, utils, Wallet } from "ethers";
+import { BigNumber, constants, Contract, utils, Wallet } from "ethers";
 import hre, { ethers, waffle } from "hardhat";
 import { mock, SinonMock } from "sinon";
 
@@ -163,32 +163,44 @@ describe("Task: withdraw", () => {
         sellToken: usdc.address,
         buyToken: usdReference.address,
         kind: OrderKind.SELL,
-        amount: utils.parseUnits("1", 6),
+        amount: usdcBalance,
       })
       .once()
-      .returns(Promise.resolve(utils.parseUnits("1", usdReference.decimals)));
+      .returns(
+        Promise.resolve(
+          usdcBalance.mul(BigNumber.from(10).pow(usdReference.decimals - 6)),
+        ),
+      );
     apiMock
       .expects("estimateTradeAmount")
       .withArgs({
         sellToken: dai.address,
         buyToken: usdReference.address,
         kind: OrderKind.SELL,
-        amount: utils.parseUnits("1", 18),
+        amount: daiBalance,
       })
       .once()
-      .returns(Promise.resolve(utils.parseUnits("1", usdReference.decimals)));
+      .returns(
+        Promise.resolve(
+          daiBalance.mul(BigNumber.from(10).pow(usdReference.decimals - 18)),
+        ),
+      );
     apiMock
       .expects("estimateTradeAmount")
       .withArgs({
         sellToken: weth.address,
         buyToken: usdReference.address,
         kind: OrderKind.SELL,
-        amount: utils.parseUnits("1", 18),
+        amount: wethBalance,
       })
       .once()
       .returns(
         Promise.resolve(
-          utils.parseUnits("1", usdReference.decimals).mul(ethUsdValue),
+          Promise.resolve(
+            wethBalance
+              .mul(ethUsdValue)
+              .mul(BigNumber.from(10).pow(usdReference.decimals - 18)),
+          ),
         ),
       );
 

--- a/test/tasks/withdrawService.test.ts
+++ b/test/tasks/withdrawService.test.ts
@@ -170,32 +170,42 @@ describe("Task: withdrawService", () => {
         sellToken: usdc.address,
         buyToken: usdReference.address,
         kind: OrderKind.SELL,
-        amount: utils.parseUnits("1", 6),
+        amount: usdcBalance,
       })
       .once()
-      .returns(Promise.resolve(utils.parseUnits("1", usdReference.decimals)));
+      .returns(
+        Promise.resolve(
+          usdcBalance.mul(BigNumber.from(10).pow(usdReference.decimals - 6)),
+        ),
+      );
     apiMock
       .expects("estimateTradeAmount")
       .withArgs({
         sellToken: dai.address,
         buyToken: usdReference.address,
         kind: OrderKind.SELL,
-        amount: utils.parseUnits("1", 18),
+        amount: daiBalance,
       })
       .once()
-      .returns(Promise.resolve(utils.parseUnits("1", usdReference.decimals)));
+      .returns(
+        Promise.resolve(
+          daiBalance.mul(BigNumber.from(10).pow(usdReference.decimals - 18)),
+        ),
+      );
     apiMock
       .expects("estimateTradeAmount")
       .withArgs({
         sellToken: weth.address,
         buyToken: usdReference.address,
         kind: OrderKind.SELL,
-        amount: utils.parseUnits("1", 18),
+        amount: wethBalance,
       })
       .once()
       .returns(
         Promise.resolve(
-          utils.parseUnits("1", usdReference.decimals).mul(ethUsdValue),
+          wethBalance
+            .mul(ethUsdValue)
+            .mul(BigNumber.from(10).pow(usdReference.decimals - 18)),
         ),
       );
 
@@ -372,20 +382,23 @@ describe("Task: withdrawService", () => {
       token: Contract,
       soldAmount: BigNumber,
     ): Promise<void> {
-      const oneUsd = Promise.resolve(
-        utils.parseUnits("1", usdReference.decimals),
-      );
-      // price
+      // value
       apiMock
         .expects("estimateTradeAmount")
         .withArgs({
           sellToken: token.address,
           buyToken: usdReference.address,
           kind: OrderKind.SELL,
-          amount: utils.parseUnits("1", await token.decimals()),
+          amount: soldAmount,
         })
         .once()
-        .returns(oneUsd);
+        .returns(
+          soldAmount.mul(
+            BigNumber.from(10).pow(
+              usdReference.decimals - (await token.decimals()),
+            ),
+          ),
+        ); // stablecoin, so amount in is usd value
       // fee and received amount
       const feeAndQuote: GetFeeAndQuoteSellOutput = {
         feeAmount: constants.Zero,


### PR DESCRIPTION
Computes the value of the current balance while accounting for the price impact of selling all tokens.

This change is needed as all usd value checks are based on a comparison with the usd value, which in the case of very high slippage tokens is currently significantly overinflated.

This has the unintended consequence of making the script harder to use on Rinkeby, as the default reference token is hard to acquire because it has small pools. This means that any threshold limit on Rinkeby should be lower than the size of the pools in order for the script to perform any withdrawal.

### Test plan

Compare the resulting withdrawal table between before and after these changes on mainnet:
```
npx hardhat withdraw --network mainnet --dry-run --receiver 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
```

[before](https://github.com/gnosis/gp-v2-contracts/files/7212440/before.txt)
[after](https://github.com/gnosis/gp-v2-contracts/files/7212441/after.txt)

For example:
- the token `0x0239d3a3485Ec54511beE9d77D92695E443bf060` has very high slippage. Before it had value ~1500usd, now it's valued 3 usd.
- The top 5 tokens by value are mostly unchanged.