### PR TITLE
Do not withdraw token if network fee is too high

### DIFF
--- a/src/tasks/ts/value.ts
+++ b/src/tasks/ts/value.ts
@@ -1,6 +1,6 @@
-import { BigNumber, constants } from "ethers";
+import { BigNumber } from "ethers";
 
-import { Api, ApiError, CallError } from "../../services/api";
+import { Api } from "../../services/api";
 import { OrderKind } from "../../ts";
 import { SupportedNetwork } from "../ts/deployment";
 import { Erc20Token, WRAPPED_NATIVE_TOKEN_ADDRESS } from "../ts/tokens";
@@ -30,33 +30,33 @@ export const REFERENCE_TOKEN: Record<SupportedNetwork, ReferenceToken> = {
   },
 } as const;
 
-export const usdValue = async function (
+export async function usdValue(
   token: Pick<Erc20Token, "symbol" | "address">,
   amount: BigNumber,
   referenceToken: ReferenceToken,
   api: Api,
 ): Promise<BigNumber> {
-  try {
-    return await api.estimateTradeAmount({
-      sellToken: token.address,
-      buyToken: referenceToken.address,
-      amount,
-      kind: OrderKind.SELL,
-    });
-  } catch (e) {
-    if (!(e instanceof Error)) {
-      throw e;
-    }
-    const errorData: ApiError = (e as CallError).apiError ?? {
-      errorType: "script internal error",
-      description: e?.message ?? "no details",
-    };
-    console.log(
-      `Warning: price retrieval failed for token ${token.symbol} (${token.address}): ${errorData.errorType} (${errorData.description})`,
-    );
-    return constants.Zero;
-  }
-};
+  return await api.estimateTradeAmount({
+    sellToken: token.address,
+    buyToken: referenceToken.address,
+    amount,
+    kind: OrderKind.SELL,
+  });
+}
+
+export async function usdValueOfEth(
+  amount: BigNumber,
+  referenceToken: ReferenceToken,
+  network: SupportedNetwork,
+  api: Api,
+): Promise<BigNumber> {
+  return await usdValue(
+    { symbol: "ETH", address: WRAPPED_NATIVE_TOKEN_ADDRESS[network] },
+    amount,
+    referenceToken,
+    api,
+  );
+}
 
 // Format amount so that it has exactly a fixed amount of decimals.
 export function formatTokenValue(

--- a/src/tasks/withdrawService.ts
+++ b/src/tasks/withdrawService.ts
@@ -243,6 +243,7 @@ export async function withdrawAndDump({
     tokens: checkedTokens,
     minValue,
     leftover,
+    maxFeePercent,
     receiver: solver.address,
     authenticator,
     settlement,

--- a/test/tasks/withdrawService.test.ts
+++ b/test/tasks/withdrawService.test.ts
@@ -18,7 +18,10 @@ import { OrderKind, domain, Order, timestamp } from "../../src/ts";
 import { deployTestContracts } from "../e2e/fixture";
 
 import { restoreStandardConsole, useDebugConsole } from "./logging";
-import { tradeTokensForNoFees } from "./withdraw.test";
+import {
+  mockQuerySellingEthForUsd,
+  tradeTokensForNoFees,
+} from "./withdraw.test";
 
 describe("Task: withdrawService", () => {
   let deployer: Wallet;
@@ -163,6 +166,14 @@ describe("Task: withdrawService", () => {
     expect(await weth.balanceOf(receiver.address)).to.deep.equal(
       constants.Zero,
     );
+
+    // query to get eth price for the withdraw script
+    mockQuerySellingEthForUsd({
+      apiMock,
+      amount: utils.parseEther("1"),
+      usdReference,
+      usdValue: utils.parseUnits(ethUsdValue.toString(), usdReference.decimals),
+    });
 
     apiMock
       .expects("estimateTradeAmount")
@@ -415,6 +426,14 @@ describe("Task: withdrawService", () => {
         .returns(Promise.resolve(feeAndQuote));
     }
 
+    // query to get eth price for the withdraw script
+    mockQuerySellingEthForUsd({
+      apiMock,
+      amount: utils.parseEther("1"),
+      usdReference,
+      usdValue: constants.Zero,
+    });
+
     await setupExpectations(dai, daiBalance);
     await setupExpectations(usdc, usdcBalance);
 
@@ -485,6 +504,14 @@ describe("Task: withdrawService", () => {
     hasSoldUsdc = false;
     hasSoldDai = false;
     hasSoldWeth = false;
+
+    // query to get eth price for the withdraw script
+    mockQuerySellingEthForUsd({
+      apiMock,
+      amount: utils.parseEther("1"),
+      usdReference,
+      usdValue: constants.Zero,
+    });
 
     await setupExpectations(weth, wethBalance);
     await setupExpectations(dai, daiBalance.sub(42));


### PR DESCRIPTION
The withdraw scripts currently lets the user decide whether to execute the transaction: before asking for confirmation to send the transaction onchain, it shows a summary of the transaction cost and of the withdrawn amount for the user to decide if the transaction is worth it. There are two pitfalls:
1. The withdraw script is used by the withdraw service without any confirmation. The parameter `min-value` should be set so that the withdrawn amount is significantly larger than the gas cost of withdrawing a single token, however a very large gas spike might still cause a very expensive withdraw transaction to happen.
2. Some tokens are more expensive than other to withdraw, and a user might want to keep expensive tokens in the contract for longer.

The proposed solution is to add a new flag in the withdraw script to exclude tokens that cost too much to withdraw compared to the withdrawn amount.
This flag will be used by default by the withdraw service and will be the same flag `max-fee-percent` that is also used in the dump part of the withdraw service.

### Test Plan

New unit test. Running the script on mainnet to double check:

<details><summary>npx hardhat withdraw --network mainnet --dry-run --receiver 0x6C642caFCbd9d8383250bb25F67aE409147f78b2 --max-fee-percent 5</summary>

```
Using account 0x627306090abaB3A6e1400e9345bC60c78a8BEf57
Current account is not a solver. Only a solver can withdraw funds from the settlement contract.
Recovering list of traded tokens...
Failed to process events from block 12593265 to 13287616, reducing range...
Processed events from block 12593265 to 12940440
Failed to process events from block 12940441 to 13287616, reducing range...
Failed to process events from block 12940441 to 13114028, reducing range...
Processed events from block 12940441 to 13027234
Processed events from block 13027235 to 13114028
Failed to process events from block 13114029 to 13287616, reducing range...
Processed events from block 13114029 to 13200822
Processed events from block 13200823 to 13287616
Warning: price retrieval failed for token mLOOT (0x2772b0dd22381932b104d683e73C5ecb5A3A2408): NoLiquidity (not enough liquidity)
Warning: price retrieval failed for token DYDX (0x92d6c1e31e14520e676a687f0a93788b716beff5): UnsupportedToken (Token address 0x92d6c1e31e14520e676a687f0a93788b716beff5)
Warning: price retrieval failed for token AUR-0819 (0x94183cfAcFacA73BA36A12a4cd7775fdAe5FED69): NoLiquidity (not enough liquidity)
Warning: price retrieval failed for token SPO (0xcbE771323587EA16dACB6016e269D7F08A7ACC4E): UnsupportedToken (Token address 0xcbe771323587ea16dacb6016e269d7f08a7acc4e)
Ignored 60.68121172680924305 units of mLOOT (0x2772b0dd22381932b104d683e73C5ecb5A3A2408) with value 0.00 USD, the gas cost of including this transaction is too high (Infinity% of the withdrawn amount)
Ignored 1011.769439121105669497 units of DYDX (0x92d6c1e31e14520e676a687f0a93788b716beff5) with value 0.00 USD, the gas cost of including this transaction is too high (Infinity% of the withdrawn amount)
Ignored 0.000000000000000214 units of AUR-0819 (0x94183cfAcFacA73BA36A12a4cd7775fdAe5FED69) with value 0.00 USD, the gas cost of including this transaction is too high (Infinity% of the withdrawn amount)
Ignored 1191.505712853700876039 units of SPO (0xcbE771323587EA16dACB6016e269D7F08A7ACC4E) with value 0.00 USD, the gas cost of including this transaction is too high (Infinity% of the withdrawn amount)
Ignored 579.836562835907413221 units of FERA (0x539f3615c1dbafa0d008d87504667458acbd16fa) with value 0.00 USD, the gas cost of including this transaction is too high (8845124114821118976.00% of the withdrawn amount)
Ignored 130.967284551957852685 units of HAKKA (0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd) with value 0.00 USD, the gas cost of including this transaction is too high (879404308956535808.00% of the withdrawn amount)
Ignored 6.524429176605093888 units of buidl_1 (0x7b123f53421b1bf8533339bfbdc7c98aa94163db) with value 0.00 USD, the gas cost of including this transaction is too high (816469044051588608.00% of the withdrawn amount)
Ignored 110.492339043040243931 units of LIX (0xd0345D30FD918D7682398ACbCdf139C808998709) with value 0.00 USD, the gas cost of including this transaction is too high (4685286467256004.00% of the withdrawn amount)
Ignored 0.000000000000026555 units of APED (0xFa898efdB91E35BD311c45b9B955F742b6719aa2) with value 0.00 USD, the gas cost of including this transaction is too high (3518958757386227.00% of the withdrawn amount)
Ignored 0.000000084897 units of HANU (0x72e5390edb7727e3d4e3436451dadaff675dbcc0) with value 0.00 USD, the gas cost of including this transaction is too high (3616377585339749.50% of the withdrawn amount)
Ignored 0.000000000000756184 units of CUR (0x13339fd07934cd674269726edf3b5ccee9dd93de) with value 0.00 USD, the gas cost of including this transaction is too high (2943017899623312.00% of the withdrawn amount)
Ignored 0.000000000000000004 units of BAYC (0xEA47B64e1BFCCb773A0420247C0aa0a3C1D2E5C5) with value 0.00 USD, the gas cost of including this transaction is too high (3396954874759752.00% of the withdrawn amount)
Ignored 0.000000000000365081 units of 1MIL (0xa4ef4b0b23c1fc81d3f9ecf93510e64f58a4a016) with value 0.00 USD, the gas cost of including this transaction is too high (1741697923862940.25% of the withdrawn amount)
Ignored 0.003760252240143925 units of TALK (0xCAabCaA4ca42e1d86dE1a201c818639def0ba7A7) with value 0.00 USD, the gas cost of including this transaction is too high (966432740577181.25% of the withdrawn amount)
Ignored 0.000000000000000002 units of GLYPH (0xD70240Dd62F4ea9a6A2416e0073D72139489d2AA) with value 0.00 USD, the gas cost of including this transaction is too high (733984507513088.25% of the withdrawn amount)
Ignored 0.000000000016105597 units of FET (0xaea46a60368a7bd060eec7df8cba43b7ef41ad85) with value 0.00 USD, the gas cost of including this transaction is too high (69953769209831.24% of the withdrawn amount)
Ignored 0.000000000282403975 units of UNT (0x8d610E20481F4C4f3aCB87bBa9c46BeF7795fdFe) with value 0.00 USD, the gas cost of including this transaction is too high (51258669881207.10% of the withdrawn amount)
Ignored 0.000000000427314658 units of Sunder (0xbDbf245c690d54b67C6e610A28486A2C6dE08bE6) with value 0.00 USD, the gas cost of including this transaction is too high (44351106451760.23% of the withdrawn amount)
Ignored 0.00000000022344501 units of GAME (0x63f88a2298a5c4aee3c216aa6d926b184a4b2437) with value 0.00 USD, the gas cost of including this transaction is too high (28927532356889.67% of the withdrawn amount)
Ignored 0.000000000308651174 units of NFTL (0xe7F72Bc0252cA7B16dBb72eEee1AfcDb2429F2DD) with value 0.00 USD, the gas cost of including this transaction is too high (33991195805731.73% of the withdrawn amount)
Ignored 0.000000019300963166 units of ZIPT (0xedd7c94fd7b4971b916d15067bc454b9e1bad980) with value 0.00 USD, the gas cost of including this transaction is too high (14479012139907.35% of the withdrawn amount)
Ignored 0.000000004622751073 units of YLDY (0x88cb253d4C8caB8CDF7948A9251Db85a13669E23) with value 0.00 USD, the gas cost of including this transaction is too high (9868030226436.09% of the withdrawn amount)
Ignored 0.012215139201153886 units of SCAT (0x8424C5aC326834B404742de0067bCb654E86BE30) with value 0.00 USD, the gas cost of including this transaction is too high (11744989976.69% of the withdrawn amount)
Ignored 28098572.095295618978108857 units of RIGHT (0xbfA3Fa772ea6d1ed0808160c9B705875ca4123a0) with value 0.00 USD, the gas cost of including this transaction is too high (1344517358.48% of the withdrawn amount)
Ignored 113.652027101196300572 units of JPYC (0x2370f9d504c7a6E775bf6E14B3F12846b594cD53) with value 0.00 USD, the gas cost of including this transaction is too high (1557671.44% of the withdrawn amount)
Ignored 0.106401631953537464 units of COR (0x9C2dc0c3CC2BADdE84B0025Cf4df1c5aF288D835) with value 0.00 USD, the gas cost of including this transaction is too high (1317197.25% of the withdrawn amount)
Ignored 0.013440121305991811 units of ALN (0x8185bc4757572da2a610f887561c32298f1a5748) with value 0.00 USD, the gas cost of including this transaction is too high (1285689.09% of the withdrawn amount)
Ignored 356587226221.040865291006045931 units of DUNG (0xDADA00A9C23390112D08a1377cc59f7d03D9df55) with value 0.00 USD, the gas cost of including this transaction is too high (866172.36% of the withdrawn amount)
Ignored 26.518089329375590104 units of AAA (0x8C6bf16C273636523C29Db7DB04396143770F6A0) with value 0.00 USD, the gas cost of including this transaction is too high (562653.84% of the withdrawn amount)
Ignored 0.111697851702785858 units of NEC (0xcc80c051057b774cd75067dc48f8987c4eb97a5e) with value 0.00 USD, the gas cost of including this transaction is too high (261638.71% of the withdrawn amount)
Ignored 0.077790838218252278 units of ROBOT (0xfb5453340c03db5ade474b27e68b6a9c6b2823eb) with value 0.01 USD, the gas cost of including this transaction is too high (72057.10% of the withdrawn amount)
Ignored 527.257141193482960896 units of SAKE (0x066798d9ef0833ccc719076dab77199ecbd178b0) with value 0.01 USD, the gas cost of including this transaction is too high (54625.52% of the withdrawn amount)
Ignored 0.78406128 units of AGS (0xdB2F2bCCe3efa95EDA95a233aF45F3e0d4f00e2A) with value 0.03 USD, the gas cost of including this transaction is too high (22226.32% of the withdrawn amount)
Ignored 4.987702138829797517 units of MTGY (0x025c9f1146d4d94F8F369B9d98104300A3c8ca23) with value 0.06 USD, the gas cost of including this transaction is too high (12829.71% of the withdrawn amount)
Ignored 2.700964023478490595 units of TONE (0x2ab6bb8408ca3199b8fa6c92d5b455f820af03c4) with value 0.07 USD, the gas cost of including this transaction is too high (11656.13% of the withdrawn amount)
Ignored 0.04898916 units of INXT (0xa8006c4ca56f24d6836727d106349320db7fef82) with value 0.09 USD, the gas cost of including this transaction is too high (9722.56% of the withdrawn amount)
Ignored 0.149881351597241451 units of BYN (0x4Bb3205bf648B7F59EF90Dee0F1B62F6116Bc7ca) with value 0.09 USD, the gas cost of including this transaction is too high (11790.40% of the withdrawn amount)
Ignored 0.806003541838746415 units of PRIME (0xE59064a8185Ed1Fca1D17999621eFedfab4425c9) with value 0.17 USD, the gas cost of including this transaction is too high (4652.20% of the withdrawn amount)
Ignored 0.46628881 units of NEX (0xE2dc070524A6e305ddB64d8513DC444B6a1ec845) with value 0.32 USD, the gas cost of including this transaction is too high (2534.37% of the withdrawn amount)
Ignored 0.22905569433208644 units of LPL (0x99295f1141d58a99e939f7be6bbe734916a875b8) with value 0.68 USD, the gas cost of including this transaction is too high (1212.93% of the withdrawn amount)
Ignored 15274.49618415618971851 units of FGLD (0x509eeCe4793B46E4d81c0D4Cb0A5A0c26C45E304) with value 0.70 USD, the gas cost of including this transaction is too high (1192.67% of the withdrawn amount)
Ignored 1.0988 units of GCR (0x6307B25A665Efc992EC1C1bC403c38F3dDd7c661) with value 0.88 USD, the gas cost of including this transaction is too high (991.17% of the withdrawn amount)
Ignored 49.083595376356841042 units of CHART (0x1d37986f252d0e349522ea6c3b98cb935495e63e) with value 0.88 USD, the gas cost of including this transaction is too high (1006.15% of the withdrawn amount)
Ignored 14.03887826108449661 units of STR (0x84Bb947fcEdba6B9C7DCEad42dF07e113bb03007) with value 1.13 USD, the gas cost of including this transaction is too high (732.65% of the withdrawn amount)
Ignored 7.41212277768805386 units of HID (0xB14eBF566511B9e6002bB286016AB2497B9b9c9D) with value 1.25 USD, the gas cost of including this transaction is too high (662.66% of the withdrawn amount)
Ignored 3898719065.765940030076399018 units of EROTICA (0xC1Fa06e8596c3FA98cCd2113C38B6b60b6eFa00d) with value 1.51 USD, the gas cost of including this transaction is too high (546.42% of the withdrawn amount)
Ignored 1.375515974410149228 units of ARIA20 (0xeDF6568618A00C6F0908Bf7758A16F76B6E04aF9) with value 1.53 USD, the gas cost of including this transaction is too high (573.13% of the withdrawn amount)
Ignored 2.115415913594273489 units of UWL (0xdbDD6F355A37b94e6C7D32fef548e98A280B8Df5) with value 1.53 USD, the gas cost of including this transaction is too high (573.67% of the withdrawn amount)
Ignored 49.841050964715955623 units of wLITI (0x0b63128C40737B13647552e0C926bCFEccC35f93) with value 1.61 USD, the gas cost of including this transaction is too high (523.53% of the withdrawn amount)
Ignored 218.377625280194324464 units of DONUT (0xc0f9bd5fa5698b6505f643900ffa515ea5df54a9) with value 1.69 USD, the gas cost of including this transaction is too high (968.77% of the withdrawn amount)
Ignored 35.819367723012129286 units of FYZ (0x6bff2fe249601ed0db3a87424a2e923118bb0312) with value 2.14 USD, the gas cost of including this transaction is too high (410.91% of the withdrawn amount)
Ignored 11.91581114448578178 units of GERO (0x3431f91b3a388115f00c5ba9fdb899851d005fb5) with value 2.21 USD, the gas cost of including this transaction is too high (420.62% of the withdrawn amount)
Ignored 10198.256479804428648448 units of ELT (0x380291A9A8593B39f123cF39cc1cc47463330b1F) with value 2.60 USD, the gas cost of including this transaction is too high (364.21% of the withdrawn amount)
Ignored 4.238243144930714246 units of uTVL-0621 (0x21ae9E080a53Ab98CC1266Ed1c8CC27FFD3256D5) with value 2.75 USD, the gas cost of including this transaction is too high (299.94% of the withdrawn amount)
Ignored 7569.933423857684298242 units of PAINT (0x4c6ec08cf3fc987c6c4beb03184d335a2dfc4042) with value 2.83 USD, the gas cost of including this transaction is too high (291.46% of the withdrawn amount)
Ignored 186.724588385645380884 units of DUST (0x424242115B5BbDc12A1f5C06Dd8DD0dDd03c321D) with value 2.90 USD, the gas cost of including this transaction is too high (290.56% of the withdrawn amount)
Ignored 485.711864463854617967 units of BILL (0x0239d3a3485Ec54511beE9d77D92695E443bf060) with value 2.98 USD, the gas cost of including this transaction is too high (282.99% of the withdrawn amount)
Ignored 5.0 units of LEND (0x80fb784b7ed66730e8b1dbd9820afd29931aab03) with value 2.98 USD, the gas cost of including this transaction is too high (300.21% of the withdrawn amount)
Ignored 3.97060602348528192 units of wCRES (0xa0afaa285ce85974c3c881256cb7f225e3a1178a) with value 3.76 USD, the gas cost of including this transaction is too high (219.03% of the withdrawn amount)
Ignored 295.004684548130984896 units of SPANK (0x42d6622dece394b54999fbd73d108123806f6a18) with value 4.02 USD, the gas cost of including this transaction is too high (205.13% of the withdrawn amount)
Ignored 13.264777401291706634 units of UNCLE (0x2d94408F45b2E6Fa9EFfe1068b75116187c4E388) with value 4.08 USD, the gas cost of including this transaction is too high (206.99% of the withdrawn amount)
Ignored 99039875.469402363658819119 units of STARS (0x7CCFeEF4F0Ff48B0E0abD19bBBebae90939f180D) with value 4.12 USD, the gas cost of including this transaction is too high (205.11% of the withdrawn amount)
Ignored 127.922176227226245599 units of LONDON (0x491D6b7D6822d5d4BC88a1264E1b47791Fd8E904) with value 4.34 USD, the gas cost of including this transaction is too high (193.74% of the withdrawn amount)
Ignored 86.907760792767417263 units of RING (0x9469d013805bffb7d3debe5e7839237e535ec483) with value 4.35 USD, the gas cost of including this transaction is too high (241.28% of the withdrawn amount)
Ignored 403.502412019860832256 units of OLY (0x6595b8fd9c920c81500dca94e53cdc712513fb1f) with value 4.36 USD, the gas cost of including this transaction is too high (226.57% of the withdrawn amount)
Ignored 50.276381283986104728 units of PCNT (0x657B83A0336561C8f64389a6f5aDE675C04b0C3b) with value 4.75 USD, the gas cost of including this transaction is too high (285.63% of the withdrawn amount)
Ignored 100.0 units of APN (0xd4342a57eCf2Fe7ffA37c33cb8f63b1500e575E6) with value 4.81 USD, the gas cost of including this transaction is too high (171.58% of the withdrawn amount)
Ignored 5000.0 units of HGT (0xba2184520A1cC49a6159c57e61E1844E085615B6) with value 5.41 USD, the gas cost of including this transaction is too high (790.18% of the withdrawn amount)
Ignored 11.78491655902489873 units of ETHIX (0xFd09911130e6930Bf87F2B0554c44F400bD80D3e) with value 5.42 USD, the gas cost of including this transaction is too high (183.01% of the withdrawn amount)
Ignored 4.073794759887804297 units of POWER (0xf2f9a7e93f845b3ce154efbeb64fb9346fcce509) with value 5.47 USD, the gas cost of including this transaction is too high (152.26% of the withdrawn amount)
Ignored 323.920243369901686784 units of PCHS (0xa4C6984E817c086Ddc3EBAEedBdcc01469586918) with value 5.84 USD, the gas cost of including this transaction is too high (142.00% of the withdrawn amount)
Ignored 23.104273376638800628 units of ROYAL (0xC0844FDF1bcbDE59a3AF0859455D964D350A2cb6) with value 5.88 USD, the gas cost of including this transaction is too high (149.21% of the withdrawn amount)
Ignored 1.164994812468763544 units of DEUS (0x3b62F3820e0B035cc4aD602dECe6d796BC325325) with value 5.93 USD, the gas cost of including this transaction is too high (140.00% of the withdrawn amount)
Ignored 43.56448534 units of PAN (0x536381a8628dBcC8C70aC9A30A7258442eAb4c92) with value 5.96 USD, the gas cost of including this transaction is too high (148.24% of the withdrawn amount)
Ignored 611.787667938254636869 units of SHARK (0x232AFcE9f1b3AAE7cb408e482E847250843DB931) with value 5.98 USD, the gas cost of including this transaction is too high (137.36% of the withdrawn amount)
Ignored 0.210899398394673467 units of Auction (0xa9b1eb5908cfc3cdf91f9b8b3a74108598009096) with value 6.34 USD, the gas cost of including this transaction is too high (131.18% of the withdrawn amount)
Ignored 50.22221411572760576 units of XIO (0x0f7f961648ae6db43c75663ac7e5414eb79b5704) with value 6.65 USD, the gas cost of including this transaction is too high (132.20% of the withdrawn amount)
Ignored 0.028710167242720865 units of GNO (0x6810e776880c02933d47db1b9fc05908e5386b96) with value 7.32 USD, the gas cost of including this transaction is too high (60.35% of the withdrawn amount)
Ignored 1.8147678032049659 units of VXV (0x7D29A64504629172a429e64183D6673b9dAcbFCe) with value 7.48 USD, the gas cost of including this transaction is too high (111.53% of the withdrawn amount)
Ignored 712414730.632752345799607055 units of KUMA (0xb525Ecee288B99216CD481C56b6EFbdbE9bF90b5) with value 7.88 USD, the gas cost of including this transaction is too high (127.01% of the withdrawn amount)
Ignored 15.2204 units of JULIEN (0xe6710e0CdA178f3D921f456902707B0d4C4A332B) with value 8.39 USD, the gas cost of including this transaction is too high (99.17% of the withdrawn amount)
Ignored 450639295.32832095310332973 units of FDOGE (0x212Ceb1923F5ab3393Ba4d1B8f14761179D07FbA) with value 8.45 USD, the gas cost of including this transaction is too high (110.83% of the withdrawn amount)
Ignored 11.400001969814157404 units of SARCO (0x7697b462a7c4ff5f8b55bdbc2f4076c2af9cf51a) with value 8.47 USD, the gas cost of including this transaction is too high (97.62% of the withdrawn amount)
Ignored 0.050510642800299194 units of UDT (0x90de74265a416e1393a450752175aed98fe11517) with value 8.56 USD, the gas cost of including this transaction is too high (126.88% of the withdrawn amount)
Ignored 6.208444051368098652 units of MATH (0x08d967bb0134f2d07f7cfb6e246680c53927dd30) with value 8.88 USD, the gas cost of including this transaction is too high (99.66% of the withdrawn amount)
Ignored 683.33558226 units of SWTH (0xB4371dA53140417CBb3362055374B10D97e420bB) with value 9.38 USD, the gas cost of including this transaction is too high (93.13% of the withdrawn amount)
Ignored 227.064866780502537545 units of DGCL (0x63B8b7d4A3EFD0735c4BFFBD95B332a55e4eB851) with value 9.71 USD, the gas cost of including this transaction is too high (91.21% of the withdrawn amount)
Ignored 31.953982773633903667 units of SUM (0x043C308BB8a5aE96D0093444be7f56459F1340b1) with value 9.82 USD, the gas cost of including this transaction is too high (90.40% of the withdrawn amount)
Ignored 7839.96872140604833792 units of NPXS (0xa15c7ebe1f07caf6bff097d8a589fb8ac49ae5b3) with value 10.11 USD, the gas cost of including this transaction is too high (92.75% of the withdrawn amount)
Ignored 44.2482972307743232 units of GYSR (0xbea98c05eeae2f3bc8c3565db7551eb738c8ccab) with value 10.26 USD, the gas cost of including this transaction is too high (80.38% of the withdrawn amount)
Ignored 7.777934895 units of MARK (0x67c597624b17b16fb77959217360b7cd18284253) with value 10.48 USD, the gas cost of including this transaction is too high (83.62% of the withdrawn amount)
Ignored 103.05866447510429424 units of SWISE (0x48c3399719b582dd63eb5aadf12a40b4c3f52fa2) with value 11.10 USD, the gas cost of including this transaction is too high (92.87% of the withdrawn amount)
Ignored 8.22577741748372992 units of KNC (0xdefa4e8a7bcba345f687a2f1456f5edd9ce97202) with value 12.05 USD, the gas cost of including this transaction is too high (81.78% of the withdrawn amount)
Ignored 2269.891037686408937472 units of BOLT (0xD5930C307d7395Ff807F2921F12C5EB82131a789) with value 12.23 USD, the gas cost of including this transaction is too high (67.82% of the withdrawn amount)
Ignored 11729005.820201017237605337 units of FREE (0x2F141Ce366a2462f02cEA3D12CF93E4DCa49e4Fd) with value 12.42 USD, the gas cost of including this transaction is too high (66.82% of the withdrawn amount)
Ignored 77.816925215666290688 units of ANGEL (0x6C7B97c7e09E790D161769a52F155125FAc6d5A1) with value 12.58 USD, the gas cost of including this transaction is too high (66.17% of the withdrawn amount)
Ignored 1668.0401813260924 units of MINI (0x4d953cf077c0c95ba090226e59a18fcf97db44ec) with value 12.61 USD, the gas cost of including this transaction is too high (89.68% of the withdrawn amount)
Ignored 4.157576967440019053 units of PIPT (0x26607ac599266b21d13c7acf7942c7701a8b699c) with value 13.28 USD, the gas cost of including this transaction is too high (64.45% of the withdrawn amount)
Ignored 586.128890433677676166 units of FOUR (0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0) with value 13.45 USD, the gas cost of including this transaction is too high (65.94% of the withdrawn amount)
Ignored 13.135307243866978529 units of UNIDX (0x95b3497bbcccc46a8f45f5cf54b0878b39f8d96c) with value 13.79 USD, the gas cost of including this transaction is too high (60.23% of the withdrawn amount)
Ignored 141.706143819848040448 units of BFLY (0xf680429328caaacabee69b7a9fdb21a71419c063) with value 14.05 USD, the gas cost of including this transaction is too high (189.00% of the withdrawn amount)
Ignored 25.164514229520384 units of DFL (0x09ce2B746C32528B7d864A1e3979Bd97d2f095AB) with value 14.16 USD, the gas cost of including this transaction is too high (67.42% of the withdrawn amount)
Ignored 1290.156642201881477367 units of LKT (0xd9b89EEe86B15634c70CaB51BAF85615A4AB91a1) with value 14.39 USD, the gas cost of including this transaction is too high (58.74% of the withdrawn amount)
Ignored 9751.256569352046675366 units of ACE (0xBDb4A359a506b0997A257dA767308436C7340245) with value 14.82 USD, the gas cost of including this transaction is too high (59.53% of the withdrawn amount)
Ignored 2708.115538813364731904 units of MOZ (0x7BD82B320EbC28D8EB3C4F5Fa2af7B14dA5b90C3) with value 15.18 USD, the gas cost of including this transaction is too high (64.90% of the withdrawn amount)
Ignored 893.722970062494892032 units of IDV (0x92Ec47DF1AA167806dFa4916D9Cfb99da6953b8F) with value 15.51 USD, the gas cost of including this transaction is too high (53.42% of the withdrawn amount)
Ignored 17.194040130827242898 units of yveCRV-DAO (0xc5bddf9843308380375a611c18b50fb9341f502a) with value 15.80 USD, the gas cost of including this transaction is too high (131.08% of the withdrawn amount)
Ignored 3371.52017629828559614 units of dKUMA (0x3f5dd1A1538a4F9f82E543098f01F22480B0A3a8) with value 15.95 USD, the gas cost of including this transaction is too high (52.01% of the withdrawn amount)
Ignored 169.99457092973111297 units of LOOM (0xa4e8c3ec456107ea67d3075bf9e3df3a75823db0) with value 16.32 USD, the gas cost of including this transaction is too high (50.97% of the withdrawn amount)
Ignored 301.319292322450243584 units of SLM (0x07a0AD7a9dfc3854466F8F29A173bf04bbA5686e) with value 16.64 USD, the gas cost of including this transaction is too high (54.22% of the withdrawn amount)
Ignored 403.242734015788474923 units of OBOT (0xeDADeB5fAa413e6c8623461849DFD0B7C3790c32) with value 16.67 USD, the gas cost of including this transaction is too high (49.80% of the withdrawn amount)
Ignored 0.328836621784915497 units of DOKI (0x9ceb84f92a0561fa3cc4132ab9c0b76a59787544) with value 16.70 USD, the gas cost of including this transaction is too high (62.74% of the withdrawn amount)
Ignored 1295118.434606336706609152 units of MILK (0x66D1B01c0Fd7c2D8718F0997494b53Ff5C485688) with value 17.03 USD, the gas cost of including this transaction is too high (48.53% of the withdrawn amount)
Ignored 1575.873448202972430336 units of SYN (0x1695936d6a953df699c38ca21c2140d497c08bd9) with value 17.04 USD, the gas cost of including this transaction is too high (48.46% of the withdrawn amount)
Ignored 24346850.375833116750297414 units of COGE (0xC382e04099A435439725BB40647e2B32dC136806) with value 17.37 USD, the gas cost of including this transaction is too high (47.88% of the withdrawn amount)
Ignored 5338.401413992523817991 units of SGLD (0x3ea6bAe5C10FF3F99925bDf29fd3F8bCae5aaA66) with value 17.53 USD, the gas cost of including this transaction is too high (47.03% of the withdrawn amount)
Ignored 3379.602983305784328192 units of STC (0x15b543e986b8c34074dfc9901136d9355a537e7e) with value 17.59 USD, the gas cost of including this transaction is too high (46.79% of the withdrawn amount)
Ignored 1380.417984546300493824 units of DSD (0xbd2f0cd039e0bfcf88901c98c0bfac5ab27566e3) with value 17.64 USD, the gas cost of including this transaction is too high (47.54% of the withdrawn amount)
Ignored 73.186157700750880357 units of Nsure (0x20945ca1df56d237fd40036d47e866c7dccd2114) with value 17.82 USD, the gas cost of including this transaction is too high (52.25% of the withdrawn amount)
Ignored 93.366801673492464724 units of SATA (0x3ebb4A4e91Ad83BE51F8d596533818b246F4bEe1) with value 17.90 USD, the gas cost of including this transaction is too high (47.17% of the withdrawn amount)
Ignored 33.183973268417375636 units of OS (0xFdB29741F239a2406AE287913Ef12415160378d3) with value 18.32 USD, the gas cost of including this transaction is too high (62.34% of the withdrawn amount)
Ignored 1.720601277927602176 units of TOSHI (0xF136D7b0B7AE5b86D21E7B78DFA95375a7360f19) with value 18.37 USD, the gas cost of including this transaction is too high (45.01% of the withdrawn amount)
Ignored 751.232457556418809814 units of GOLD (0x150b0b96933B75Ce27af8b92441F8fB683bF9739) with value 18.99 USD, the gas cost of including this transaction is too high (44.03% of the withdrawn amount)
Ignored 1582586.431052299805167939 units of PUSSY (0x9196E18Bc349B1F64Bc08784eaE259525329a1ad) with value 19.06 USD, the gas cost of including this transaction is too high (43.48% of the withdrawn amount)
Ignored 0.327917562967830272 units of NYAN-2 (0xbF4a9A37EcFc21825011285222c36aB35De51F14) with value 19.51 USD, the gas cost of including this transaction is too high (52.92% of the withdrawn amount)
Ignored 1.209339946315570603 units of APING (0xEC02F6E35183D46Da66c55F2aaC1aD6F45474a8c) with value 19.65 USD, the gas cost of including this transaction is too high (42.01% of the withdrawn amount)
Ignored 1928.643059657587294208 units of ELX (0x9048c33c7BaE0bbe9ad702b17B4453a83900D154) with value 19.67 USD, the gas cost of including this transaction is too high (59.90% of the withdrawn amount)
Ignored 0.258081813372984618 units of DEFI5 (0xfa6de2697d59e88ed7fc4dfe5a33dac43565ea41) with value 20.17 USD, the gas cost of including this transaction is too high (50.07% of the withdrawn amount)
Ignored 0.000830709770716639 units of CLOCK (0xA4e4fF5A3AeA352378a3bFefEf13765130909376) with value 20.95 USD, the gas cost of including this transaction is too high (58.00% of the withdrawn amount)
Ignored 35901.970025 units of FNT (0xdc5864ede28bd4405aa04d93e05a0531797d9d59) with value 20.97 USD, the gas cost of including this transaction is too high (40.15% of the withdrawn amount)
Ignored 86.324186616293028958 units of DGLD (0x6A55B1105497CE7939349f83cFE8b966845b1eB8) with value 21.26 USD, the gas cost of including this transaction is too high (39.61% of the withdrawn amount)
Ignored 0.149013502820697506 units of SHEESHA (0x232FB065D9d24c34708eeDbF03724f2e95ABE768) with value 21.26 USD, the gas cost of including this transaction is too high (39.10% of the withdrawn amount)
Ignored 9.645007511592385213 units of SRSC20 (0x5d98030ee646e6b3f25425C31c038310696616EA) with value 21.41 USD, the gas cost of including this transaction is too high (49.18% of the withdrawn amount)
Ignored 20.679013067757644289 units of ERC20-EPK (0xDaF88906aC1DE12bA2b1D2f7bfC94E9638Ac40c4) with value 21.44 USD, the gas cost of including this transaction is too high (38.52% of the withdrawn amount)
Ignored 77.285336360121382107 units of OPEN (0x69e8b9528cabda89fe846c67675b5d73d463a916) with value 21.62 USD, the gas cost of including this transaction is too high (44.15% of the withdrawn amount)
Ignored 105.975908303517138944 units of BAG (0x28a06c02287e657ec3f8e151a13c36a1d43814b0) with value 21.97 USD, the gas cost of including this transaction is too high (45.86% of the withdrawn amount)
Ignored 236.396776871207633731 units of CLV (0x80C62FE4487E1351b47Ba49809EBD60ED085bf52) with value 22.21 USD, the gas cost of including this transaction is too high (40.34% of the withdrawn amount)
Ignored 186.648732368698041468 units of DoTx (0xFAb5a05C933f1A2463E334E011992E897D56eF0a) with value 22.63 USD, the gas cost of including this transaction is too high (39.59% of the withdrawn amount)
Ignored 2.053941 units of ALICE (0xac51066d7bec65dc4589368da368b212745d63e8) with value 22.64 USD, the gas cost of including this transaction is too high (36.42% of the withdrawn amount)
Ignored 4.754898463335977984 units of PLU (0xd8912c10681d8b21fd3742244f44658dba12264e) with value 22.91 USD, the gas cost of including this transaction is too high (35.92% of the withdrawn amount)
Ignored 74.29627912 units of CVC (0x41e5560054824ea6b0732e656e3ad64e20e94e45) with value 23.06 USD, the gas cost of including this transaction is too high (36.10% of the withdrawn amount)
Ignored 14.1279953825306112 units of DIA (0x84ca8bc7997272c7cfb4d0cd3d55cd942b3c9419) with value 24.52 USD, the gas cost of including this transaction is too high (33.83% of the withdrawn amount)
Ignored 11738.960482837247180909 units of CHIZ (0x5c761c1a21637362374204000e383204d347064C) with value 26.21 USD, the gas cost of including this transaction is too high (32.12% of the withdrawn amount)
Ignored 44146343.688493595879420672 units of ETHM (0x340eF83Ec8560892168D4062720F030460468656) with value 26.63 USD, the gas cost of including this transaction is too high (31.97% of the withdrawn amount)
Ignored 0.022823882 units of xFUND (0x892a6f9df0147e5f079b0993f486f9aca3c87881) with value 26.81 USD, the gas cost of including this transaction is too high (30.91% of the withdrawn amount)
Ignored 2.210010662757754368 units of DEXE (0xde4ee8057785a7e8e800db58f9784845a5c2cbd6) with value 26.86 USD, the gas cost of including this transaction is too high (102.29% of the withdrawn amount)
Ignored 10154977850.103436166724103403 units of SHIH (0x841fb148863454a3b3570f515414759be9091465) with value 27.13 USD, the gas cost of including this transaction is too high (30.51% of the withdrawn amount)
Ignored 26.410515689523202863 units of yvBOOST (0x9d409a0A012CFbA9B15F6D4B36Ac57A46966Ab9a) with value 27.36 USD, the gas cost of including this transaction is too high (32.49% of the withdrawn amount)
Ignored 0.097725132824007632 units of rKSM (0x3c3842c4d3037Ae121d69eA1e7a0b61413BE806C) with value 27.44 USD, the gas cost of including this transaction is too high (32.14% of the withdrawn amount)
Ignored 1665.99 units of TEL (0x467bccd9d29f223bce8043b84e8c8b282827790f) with value 27.49 USD, the gas cost of including this transaction is too high (30.20% of the withdrawn amount)
Ignored 25.784923786515078402 units of YLA (0x9ba60bA98413A60dB4C651D4afE5C937bbD8044B) with value 27.90 USD, the gas cost of including this transaction is too high (36.47% of the withdrawn amount)
Ignored 65.618105289939375351 units of SGT (0x84810bcf08744d5862b8181f12d17bfd57d3b078) with value 28.45 USD, the gas cost of including this transaction is too high (33.45% of the withdrawn amount)
Ignored 3.182574954404298711 units of DFIO (0xeE3b9B531F4C564c70e14B7b3BB7D516f33513ff) with value 28.70 USD, the gas cost of including this transaction is too high (28.93% of the withdrawn amount)
Ignored 28.681221200598458396 units of SALE (0xF063fE1aB7a291c5d06a86e14730b00BF24cB589) with value 28.72 USD, the gas cost of including this transaction is too high (31.10% of the withdrawn amount)
Ignored 6394.073559567993667584 units of MCX (0xd15ecdcf5ea68e3995b2d0527a0ae0a3258302f8) with value 29.08 USD, the gas cost of including this transaction is too high (15.58% of the withdrawn amount)
Ignored 1046.808875733197389824 units of MNY (0xA6F7645ed967FAF708A614a2fcA8D4790138586f) with value 29.11 USD, the gas cost of including this transaction is too high (28.29% of the withdrawn amount)
Ignored 243.433826221207748608 units of CNT (0x429876c4a6f89FB470E92456B8313879DF98B63c) with value 29.53 USD, the gas cost of including this transaction is too high (31.37% of the withdrawn amount)
Ignored 7.694004121655483392 units of arte (0x34612903db071e888a4dadcaa416d3ee263a87b9) with value 29.66 USD, the gas cost of including this transaction is too high (27.85% of the withdrawn amount)
Ignored 0.365155783996093568 units of pBTC35A (0xa8b12cc90abf65191532a12bb5394a714a46d358) with value 29.76 USD, the gas cost of including this transaction is too high (36.43% of the withdrawn amount)
Ignored 359.239523326066884608 units of ETHV_Ethverse (0xeeeeeeeee2af8d0e1940679860398308e0ef24d6) with value 30.53 USD, the gas cost of including this transaction is too high (27.10% of the withdrawn amount)
Ignored 1747.945910354475811755 units of C4G3 (0xf2Ef3551C1945A7218fc4eC0a75c9eCFDF012A4F) with value 30.60 USD, the gas cost of including this transaction is too high (28.27% of the withdrawn amount)
Ignored 6.060702601971386368 units of VISION (0xF406F7A9046793267bc276908778B29563323996) with value 30.83 USD, the gas cost of including this transaction is too high (31.62% of the withdrawn amount)
Ignored 142.92183065 units of DOGE (0x4206931337dc273a630d328dA6441786BfaD668f) with value 31.17 USD, the gas cost of including this transaction is too high (26.59% of the withdrawn amount)
Ignored 7.029397171819900928 units of WHL (0x2aF72850c504dDD3c1876C66a914cAee7Ff8a46A) with value 31.27 USD, the gas cost of including this transaction is too high (26.51% of the withdrawn amount)
Ignored 4.3144899586114166 units of ROL (0x2e071D2966Aa7D8dECB1005885bA1977D6038A65) with value 31.41 USD, the gas cost of including this transaction is too high (28.17% of the withdrawn amount)
Ignored 15.686070967741967887 units of FOL (0xA8580F3363684d76055bdC6660CaeFe8709744e1) with value 31.42 USD, the gas cost of including this transaction is too high (28.30% of the withdrawn amount)
Ignored 57.882711111733731328 units of BID (0x00000000000045166C45aF0FC6E4Cf31D9E14B9A) with value 32.67 USD, the gas cost of including this transaction is too high (25.37% of the withdrawn amount)
Ignored 17429.763844465285276362 units of WAS (0x0c572544a4Ee47904d54aaA6A970AF96B6f00E1b) with value 32.79 USD, the gas cost of including this transaction is too high (30.97% of the withdrawn amount)
Ignored 0.01300304220769554 units of CRETH2 (0xcbc1065255cbc3ab41a6868c22d1f1c573ab89fd) with value 33.45 USD, the gas cost of including this transaction is too high (24.82% of the withdrawn amount)
Ignored 411.793291201987498885 units of INST (0x6f40d4a6237c257fff2db00fa0510deeecd303eb) with value 33.68 USD, the gas cost of including this transaction is too high (32.87% of the withdrawn amount)
Ignored 10.324123773106509384 units of C98 (0xAE12C5930881c53715B369ceC7606B70d8EB229f) with value 34.36 USD, the gas cost of including this transaction is too high (25.61% of the withdrawn amount)
Ignored 85.164578595193280179 units of FXF (0x8a40c222996f9f3431f63bf80244c36822060f12) with value 34.62 USD, the gas cost of including this transaction is too high (30.17% of the withdrawn amount)
Ignored 113.427917 units of POWR (0x595832f8fc6bf59c85c527fec3740a1b7a361269) with value 34.93 USD, the gas cost of including this transaction is too high (23.61% of the withdrawn amount)
Ignored 351.8195 units of KERMAN (0x7841B2A48D1F6e78ACeC359FEd6D874Eb8a0f63c) with value 35.36 USD, the gas cost of including this transaction is too high (23.55% of the withdrawn amount)
Ignored 0.318130127020640426 units of DFSocial (0x54ee01beB60E745329E6a8711Ad2D6cb213e38d7) with value 35.41 USD, the gas cost of including this transaction is too high (23.49% of the withdrawn amount)
Ignored 99.63107439 units of AGIX (0x5b7533812759b45c2b44c19e320ba2cd2681b542) with value 35.55 USD, the gas cost of including this transaction is too high (24.64% of the withdrawn amount)
Ignored 0.058549783241606647 units of GFARM2 (0x831091dA075665168E01898c6DAC004A867f1e1B) with value 35.56 USD, the gas cost of including this transaction is too high (23.30% of the withdrawn amount)
Ignored 147.143698331779350528 units of ZDEX (0x5150956E082C748Ca837a5dFa0a7C10CA4697f9c) with value 35.72 USD, the gas cost of including this transaction is too high (23.25% of the withdrawn amount)
Ignored 136.882512327156 units of GRID (0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd) with value 35.87 USD, the gas cost of including this transaction is too high (23.00% of the withdrawn amount)
Ignored 786.670825304712445952 units of RFOX (0xa1d6df714f91debf4e0802a542e13067f31b8262) with value 36.12 USD, the gas cost of including this transaction is too high (23.38% of the withdrawn amount)
Ignored 6211.490770219826151424 units of FLURRY (0x60F63B76E2Fc1649E57a3489162732A90ACf59FE) with value 36.14 USD, the gas cost of including this transaction is too high (31.01% of the withdrawn amount)
Ignored 1789.40771271 units of FUN (0x419d0d8bdd9af5e606ae2232ed285aff190e711b) with value 36.15 USD, the gas cost of including this transaction is too high (34.92% of the withdrawn amount)
Ignored 410.638826088270510114 units of SNT (0x744d70fdbe2ba4cf95131626614a1763df805b9e) with value 36.17 USD, the gas cost of including this transaction is too high (64.61% of the withdrawn amount)
Ignored 12548.8372783 units of GIV (0xf6537FE0df7F0Cc0985Cf00792CC98249E73EFa0) with value 36.23 USD, the gas cost of including this transaction is too high (22.79% of the withdrawn amount)
Ignored 163.645786295711105024 units of WDOGE (0x35a532d376FFd9a705d0Bb319532837337A398E7) with value 36.24 USD, the gas cost of including this transaction is too high (22.83% of the withdrawn amount)
Ignored 490.017254796835160064 units of INFI (0x159751323a9e0415dd3d6d42a1212fe9f4a0848c) with value 36.43 USD, the gas cost of including this transaction is too high (22.76% of the withdrawn amount)
Ignored 1615.153462 units of REV (0x2ef52Ed7De8c5ce03a4eF0efbe9B7450F2D7Edc9) with value 36.46 USD, the gas cost of including this transaction is too high (36.02% of the withdrawn amount)
Ignored 2293.049081050140026456 units of ZERO (0xf0939011a9bb95c3b791f0cb546377ed2693a574) with value 37.64 USD, the gas cost of including this transaction is too high (21.85% of the withdrawn amount)
Ignored 200.0 units of RTK (0x1F6DEADcb526c4710Cf941872b86dcdfBbBD9211) with value 37.75 USD, the gas cost of including this transaction is too high (34.85% of the withdrawn amount)
Ignored 165.672953494395387904 units of REVO (0x155040625D7ae3e9caDA9a73E3E44f76D3Ed1409) with value 38.19 USD, the gas cost of including this transaction is too high (21.88% of the withdrawn amount)
Ignored 2.175945943808367619 units of BDT (0x4Efe8665e564bF454cCF5C90Ee16817F7485d5Cf) with value 38.19 USD, the gas cost of including this transaction is too high (21.75% of the withdrawn amount)
Ignored 256.785182594399305728 units of TRADE (0x6f87d756daf0503d08eb8993686c7fc01dc44fb1) with value 38.23 USD, the gas cost of including this transaction is too high (21.74% of the withdrawn amount)
Ignored 144.635274713551044608 units of BZRX (0x56d811088235f11c8920698a204a5010a788f4b3) with value 38.28 USD, the gas cost of including this transaction is too high (64.77% of the withdrawn amount)
Ignored 110.819671364206412533 units of GMT (0x7Ddc52c4De30e94Be3A6A0A2b259b2850f421989) with value 38.58 USD, the gas cost of including this transaction is too high (23.32% of the withdrawn amount)
Ignored 17.038803004681087304 units of SUPERBID (0x0563dce613d559a47877ffd1593549fb9d3510d6) with value 38.83 USD, the gas cost of including this transaction is too high (21.30% of the withdrawn amount)
Ignored 6974.816970800326770688 units of RPTC (0x3B08c03Fa8278cF81B9043B228183760376fcdBB) with value 39.03 USD, the gas cost of including this transaction is too high (21.18% of the withdrawn amount)
Ignored 915.850325123960158611 units of QSP (0x99ea4dB9EE77ACD40B119BD1dC4E33e1C070b80d) with value 39.68 USD, the gas cost of including this transaction is too high (24.79% of the withdrawn amount)
Ignored 29.409538968811514345 units of FRONT (0xf8c3527cc04340b208c854e985240c02f7b7793f) with value 39.85 USD, the gas cost of including this transaction is too high (20.86% of the withdrawn amount)
Ignored 51.499965658688618496 units of PINT (0xFECBa472B2540C5a2d3700b2C9E06F0aa7dC6462) with value 40.59 USD, the gas cost of including this transaction is too high (52.73% of the withdrawn amount)
Ignored 144.494132427859091547 units of ZEE (0x2edf094db69d6dcd487f1b3db9febe2eec0dd4c5) with value 40.71 USD, the gas cost of including this transaction is too high (20.39% of the withdrawn amount)
Ignored 302.879412383389347 units of CNJ (0x00A55375002f3cDa400383F479e7Cd57Bad029A9) with value 41.18 USD, the gas cost of including this transaction is too high (23.26% of the withdrawn amount)
Ignored 3271.463872034188760535 units of THEOS (0x9e10f61749c4952C320412A6B26901605Ff6Da1d) with value 41.33 USD, the gas cost of including this transaction is too high (20.10% of the withdrawn amount)
Ignored 11.730817468709459968 units of LIT (0xb59490ab09a0f526cc7305822ac65f2ab12f9723) with value 41.57 USD, the gas cost of including this transaction is too high (19.98% of the withdrawn amount)
Ignored 28.088748346696261016 units of PERI (0x5d30aD9C6374Bf925D0A75454fa327AACf778492) with value 41.59 USD, the gas cost of including this transaction is too high (49.49% of the withdrawn amount)
Ignored 3194.0 units of CND (0xd4c435f5b09f855c3317c8524cb1f586e42795fa) with value 41.71 USD, the gas cost of including this transaction is too high (56.10% of the withdrawn amount)
Ignored 126.753335852601982976 units of MOON (0x68a3637ba6e75c0f66b61a42639c4e9fcd3d4824) with value 41.77 USD, the gas cost of including this transaction is too high (22.19% of the withdrawn amount)
Ignored 177.447916004676734169 units of VERA (0xd7f0cC50AD69408aE58be033F4f85D2367C2e468) with value 41.97 USD, the gas cost of including this transaction is too high (40.19% of the withdrawn amount)
Ignored 2298.325288295635924609 units of JUP (0x4b1e80cac91e2216eeb63e29b957eb91ae9c2be8) with value 41.99 USD, the gas cost of including this transaction is too high (19.70% of the withdrawn amount)
Ignored 20.42212628 units of CUBE (0xDf801468a808a32656D2eD2D2d80B72A129739f4) with value 42.05 USD, the gas cost of including this transaction is too high (19.87% of the withdrawn amount)
Ignored 13540.522949207286392392 units of MMM (0x5b558564B57E4ff88c6b8D8E7EeEe599bF79B368) with value 42.09 USD, the gas cost of including this transaction is too high (19.63% of the withdrawn amount)
Ignored 6835.134023698450743296 units of BITE (0x4eED0fa8dE12D5a86517f214C2f11586Ba2ED88D) with value 42.26 USD, the gas cost of including this transaction is too high (20.01% of the withdrawn amount)
Ignored 11.681223466411763572 units of BZN (0x6524B87960c2d573AE514fd4181777E7842435d4) with value 44.05 USD, the gas cost of including this transaction is too high (18.94% of the withdrawn amount)
Ignored 48.021945332623923647 units of UFT (0x0202be363b8a4820f3f4de7faf5224ff05943ab1) with value 44.63 USD, the gas cost of including this transaction is too high (18.59% of the withdrawn amount)
Ignored 801.970914169196380159 units of B21 (0x6Faa826aF0568d1866Fca570dA79B318ef114dAb) with value 45.25 USD, the gas cost of including this transaction is too high (19.62% of the withdrawn amount)
Ignored 0.003895202508050729 units of MEEB (0x641927E970222B10b2E8CDBC96b1B4F427316f16) with value 45.61 USD, the gas cost of including this transaction is too high (26.65% of the withdrawn amount)
Ignored 1.810019260208095232 units of SEED (0x30cF203b48edaA42c3B4918E955fED26Cd012A3F) with value 45.67 USD, the gas cost of including this transaction is too high (62.56% of the withdrawn amount)
Ignored 18.973541533967806464 units of RELAY (0x5D843Fa9495d23dE997C394296ac7B4D721E841c) with value 46.73 USD, the gas cost of including this transaction is too high (17.64% of the withdrawn amount)
Ignored 951.266124367579874963 units of $HRIMP (0x9077F9e1eFE0eA72867ac89046b2a6264CbcaeF5) with value 46.86 USD, the gas cost of including this transaction is too high (17.72% of the withdrawn amount)
Ignored 0.185759493205763967 units of DONA (0x058bC8Ef040bD3971418E36aA88b64899378CcF4) with value 47.29 USD, the gas cost of including this transaction is too high (18.73% of the withdrawn amount)
Ignored 3182.191642281740050497 units of BLACK (0xd714d91A169127e11D8FAb3665d72E8b7ef9Dbe2) with value 47.40 USD, the gas cost of including this transaction is too high (28.22% of the withdrawn amount)
Ignored 964.838715316149100189 units of JRT (0x8a9c67fee641579deba04928c4bc45f66e26343a) with value 48.54 USD, the gas cost of including this transaction is too high (21.29% of the withdrawn amount)
Ignored 75.522293467440020246 units of HH (0x3fa729b4548becbad4eab6ef18413470e6d5324c) with value 48.57 USD, the gas cost of including this transaction is too high (21.39% of the withdrawn amount)
Ignored 400.3072941217 units of ENX (0xd0d7A9f2021958e51d60D6966b7BbeD9D1CB22B5) with value 48.63 USD, the gas cost of including this transaction is too high (16.97% of the withdrawn amount)
Ignored 244.597788797579853824 units of RBC (0xa4eed63db85311e22df4473f87ccfc3dadcfa3e3) with value 48.75 USD, the gas cost of including this transaction is too high (18.33% of the withdrawn amount)
Ignored 312.798680039198567554 units of SCT (0x6fa0952355607dfb2d399138b7fe10eb90f245e4) with value 49.57 USD, the gas cost of including this transaction is too high (17.08% of the withdrawn amount)
Ignored 35.545344333850832896 units of NEXO (0xb62132e35a6c13ee1ee0f84dc5d40bad8d815206) with value 49.91 USD, the gas cost of including this transaction is too high (16.92% of the withdrawn amount)
Ignored 1147.703847029434637137 units of KEK (0x3fa400483487A489EC9b1dB29C4129063EEC4654) with value 50.03 USD, the gas cost of including this transaction is too high (57.99% of the withdrawn amount)
Ignored 39.192254750068020554 units of YETI (0xb4bebd34f6daafd808f73de0d10235a92fbb6c3d) with value 50.28 USD, the gas cost of including this transaction is too high (17.03% of the withdrawn amount)
Ignored 2670.68799889 units of Coval (0x3d658390460295fb963f54dc0899cfb1c30776df) with value 50.33 USD, the gas cost of including this transaction is too high (23.96% of the withdrawn amount)
Ignored 39.35159182 units of RUSH (0xcFCd43D7eE21416a71c2EB9888587D52716Fc77a) with value 50.58 USD, the gas cost of including this transaction is too high (16.85% of the withdrawn amount)
Ignored 431.489439619962155008 units of IMX (0x7b35Ce522CB72e4077BaeB96Cb923A5529764a00) with value 51.25 USD, the gas cost of including this transaction is too high (18.33% of the withdrawn amount)
Ignored 375.749515 units of XKI (0x4f6103BAd230295baCF30f914FDa7D4273B7F585) with value 52.64 USD, the gas cost of including this transaction is too high (18.70% of the withdrawn amount)
Ignored 35.254722789752348137 units of STBZ (0xb987d48ed8f2c468d52d6405624eadba5e76d723) with value 52.88 USD, the gas cost of including this transaction is too high (16.58% of the withdrawn amount)
Ignored 880.31265994170302464 units of GEN (0x543ff227f64aa17ea132bf9886cab5db55dcaddf) with value 53.68 USD, the gas cost of including this transaction is too high (15.75% of the withdrawn amount)
Ignored 189.92444123891605012 units of KKO (0x368C5290b13cAA10284Db58B4ad4F3E9eE8bf4c9) with value 54.05 USD, the gas cost of including this transaction is too high (15.36% of the withdrawn amount)
Ignored 1.0 units of bALPHA (0x7a5ce6abd131ea6b148a022cb76fc180ae3315a6) with value 54.09 USD, the gas cost of including this transaction is too high (15.29% of the withdrawn amount)
Ignored 7.919658440461295616 units of STAD (0x5918f7add7fd774Cffb8a67cb696ecC4597b5536) with value 54.52 USD, the gas cost of including this transaction is too high (15.11% of the withdrawn amount)
Ignored 2000.0 units of FLy (0x85f6eB2BD5a062f5F8560BE93FB7147e16c81472) with value 55.59 USD, the gas cost of including this transaction is too high (15.87% of the withdrawn amount)
Ignored 279.460340225593604244 units of SAN (0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098) with value 55.73 USD, the gas cost of including this transaction is too high (15.88% of the withdrawn amount)
Ignored 166.3530366627700736 units of HYVE (0xd794DD1CAda4cf79C9EebaAb8327a1B0507ef7d4) with value 56.07 USD, the gas cost of including this transaction is too high (17.36% of the withdrawn amount)
Ignored 39952.604045728591517297 units of XNK (0xbc86727e770de68b1060c91f6bb6945c73e10388) with value 57.41 USD, the gas cost of including this transaction is too high (14.86% of the withdrawn amount)
Ignored 104.329227232809503748 units of SX (0x99fe3b1391503a1bc1788051347a1324bff41452) with value 58.16 USD, the gas cost of including this transaction is too high (14.26% of the withdrawn amount)
Ignored 981.751345330386995585 units of SPH (0xa0cf46eb152656c7090e769916eb44a138aaa406) with value 58.19 USD, the gas cost of including this transaction is too high (14.51% of the withdrawn amount)
Ignored 184.562230473067605407 units of RULER (0x2aeccb42482cc64e087b6d2e5da39f5a7a7001f8) with value 58.66 USD, the gas cost of including this transaction is too high (14.10% of the withdrawn amount)
Ignored 37051.780939 units of PARTY (0x314bD765cAB4774b2E547eB0aA15013e03FF74d2) with value 58.86 USD, the gas cost of including this transaction is too high (14.10% of the withdrawn amount)
Ignored 4444.317512842527899648 units of LIME (0x9D0B65a76274645B29e4cc41B8f23081fA09f4A3) with value 59.10 USD, the gas cost of including this transaction is too high (18.03% of the withdrawn amount)
Ignored 2.726812807668308167 units of WAVES (0x1cF4592ebfFd730c7dc92c1bdFFDfc3B9EfCf29a) with value 59.42 USD, the gas cost of including this transaction is too high (29.61% of the withdrawn amount)
Ignored 1310.158954965860876288 units of PNL (0x9FC8f0ca1668E87294941b7f627e9C15eA06B459) with value 59.46 USD, the gas cost of including this transaction is too high (15.63% of the withdrawn amount)
Ignored 14085.894781685056570427 units of WAIF (0xB2279B6769CFBa691416F00609b16244c0cF4b20) with value 59.68 USD, the gas cost of including this transaction is too high (13.93% of the withdrawn amount)
Ignored 80.296820476333951024 units of FAI (0xCda2f16C6Aa895D533506B426AFF827b709c87F5) with value 60.15 USD, the gas cost of including this transaction is too high (13.76% of the withdrawn amount)
Ignored 0.015591402184584034 units of YFII (0xa1d0e215a23d7030842fc67ce582a6afa3ccab83) with value 60.91 USD, the gas cost of including this transaction is too high (13.55% of the withdrawn amount)
Ignored 112.75521055017701872 units of TRADE (0x6e5970DBd6fc7eb1f29C6D2eDF2bC4c36124C0C1) with value 60.94 USD, the gas cost of including this transaction is too high (13.53% of the withdrawn amount)
Ignored 0.541860536243676516 units of PPBLZ (0x4D2eE5DAe46C86DA2FF521F7657dad98834f97b8) with value 61.41 USD, the gas cost of including this transaction is too high (14.31% of the withdrawn amount)
Ignored 425.369091528178784072 units of DERI (0xa487bf43cf3b10dffc97a9a744cbb7036965d3b9) with value 61.73 USD, the gas cost of including this transaction is too high (13.40% of the withdrawn amount)
Ignored 438.512778394174947328 units of FMT (0x99c6e435eC259A7E8d65E1955C9423DB624bA54C) with value 61.74 USD, the gas cost of including this transaction is too high (14.30% of the withdrawn amount)
Ignored 6172.988403561391158961 units of CATE (0xa42f266684ac2ad6ecb00df95b1c76efbb6f136c) with value 61.87 USD, the gas cost of including this transaction is too high (13.42% of the withdrawn amount)
Ignored 66.188336719656147551 units of BONE (0x9813037ee2218799597d83D4a5B6F3b6778218d9) with value 62.16 USD, the gas cost of including this transaction is too high (14.92% of the withdrawn amount)
Ignored 8.97669044617803789 units of DORA (0xbc4171f45ef0ef66e76f979df021a34b46dcc81d) with value 62.68 USD, the gas cost of including this transaction is too high (13.16% of the withdrawn amount)
Ignored 1.637916498843046912 units of CRU (0x32a7c02e79c4ea1008dd6564b35f131428673c41) with value 62.80 USD, the gas cost of including this transaction is too high (13.21% of the withdrawn amount)
Ignored 221.261447027940042296 units of AVS (0x94d916873B22C9C1b53695f1c002F78537B9b3b2) with value 63.85 USD, the gas cost of including this transaction is too high (12.96% of the withdrawn amount)
Ignored 16958.406962738140779152 units of ISP (0xC8807f0f5BA3fa45FfBdc66928d71c5289249014) with value 64.48 USD, the gas cost of including this transaction is too high (12.89% of the withdrawn amount)
Ignored 200.204939 units of IXS (0x73d7c860998CA3c01Ce8c808F5577d94d545d1b4) with value 64.80 USD, the gas cost of including this transaction is too high (13.46% of the withdrawn amount)
Ignored 33.365838499 units of BASE (0x07150e919b4de5fd6a63de1f9384828396f25fdc) with value 65.54 USD, the gas cost of including this transaction is too high (15.80% of the withdrawn amount)
Ignored 290.490167824943775744 units of SHROOM (0xed0439eacf4c4965ae4613d77a5c2efe10e5f183) with value 65.85 USD, the gas cost of including this transaction is too high (12.55% of the withdrawn amount)
Ignored 3.121999641193349091 units of PDEX (0xF59ae934f6fe444afC309586cC60a84a0F89Aaea) with value 65.86 USD, the gas cost of including this transaction is too high (14.32% of the withdrawn amount)
Ignored 2643.279949174297308425 units of SYNC (0xb6ff96b8a8d214544ca0dbc9b33f7ad6503efd32) with value 66.85 USD, the gas cost of including this transaction is too high (12.39% of the withdrawn amount)
Ignored 10656.041166855537263297 units of L3P (0xdeF1da03061DDd2A5Ef6c59220C135dec623116d) with value 66.90 USD, the gas cost of including this transaction is too high (16.50% of the withdrawn amount)
Ignored 850.48407643041431552 units of ORO (0xc3eb2622190c57429aac3901808994443b64b466) with value 67.37 USD, the gas cost of including this transaction is too high (12.32% of the withdrawn amount)
Ignored 118.839367734407759558 units of POLY (0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec) with value 68.24 USD, the gas cost of including this transaction is too high (12.25% of the withdrawn amount)
Ignored 62.40663652 units of STORJ (0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac) with value 68.31 USD, the gas cost of including this transaction is too high (12.21% of the withdrawn amount)
Ignored 406.436089062544373666 units of DOWS (0x661ab0ed68000491d98c796146bcf28c20d7c559) with value 69.54 USD, the gas cost of including this transaction is too high (15.95% of the withdrawn amount)
Ignored 2.52565917 units of TIME (0x485d17a6f1b8780392d53d64751824253011a260) with value 70.47 USD, the gas cost of including this transaction is too high (11.74% of the withdrawn amount)
Ignored 0.468800926 units of DJ15 (0x5d269fac3B2e0552b0F34cdc253bDB427682A4b9) with value 71.48 USD, the gas cost of including this transaction is too high (12.28% of the withdrawn amount)
Ignored 1001186.262537071341407542 units of gKIMCHI (0x4b7DfAe2567181E54776337C840e142ACb42AA1F) with value 71.75 USD, the gas cost of including this transaction is too high (11.53% of the withdrawn amount)
Ignored 157.472650406880030373 units of WISE (0x66a0f676479cee1d7373f3dc2e2952778bff5bd6) with value 72.48 USD, the gas cost of including this transaction is too high (11.39% of the withdrawn amount)
Ignored 12574.471 units of DEC (0x9393fdc77090F31c7db989390D43F454B1A6E7F3) with value 73.05 USD, the gas cost of including this transaction is too high (11.33% of the withdrawn amount)
Ignored 4.806685976546300928 units of SAI (0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359) with value 73.18 USD, the gas cost of including this transaction is too high (12.10% of the withdrawn amount)
Ignored 879.65798727 units of WAX (0x39Bb259F66E1C59d5ABEF88375979b4D20D98022) with value 73.72 USD, the gas cost of including this transaction is too high (12.02% of the withdrawn amount)
Ignored 524.765303850109896749 units of APYS (0xf7413489c474ca4399eeE604716c72879Eea3615) with value 74.14 USD, the gas cost of including this transaction is too high (11.21% of the withdrawn amount)
Ignored 0.279922824405106886 units of XOR (0x40fd72257597aa14c7231a7b1aaa29fce868f677) with value 74.31 USD, the gas cost of including this transaction is too high (11.07% of the withdrawn amount)
Ignored 3648.034323798100335072 units of UNISTAKE (0x9ed8e7c9604790f7ec589f99b94361d8aab64e5e) with value 74.52 USD, the gas cost of including this transaction is too high (11.08% of the withdrawn amount)
Ignored 369.237174668048824453 units of ASAP (0xcC665390b03c5D324D8fAF81C15eCee29A73bCB4) with value 75.16 USD, the gas cost of including this transaction is too high (12.62% of the withdrawn amount)
Ignored 46.480972423937942714 units of COIN (0x87b008E57F640D94Ee44Fd893F0323AF933F9195) with value 76.60 USD, the gas cost of including this transaction is too high (11.43% of the withdrawn amount)
Ignored 547.739624083093108677 units of BCDT (0xacfa209fb73bf3dd5bbfb1101b9bc999c49062a5) with value 79.09 USD, the gas cost of including this transaction is too high (11.89% of the withdrawn amount)
Ignored 1999.80236836 units of SENT (0xa44e5137293e855b1b7bc7e2c6f8cd796ffcb037) with value 79.16 USD, the gas cost of including this transaction is too high (10.77% of the withdrawn amount)
Ignored 178.9938 units of SQUIG (0x373acdA15Ce392362e4b46ED97a7feEcD7EF9EB8) with value 79.20 USD, the gas cost of including this transaction is too high (11.12% of the withdrawn amount)
Ignored 0.254039154792564224 units of DELTA rLP (0xfcfC434ee5BfF924222e084a8876Eee74Ea7cfbA) with value 79.71 USD, the gas cost of including this transaction is too high (12.41% of the withdrawn amount)
Ignored 39.366678 units of WSCRT (0x2B89bF8ba858cd2FCee1faDa378D5cd6936968Be) with value 80.17 USD, the gas cost of including this transaction is too high (12.37% of the withdrawn amount)
Ignored 148.284370565410663589 units of HXRO (0x4bD70556ae3F8a6eC6C4080A0C327B24325438f3) with value 80.26 USD, the gas cost of including this transaction is too high (10.65% of the withdrawn amount)
Ignored 678.10563622729049303 units of ARCONA (0x0f71b8de197a1c84d31de0f1fa7926c365f052b3) with value 81.34 USD, the gas cost of including this transaction is too high (11.56% of the withdrawn amount)
Ignored 261.99485757655792229 units of DUCK (0xc0ba369c8db6eb3924965e5c4fd0b4c1b91e305f) with value 81.39 USD, the gas cost of including this transaction is too high (10.16% of the withdrawn amount)
Ignored 242164.79727410595954688 units of BAX (0x9a0242b7a33DAcbe40eDb927834F96eB39f8fBCB) with value 82.42 USD, the gas cost of including this transaction is too high (10.17% of the withdrawn amount)
Ignored 710.052964324102001012 units of TCP (0x06576eB3B212d605B797dC15523d9Dc9F4F66DB4) with value 82.63 USD, the gas cost of including this transaction is too high (10.04% of the withdrawn amount)
Ignored 0.170847905320074805 units of VRX (0x87de305311d5788e8da38d19bb427645b09cb4e5) with value 82.74 USD, the gas cost of including this transaction is too high (10.04% of the withdrawn amount)
Ignored 592.495097263146008576 units of DRGN (0x419c4dB4B9e25d6Db2AD9691ccb832C8D9fDA05E) with value 82.85 USD, the gas cost of including this transaction is too high (10.04% of the withdrawn amount)
Ignored 297.552204442900075049 units of RAMP (0x33d0568941c0c64ff7e0fb4fba0b11bd37deed9f) with value 83.75 USD, the gas cost of including this transaction is too high (10.53% of the withdrawn amount)
Ignored 1036.655102094584176926 units of ANKR (0x8290333cef9e6d528dd5618fb97a76f268f3edd4) with value 83.96 USD, the gas cost of including this transaction is too high (9.92% of the withdrawn amount)
Ignored 1.963599 units of MEDIA (0xdb726152680eCe3c9291f1016f1d36f3995f6941) with value 84.05 USD, the gas cost of including this transaction is too high (10.41% of the withdrawn amount)
Ignored 22.634069 units of HGET (0x7968bc6a03017ea2de509aaa816f163db0f35148) with value 85.24 USD, the gas cost of including this transaction is too high (9.68% of the withdrawn amount)
Ignored 321.013895981593765095 units of NAME (0xe1A4c5BBb704a92599FEdB191f451E0d3a1ed842) with value 85.25 USD, the gas cost of including this transaction is too high (9.71% of the withdrawn amount)
Ignored 60.992753591464313608 units of FLOAT (0xb05097849BCA421A3f51B249BA6CCa4aF4b97cb9) with value 85.81 USD, the gas cost of including this transaction is too high (12.07% of the withdrawn amount)
Ignored 123.460608261272200461 units of GEEQ (0x6b9f031d718dded0d681c20cb754f97b3bb81b78) with value 85.86 USD, the gas cost of including this transaction is too high (10.24% of the withdrawn amount)
Ignored 7.16329874 units of COC (0x22B6C31c2bEB8f2d0d5373146Eed41Ab9eDe3caf) with value 88.27 USD, the gas cost of including this transaction is too high (9.36% of the withdrawn amount)
Ignored 24.739465683 units of ICHI (0x903bef1736cddf2a537176cf3c64579c3867a881) with value 88.29 USD, the gas cost of including this transaction is too high (9.35% of the withdrawn amount)
Ignored 0.149861987025790233 units of WHITE (0x5f0e628b693018f639d10e4a4f59bd4d8b2b6b44) with value 88.52 USD, the gas cost of including this transaction is too high (9.35% of the withdrawn amount)
Ignored 3282.4306153 units of SDX (0x041fdd6637eCfD96af8804278AC12660ac2D12c0) with value 90.00 USD, the gas cost of including this transaction is too high (9.15% of the withdrawn amount)
Ignored 2.04792206097867197 units of $MAID (0x4Af698B479D0098229DC715655c667Ceb6cd8433) with value 90.85 USD, the gas cost of including this transaction is too high (9.05% of the withdrawn amount)
Ignored 349.720932010887024858 units of PRE (0xec213f83defb583af3a000b1c0ada660b1902a0f) with value 90.97 USD, the gas cost of including this transaction is too high (11.40% of the withdrawn amount)
Ignored 464.743359386683148851 units of GS (0xe0b9a2c3e9f40cf74b2c7f591b2b0cca055c3112) with value 93.32 USD, the gas cost of including this transaction is too high (9.45% of the withdrawn amount)
Ignored 2.12915139170190432 units of NDR (0x739763a258640919981f9ba610ae65492455be53) with value 93.59 USD, the gas cost of including this transaction is too high (10.60% of the withdrawn amount)
Ignored 391.747183877373422778 units of GAINS (0xd9b312d77bc7bed9b9cecb56636300bed4fe5ce9) with value 93.82 USD, the gas cost of including this transaction is too high (8.84% of the withdrawn amount)
Ignored 0.232589693197150939 units of UNCX (0xadb2437e6f65682b85f814fbc12fec0508a7b1d0) with value 94.11 USD, the gas cost of including this transaction is too high (9.90% of the withdrawn amount)
Ignored 3.261825761024626914 units of UNCL (0x2f4eb47A1b1F4488C71fc10e39a4aa56AF33Dd49) with value 95.32 USD, the gas cost of including this transaction is too high (8.70% of the withdrawn amount)
Ignored 31100.535414561899785334 units of TTT (0x9F599410D207f3D2828a8712e5e543AC2E040382) with value 95.97 USD, the gas cost of including this transaction is too high (9.22% of the withdrawn amount)
Ignored 2124.874254806854966968 units of rHEGIC2 (0xAd7Ca17e23f13982796D27d1E6406366Def6eE5f) with value 97.44 USD, the gas cost of including this transaction is too high (9.00% of the withdrawn amount)
Ignored 5.866083718119286653 units of eSOV (0xbdab72602e9AD40FC6a6852CAf43258113B8F7a5) with value 98.22 USD, the gas cost of including this transaction is too high (11.47% of the withdrawn amount)
Ignored 4002.294244831641418424 units of SPC (0x86ed939b500e121c0c5f493f399084db596dad20) with value 98.65 USD, the gas cost of including this transaction is too high (8.38% of the withdrawn amount)
Ignored 12.175521273379208608874496 units of NEAR (0x85F17Cf997934a597031b2E18a9aB6ebD4B9f6a4) with value 98.67 USD, the gas cost of including this transaction is too high (8.39% of the withdrawn amount)
Ignored 490.938876938535999567 units of REQ (0x8f8221afbb33998d8584a2b05749ba73c37a938a) with value 98.88 USD, the gas cost of including this transaction is too high (8.95% of the withdrawn amount)
Ignored 3322.764386802834341888 units of ESD (0x36f3fd68e7325a35eb768f1aedaae9ea0689d723) with value 99.24 USD, the gas cost of including this transaction is too high (8.45% of the withdrawn amount)
Ignored 4.522911559317104565 units of bBADGER (0x19D97D8fA813EE2f51aD4B4e04EA08bAf4DFfC28) with value 99.26 USD, the gas cost of including this transaction is too high (10.46% of the withdrawn amount)
Ignored 65.499991650431134183 units of rFIS (0xC82eb6dEa0c93EDb8B697B89ad1b13d19469D635) with value 100.15 USD, the gas cost of including this transaction is too high (8.81% of the withdrawn amount)
Ignored 378.191809418105749854 units of XEND (0xe4cfe9eaa8cdb0942a80b7bc68fd8ab0f6d44903) with value 100.68 USD, the gas cost of including this transaction is too high (8.75% of the withdrawn amount)
Ignored 2953.152372957106141702 units of 1-UP (0xC86817249634ac209bc73fCa1712bBd75E37407d) with value 100.86 USD, the gas cost of including this transaction is too high (17.19% of the withdrawn amount)
Ignored 21.242233011476430531 units of AXIAv3 (0x793786e2dd4Cc492ed366a94B88a3Ff9ba5E7546) with value 101.42 USD, the gas cost of including this transaction is too high (10.22% of the withdrawn amount)
Ignored 328.74088167 units of YOP (0xae1eaae3f627aaca434127644371b67b18444051) with value 101.57 USD, the gas cost of including this transaction is too high (8.12% of the withdrawn amount)
Ignored 820.614021819634086745 units of TCR (0x9C4A4204B79dd291D6b6571C5BE8BbcD0622F050) with value 101.80 USD, the gas cost of including this transaction is too high (8.16% of the withdrawn amount)
Ignored 188.770617019378280408 units of COTI (0xddb3422497e61e13543bea06989c0789117555c5) with value 101.91 USD, the gas cost of including this transaction is too high (8.21% of the withdrawn amount)
Ignored 7908.714478592385465032 units of IBY (0x6A68DE599E8E0b1856E322CE5Bd11c5C3C79712B) with value 102.02 USD, the gas cost of including this transaction is too high (8.69% of the withdrawn amount)
Ignored 9.797989090640620877 units of wSIENNA (0x9b00e6E8D787b13756eb919786c9745054DB64f9) with value 102.38 USD, the gas cost of including this transaction is too high (9.73% of the withdrawn amount)
Ignored 322.60205531101220864 units of CMP (0x9f20Ed5f919DC1C1695042542C13aDCFc100dcab) with value 103.78 USD, the gas cost of including this transaction is too high (7.94% of the withdrawn amount)
Ignored 219.224240706207757375 units of DFYN (0x9695e0114e12c0d3a3636fab5a18e6b737529023) with value 104.38 USD, the gas cost of including this transaction is too high (7.91% of the withdrawn amount)
Ignored 109.303777941657019416 units of UST (0xa47c8bf37f92abed4a126bda807a7b7498661acd) with value 108.88 USD, the gas cost of including this transaction is too high (7.62% of the withdrawn amount)
Ignored 205.437372910986885093 units of PRQ (0x362bc847a3a9637d3af6624eec853618a43ed7d2) with value 109.92 USD, the gas cost of including this transaction is too high (8.84% of the withdrawn amount)
Ignored 3360.0 units of SOTA (0x0dde6f6e345bfd23f3f419f0dfe04e93143b44fb) with value 110.17 USD, the gas cost of including this transaction is too high (8.45% of the withdrawn amount)
Ignored 126.523599201501792972 units of CWAP (0xE74dC43867E0cbEB208F1a012fc60DcBbF0E3044) with value 110.74 USD, the gas cost of including this transaction is too high (7.50% of the withdrawn amount)
Ignored 16.351323 units of CLV (0x22222C03318440305aC3e8a7820563d6A9FD777F) with value 111.06 USD, the gas cost of including this transaction is too high (8.33% of the withdrawn amount)
Ignored 50.0 units of LON (0x0000000000095413afc295d19edeb1ad7b71c952) with value 113.31 USD, the gas cost of including this transaction is too high (7.32% of the withdrawn amount)
Ignored 589.792741997535776161 units of DEC (0x30f271c9e86d2b7d00a6376cd96a1cfbd5f0b9b3) with value 113.60 USD, the gas cost of including this transaction is too high (7.74% of the withdrawn amount)
Ignored 735.866182393726901362 units of $ITG (0xF88b137cfa667065955ABD17525e89EDCF4D6426) with value 114.24 USD, the gas cost of including this transaction is too high (8.70% of the withdrawn amount)
Ignored 672.309321764649385984 units of TANGO (0x182f4c4c97cd1c24e1df8fc4c053e5c47bf53bef) with value 115.12 USD, the gas cost of including this transaction is too high (7.68% of the withdrawn amount)
Ignored 293.804129364170906144 units of uGMC (0xD4f2249dd6c26446F1413f6d97F14fcaa7792545) with value 115.99 USD, the gas cost of including this transaction is too high (7.17% of the withdrawn amount)
Ignored 24.047357959710062594 units of DEGEN (0x126c121f99e1e211df2e5f8de2d96fa36647c855) with value 116.79 USD, the gas cost of including this transaction is too high (8.65% of the withdrawn amount)
Ignored 69.641182703758487124 units of BCUG (0x14da7b27b2e0fedefe0a664118b0c9bc68e2e9af) with value 118.25 USD, the gas cost of including this transaction is too high (8.03% of the withdrawn amount)
Ignored 1580.670610789773173556 units of BiFi (0x2791bfd60d232150bff86b39b7146c0eaaa2ba81) with value 119.55 USD, the gas cost of including this transaction is too high (7.32% of the withdrawn amount)
Ignored 2.33528002 units of cETH (0x4ddc2d193948926d02f9b1fe9e1daa0718270ed5) with value 119.90 USD, the gas cost of including this transaction is too high (22.00% of the withdrawn amount)
Ignored 3639.070301230655773459 units of TOWER (0x1c9922314ed1415c95b9fd453c3818fd41867d0b) with value 119.96 USD, the gas cost of including this transaction is too high (6.89% of the withdrawn amount)
Ignored 37.552334505738102703 units of ROUTE (0x16eccfdbb4ee1a85a33f3a9b21175cd7ae753db4) with value 120.90 USD, the gas cost of including this transaction is too high (7.84% of the withdrawn amount)
Ignored 1409.222502195798294647 units of WIVA (0xA00055e6EE4D1f4169096EcB682F70cAa8c29987) with value 121.42 USD, the gas cost of including this transaction is too high (8.37% of the withdrawn amount)
Ignored 152.006765048006841063 units of AES (0xd932ba8adF16009E5571648e070f9Eebb2f259c0) with value 122.25 USD, the gas cost of including this transaction is too high (6.77% of the withdrawn amount)
Ignored 11526.182225166292298218 units of SAITO (0xFa14Fa6958401314851A17d6C5360cA29f74B57B) with value 123.80 USD, the gas cost of including this transaction is too high (6.68% of the withdrawn amount)
Ignored 63303.349374916102086526 units of CNTR (0x03042482d64577A7bdb282260e2eA4c8a89C064B) with value 124.79 USD, the gas cost of including this transaction is too high (7.07% of the withdrawn amount)
Ignored 0.19592350551561383 units of aKLIMA (0x6b4d5e9ec2aceA23D4110F4803Da99E25443c5Df) with value 124.92 USD, the gas cost of including this transaction is too high (7.90% of the withdrawn amount)
Ignored 10560.850934540239632608 units of PRT (0x6d0f5149c502faf215c89ab306ec3e50b15e2892) with value 125.92 USD, the gas cost of including this transaction is too high (6.54% of the withdrawn amount)
Ignored 29.494345663516985345 units of BUILD (0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739) with value 127.56 USD, the gas cost of including this transaction is too high (6.50% of the withdrawn amount)
Ignored 529.851953895651668997 units of DEXTF (0x5f64ab1544d28732f0a24f4713c2c8ec0da089f0) with value 132.18 USD, the gas cost of including this transaction is too high (6.29% of the withdrawn amount)
Ignored 67.173787465209644207 units of O3 (0xee9801669c6138e84bd50deb500827b776777d28) with value 133.82 USD, the gas cost of including this transaction is too high (11.10% of the withdrawn amount)
Ignored 3944.030281030938394624 units of UTU (0xa58a4f5c4bb043d2cc1e170613b74e767c94189b) with value 134.04 USD, the gas cost of including this transaction is too high (6.21% of the withdrawn amount)
Ignored 17101.1624 units of XPR (0xd7efb00d12c2c13131fd319336fdf952525da2af) with value 134.57 USD, the gas cost of including this transaction is too high (6.14% of the withdrawn amount)
Ignored 49.135492460047829968 units of NDX (0x86772b1409b61c639eaac9ba0acfbb6e238e5f83) with value 134.67 USD, the gas cost of including this transaction is too high (7.02% of the withdrawn amount)
Ignored 29.576933636328845312 units of FEWGO (0x60e46a4Dd91D10506D8eFA2caA266E7191fe7Ea8) with value 134.84 USD, the gas cost of including this transaction is too high (6.11% of the withdrawn amount)
Ignored 5613.209746077531376318 units of MoFi (0xB2dbF14D0b47ED3Ba02bDb7C954e05A72deB7544) with value 137.10 USD, the gas cost of including this transaction is too high (6.03% of the withdrawn amount)
Ignored 2372.129338920119702357 units of LUA (0xb1f66997a5760428d3a87d68b90bfe0ae64121cc) with value 139.65 USD, the gas cost of including this transaction is too high (6.70% of the withdrawn amount)
Ignored 88888 units of DRC_1 (0xa150db9b1fa65b44799d4dd949d922c0a33ee606) with value 140.03 USD, the gas cost of including this transaction is too high (5.87% of the withdrawn amount)
Ignored 9713.6848288790134478 units of CRED (0xED7Fa212E100DFb3b13B834233E4B680332a3420) with value 140.21 USD, the gas cost of including this transaction is too high (5.89% of the withdrawn amount)
Ignored 28495.935136271250463053 units of SHLD (0xd49EFA7BC0D339D74f487959C573d518BA3F8437) with value 142.30 USD, the gas cost of including this transaction is too high (8.50% of the withdrawn amount)
Ignored 911.794773798165292796 units of DVD (0x77dcE26c03a9B833fc2D7C31C22Da4f42e9d9582) with value 142.53 USD, the gas cost of including this transaction is too high (9.26% of the withdrawn amount)
Ignored 0.617102605816694208 units of BETA (0x35F67c1D929E106FDfF8D1A55226AFe15c34dbE2) with value 142.55 USD, the gas cost of including this transaction is too high (5.80% of the withdrawn amount)
Ignored 143.626778951123857515 units of BOSON (0xc477d038d5420c6a9e0b031712f61c5120090de9) with value 143.44 USD, the gas cost of including this transaction is too high (6.07% of the withdrawn amount)
Ignored 12.905782230054679546 units of ANTv1 (0x960b236a07cf122663c4303350609a66a7b288c0) with value 143.46 USD, the gas cost of including this transaction is too high (16.33% of the withdrawn amount)
Ignored 2.562674357414994212 units of DMT (0x79126d32a86e6663F3aAac4527732d0701c1AE6c) with value 143.97 USD, the gas cost of including this transaction is too high (5.77% of the withdrawn amount)
Ignored 17082.766022142850891776 units of COOK (0xff75ced57419bcaebe5f05254983b013b0646ef5) with value 144.22 USD, the gas cost of including this transaction is too high (7.22% of the withdrawn amount)
Ignored 987.310330260238207829 units of GMEE (0xD9016A907Dc0ECfA3ca425ab20B6b785B42F2373) with value 145.95 USD, the gas cost of including this transaction is too high (5.67% of the withdrawn amount)
Ignored 413.279977861433407732 units of VNTW (0xd0f05D3D4e4d1243Ac826d8c6171180c58eaa9BC) with value 146.46 USD, the gas cost of including this transaction is too high (5.65% of the withdrawn amount)
Ignored 1.511182190426318636 units of FFF (0xaBAfA52D3d5A2c18A4C1Ae24480D22B831fC0413) with value 147.22 USD, the gas cost of including this transaction is too high (6.86% of the withdrawn amount)
Ignored 314.455473103313889993 units of MOAR (0x187Eff9690E1F1A61d578C7c492296eaAB82701a) with value 147.37 USD, the gas cost of including this transaction is too high (5.62% of the withdrawn amount)
Ignored 7126.19426323 units of BOND_finance (0x5dc02ea99285e17656b8350722694c35154db1e8) with value 147.76 USD, the gas cost of including this transaction is too high (5.94% of the withdrawn amount)
Ignored 10992.357389893593130807 units of PARA (0x3a8d5BC8A8948b68DfC0Ce9C14aC4150e083518c) with value 150.47 USD, the gas cost of including this transaction is too high (5.50% of the withdrawn amount)
Ignored 156.908383724934363919 units of zUSD (0x76417e660df3e5c90c0361674c192da152a806e4) with value 151.09 USD, the gas cost of including this transaction is too high (6.53% of the withdrawn amount)
Ignored 2329.792602385743916469 units of wXEQ (0x4a5B3D0004454988C50e8dE1bCFC921EE995ADe3) with value 151.74 USD, the gas cost of including this transaction is too high (5.47% of the withdrawn amount)
Ignored 1079.876171235038900339 units of TSX (0x734C90044a0bA31B3F2e640c10dC5d3540499Bfd) with value 157.48 USD, the gas cost of including this transaction is too high (6.64% of the withdrawn amount)
Ignored 199.212461122667645707 units of MARSH (0x5a666c7d92e5fa7edcb6390e4efd6d0cdd69cf37) with value 158.24 USD, the gas cost of including this transaction is too high (5.23% of the withdrawn amount)
Ignored 0.518627494431137722 units of BDI (0x0309c98B1bffA350bcb3F9fB9780970CA32a5060) with value 161.37 USD, the gas cost of including this transaction is too high (5.87% of the withdrawn amount)
Ignored 1248.36561681186639328 units of UDO (0xea3983Fc6D0fbbC41fb6F6091f68F3e08894dC06) with value 166.58 USD, the gas cost of including this transaction is too high (5.55% of the withdrawn amount)
Ignored 587.873939742589131586 units of i7 (0x560cC7De81B2A594F6518713cBE122bCF297A6E8) with value 167.92 USD, the gas cost of including this transaction is too high (5.11% of the withdrawn amount)
Ignored 608.002708996201895273 units of DOUGH (0xad32a8e6220741182940c5abf610bde99e737b2d) with value 168.52 USD, the gas cost of including this transaction is too high (17.22% of the withdrawn amount)
Ignored 64.082371255540813995 units of GET (0x8a854288a5976036a725879164ca3e91d30c6a1b) with value 171.35 USD, the gas cost of including this transaction is too high (5.18% of the withdrawn amount)
Ignored 257.075365728960900363 units of RAIL (0xe76C6c83af64e4C60245D8C7dE953DF673a7A33D) with value 171.76 USD, the gas cost of including this transaction is too high (5.10% of the withdrawn amount)
Ignored 112.361129502330725407 units of GHST (0x3f382dbd960e3a9bbceae22651e88158d2791550) with value 171.76 USD, the gas cost of including this transaction is too high (16.89% of the withdrawn amount)
Ignored 3.756161024978595072 units of TRB (0x88df592f8eb5d7bd38bfef7deb0fbc02cf3778a0) with value 176.78 USD, the gas cost of including this transaction is too high (12.14% of the withdrawn amount)
Ignored 302.94176389244512918 units of MATTER (0x9B99CcA871Be05119B2012fd4474731dd653FEBe) with value 184.17 USD, the gas cost of including this transaction is too high (5.15% of the withdrawn amount)
Ignored 201.863087338886887195 units of COMFI (0x752Efadc0a7E05ad1BCCcDA22c141D01a75EF1e4) with value 184.44 USD, the gas cost of including this transaction is too high (5.15% of the withdrawn amount)
Ignored 1805.217185249500402283 units of LKR (0x80CE3027a70e0A928d9268994e9B85d03Bd4CDcf) with value 189.53 USD, the gas cost of including this transaction is too high (7.44% of the withdrawn amount)
Ignored 0.065793104063352157 units of sETH (0x5e74C9036fb86BD7eCdcb084a0673EFc32eA31cb) with value 193.64 USD, the gas cost of including this transaction is too high (10.10% of the withdrawn amount)
Ignored 1156.452285007605018624 units of LSS (0x3B9BE07d622aCcAEd78f479BC0EDabFd6397E320) with value 218.78 USD, the gas cost of including this transaction is too high (5.57% of the withdrawn amount)
Ignored 965.063879446642987108 units of NUX (0x89bd2e7e388fab44ae88bef4e1ad12b4f1e0911c) with value 269.77 USD, the gas cost of including this transaction is too high (13.41% of the withdrawn amount)
Ignored 39.914963397795045969 units of BAND (0xba11d00c5f74255f56a5e366f4f77f5a186d7f55) with value 313.16 USD, the gas cost of including this transaction is too high (8.18% of the withdrawn amount)
Ignored 16412.37601423 units of cDAI (0x5d3a536e4d6dbd6114cc1ead35777bab948e3643) with value 332.18 USD, the gas cost of including this transaction is too high (8.81% of the withdrawn amount)
Ignored 42020.62089949 units of cUSDC (0x39aa39c021dfbae8fac545936693ac917d5e7563) with value 448.32 USD, the gas cost of including this transaction is too high (5.88% of the withdrawn amount)
Ignored 25577.912195901313371 units of NII (0x7c8155909cd385f120a56ef90728dd50f9ccbe52) with value 501.33 USD, the gas cost of including this transaction is too high (5.98% of the withdrawn amount)
Amounts to withdraw:
 address                                    | balance (usd) | balance                       | withdrawn amount              | symbol        
--------------------------------------------+---------------+-------------------------------+-------------------------------+---------------
 0x7bef710a5759d197ec0bf621c3df802c2d60d848 |        168.46 |       1660.353362539218702108 |       1660.353362539218702108 | SHOPX         
 0x358aa737e033f34df7c54306960a38d09aabd523 |        168.82 |       7068.589580444129087637 |       7068.589580444129087637 | ARES          
 0x653430560bE843C4a3D143d0110e896c2Ab8ac0D |        169.75 |         95.199374000000000000 |         95.199374000000000000 | MOF           
 0xf151980E7A781481709e8195744bF2399FB3Cba4 |        172.05 |      21853.302757111686723529 |      21853.302757111686723529 | FWT           
 0xed0889F7E1c7C7267407222Be277e1f1Ef4d4892 |        178.74 |      16774.378116411228420769 |      16774.378116411228420769 | MEL           
 0xeCD20F0EBC3dA5E514b4454E3dc396E7dA18cA6A |        183.01 |         33.399742510712686807 |         33.399742510712686807 | CUDL          
 0x9AAb071B4129B083B01cB5A0Cb513Ce7ecA26fa5 |        183.75 |        292.580000000000000000 |        292.580000000000000000 | HUNT          
 0x70401dfd142a16dc7031c56e862fc88cb9537ce0 |        187.41 |          3.260177605751543941 |          3.260177605751543941 | BIRD          
 0xd084b83c305dafd76ae3e1b4e1f1fe2ecccb3988 |        187.45 |        953.869378629358585717 |        953.869378629358585717 | TVK           
 0xBEaB712832112bd7664226db7CD025B153D3af55 |        188.90 |        712.125433947614893792 |        712.125433947614893792 | BRIGHT        
 0x0cdf9acd87e940837ff21bb40c9fd55f68bba059 |        188.95 |        575.426532094437114555 |        575.426532094437114555 | MINT          
 0xCc0014cCb39F6e86b1BE0f17859A783B6722722F |        191.66 |      19936.655755706843047905 |      19936.655755706843047905 | SHO           
 0xd56dac73a4d6766464b38ec6d91eb45ce7457c44 |        191.94 |       1816.182745763899481110 |       1816.182745763899481110 | PAN           
 0x81B1bFD6CB9Ad42DB395c2a27F73D4DCf5777e2D |        191.99 |       1536.911800000000000000 |       1536.911800000000000000 | RARE          
 0x83e6f1e41cdd28eaceb20cb649155049fac3d5aa |        192.86 |        125.882899854496146274 |        125.882899854496146274 | POLS          
 0x4ABB9cC67BD3da9Eb966d1159A71a0e68BD15432 |        192.87 |      11089.888242955295749765 |      11089.888242955295749765 | KEL           
 0x56A86d648c435DC707c8405B78e2Ae8eB4E60Ba4 |        193.89 |       9128.359661453613749721 |       9128.359661453613749721 | STACK         
 0xceb286c9604c542d3cc08b41aa6c9675b078a832 |        193.99 |      12744.808114320443593444 |      12744.808114320443593444 | VTX           
 0x5DE7Cc4BcBCa31c473F6D2F27825Cfb09cc0Bb16 |        199.90 |          0.169286331619688153 |          0.169286331619688153 | XBE           
 0xF4b5470523cCD314C6B9dA041076e7D79E0Df267 |        200.26 |       1432.172044194727205933 |       1432.172044194727205933 | BBANK         
 0x852e5427c86A3b46DD25e5FE027bb15f53c4BCb8 |        201.72 |       1380.940197534486894000 |       1380.940197534486894000 | NIIFI         
 0x1776e1f26f98b1a5df9cd347953a26dd3cb46671 |        203.59 |          5.090357490595307350 |          5.090357490595307350 | NMR           
 0x9E46A38F5DaaBe8683E10793b06749EEF7D733d1 |        205.02 |      38051.840577545550650250 |      38051.840577545550650250 | NCT           
 0x84bA4aEcfDe39D69686a841BAb434C32d179a169 |        208.26 |      26339.333152176008092052 |      26339.333152176008092052 | MTHD          
 0x2A039B1D9bBDccBb91be28691b730ca893e5e743 |        209.18 |        202.002851469277316412 |        202.002851469277316412 | RNB           
 0x464FdB8AFFC9bac185A7393fd4298137866DCFB8 |        212.79 |        781.427008616387317777 |        781.427008616387317777 | REALM         
 0x7de91b204c1c737bcee6f000aaa6569cf7061cb7 |        213.36 |         14.812506053000000000 |         14.812506053000000000 | XRT           
 0x5D2C6545d16e3f927a25b4567E39e2cf5076BeF4 |        213.61 |          7.359107966581333116 |          7.359107966581333116 | KAPPA         
 0xDC59ac4FeFa32293A95889Dc396682858d52e5Db |        215.44 |        512.994175000000000000 |        512.994175000000000000 | BEAN          
 0xbF776e4FCa664D791C4Ee3A71e2722990E003283 |        215.67 |       1298.399631416086336714 |       1298.399631416086336714 | SMTY          
 0xbc194e6f748a222754C3E8b9946922c09E7d4e91 |        216.49 |       1400.000000000000000000 |       1400.000000000000000000 | LEV           
 0xf4d861575ecc9493420a3f5a14f85b13f0b50eb3 |        217.03 |        907.720234720704743644 |        907.720234720704743644 | FCL           
 0x9be89d2a4cd102d8fecc6bf9da793be995c22541 |        217.99 |          0.005070920000000000 |          0.005070920000000000 | BBTC          
 0x94d863173ee77439e4292284ff13fad54b3ba182 |        220.03 |       5974.521950358935984128 |       5974.521950358935984128 | ADEL          
 0x7dd9c5cba05e151c895fde1cf355c9a1d5da6429 |        221.05 |        469.757912560000000000 |        469.757912560000000000 | GLM           
 0xAAA7A10a8ee237ea61E8AC46C50A8Db8bCC1baaa |        221.57 |       8926.524738478153814416 |       8926.524738478153814416 | QANX          
 0xD2dDa223b2617cB616c1580db421e4cFAe6a8a85 |        221.72 |     418991.671841578318690268 |     418991.671841578318690268 | BONDLY        
 0x0488401c3f535193fa8df029d9ffe615a06e74e6 |        223.07 |      58638.004951851104086481 |      58638.004951851104086481 | SRK           
 0x275f5ad03be0fa221b4c6649b8aee09a42d9412a |        224.80 |          0.595329068800468176 |          0.595329068800468176 | MONA          
 0xc4de189abf94c57f396bd4c52ab13b954febefd8 |        226.45 |        288.097541683472391907 |        288.097541683472391907 | B20           
 0x9aeb50f542050172359a0e1a25a9933bc8c01259 |        228.44 |        584.642282890000000000 |        584.642282890000000000 | OIN           
 0x20c36f062a31865bed8a5b1e512d9a1a20aa333a |        229.25 |       2268.923037357867895637 |       2268.923037357867895637 | DFD           
 0x1c5db575e2ff833e46a2e9864c22f4b22e0b37c2 |        231.40 |          2.000000000000000000 |          2.000000000000000000 | renZEC        
 0x6c6ee5e31d828de241282b9606c8e98ea48526e2 |        236.43 |      29079.692268935219289959 |      29079.692268935219289959 | HOT           
 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0 |        238.83 |          0.076854205898296882 |          0.076854205898296882 | wstETH        
 0xa0bed124a09ac2bd941b10349d8d224fe3c955eb |        239.00 |        154.211696592795917459 |        154.211696592795917459 | DEPAY         
 0x29cbd0510eec0327992cd6006e63f9fa8e7f33b7 |        239.97 |      56260.292526116827037696 |      56260.292526116827037696 | TIDAL         
 0x9534ad65fb398e27ac8f4251dae1780b989d136e |        240.32 |         36.863372850324122070 |         36.863372850324122070 | PYR           
 0x8b6c3b7C01D9dB4393f9aa734750F36df1543E9A |        251.61 |       4521.185932042675979640 |       4521.185932042675979640 | VI            
 0x7865af71cf0b288b4e7f654f4f7851eb46a2b7f8 |        252.02 |      45770.012718963721069843 |      45770.012718963721069843 | SNTVT         
 0x71ba91dC68C6a206Db0A6A92B4b1De3f9271432d |        252.25 |      23887.886827228133725499 |      23887.886827228133725499 | wMBX          
 0xf1a91C7d44768070F711c68f33A7CA25c8D30268 |        252.60 |        147.113821110253069771 |        147.113821110253069771 | C3            
 0x49e833337ece7afe375e44f4e3e8481029218e5c |        252.89 |        211.940298296630128110 |        211.940298296630128110 | VALUE         
 0x178c820f862b14f316509ec36b13123da19a6054 |        253.17 |         29.852974312633597745 |         29.852974312633597745 | EWTB          
 0xe0ad1806fd3e7edf6ff52fdb822432e847411033 |        255.81 |        541.769312351558149892 |        541.769312351558149892 | ONX           
 0x3758e00b100876C854636eF8Db61988931BB8025 |        256.48 |        457.475913969649642768 |        457.475913969649642768 | UNIQ          
 0x9Dfc4B433D359024Eb3E810d77d60fbE8B0d9B82 |        257.49 |          2.050000000000000000 |          2.050000000000000000 | DANDY         
 0xd23ac27148af6a2f339bd82d0e3cff380b5093de |        259.25 |        612.217709978322967628 |        612.217709978322967628 | SI            
 0x8281eE37F164C0E26E6B6f87E7695Baac256dF07 |        261.36 |         27.029286236328340536 |         27.029286236328340536 | DAC           
 0xFAc3f6391C86004289A186Ae0198180fCB4D49Ab |        261.99 |       9288.206496975634591430 |       9288.206496975634591430 | IMPACT        
 0xb26631c6dda06ad89b93c71400d25692de89c068 |        262.05 |        167.276348940721377222 |        167.276348940721377222 | MINDS         
 0xbbff34e47e559ef680067a6b1c980639eeb64d24 |        263.93 |      18701.282999580518530025 |      18701.282999580518530025 | L2            
 0xbc6da0fe9ad5f3b0d58160288917aa56653660e9 |        264.89 |        279.475555525419827001 |        279.475555525419827001 | alUSD         
 0xaaaebe6fe48e54f431b0c390cfaf0b017d09d42d |        266.67 |         53.744400000000000000 |         53.744400000000000000 | CEL           
 0xee573a945b01b788b9287ce062a0cfc15be9fd86 |        267.36 |        606.389684685837388797 |        606.389684685837388797 | XED           
 0x618679dF9EfCd19694BB1daa8D00718Eacfa2883 |        270.17 |       1833.020162702150706511 |       1833.020162702150706511 | XYZ           
 0x1b40183efb4dd766f11bda7a7c3ad8982e998421 |        272.13 |         37.556241542271763227 |         37.556241542271763227 | VSP           
 0x1E1EEd62F8D82ecFd8230B8d283D5b5c1bA81B55 |        273.91 |          9.895800122231083708 |          9.895800122231083708 | GAMMA         
 0xaaaf91d9b90df800df4f55c205fd6989c977e73a |        275.57 |       1216.050313680000000000 |       1216.050313680000000000 | TKN           
 0x0fe629d1e84e171f8ff0c1ded2cc2221caa48a3f |        276.17 |          0.100384925794667298 |          0.100384925794667298 | MASK          
 0x106538cc16f938776c7c180186975bca23875287 |        277.19 |         46.271502691726686149 |         46.271502691726686149 | BASv2         
 0x896e145568624a498c5a909187363AE947631503 |        281.52 |         84.636794018020072435 |         84.636794018020072435 | WASABI        
 0x1321f1f1aa541a56c31682c57b80ecfccd9bb288 |        281.63 |        325.818267734741536304 |        325.818267734741536304 | ARCX          
 0x269616D549D7e8Eaa82DFb17028d0B212D11232A |        283.58 |          0.000982312917888717 |          0.000982312917888717 | PUNK          
 0x217ddEad61a42369A266F1Fb754EB5d3EBadc88a |        283.77 |        486.094282839398105618 |        486.094282839398105618 | DON           
 0xeb4c2781e4eba804ce9a9803c67d0893436bb27d |        285.91 |          0.006364130000000000 |          0.006364130000000000 | renBTC        
 0x0275E1001e293C46CFe158B3702AADe0B99f88a5 |        290.70 |        348.631788243282350728 |        348.631788243282350728 | OIL           
 0x7eaf9c89037e4814dc0d9952ac7f888c784548db |        293.41 |       3588.952108452445719642 |       3588.952108452445719642 | ROYA          
 0x1614f18fc94f47967a3fbe5ffcd46d4e7da3d787 |        295.42 |        594.783964337942679311 |        594.783964337942679311 | PAID          
 0x5EeAA2DCb23056F4E8654a349E57eBE5e76b5e6e |        296.39 |        399.713792959095656791 |        399.713792959095656791 | VPP           
 0xaA8330FB2B4D5D07ABFE7A72262752a8505C6B37 |        300.21 |       2324.750971247336954131 |       2324.750971247336954131 | POLC          
 0xeabb8996ea1662cad2f7fb715127852cd3262ae9 |        300.65 |        779.606139739669878722 |        779.606139739669878722 | CNFI          
 0x7240ac91f01233baaf8b064248e80feaa5912ba3 |        303.67 |         41.514575765071461684 |         41.514575765071461684 | OCTO          
 0x35bD01FC9d6D5D81CA9E055Db88Dc49aa2c699A8 |        304.59 |          2.854099814712181670 |          2.854099814712181670 | FWB           
 0xa8c8CfB141A3bB59FEA1E2ea6B79b5ECBCD7b6ca |        306.52 |        812.378510164320772162 |        812.378510164320772162 | NOIA          
 0x295B42684F90c77DA7ea46336001010F2791Ec8c |        306.88 |      11074.062265648059759654 |      11074.062265648059759654 | XI            
 0x36CE7a52CDa404b8fa87a98d0d17EC7dd0B144ED |        316.22 |        834.168776094527512448 |        834.168776094527512448 | PSLIP         
 0xf974b5f9Ac9c6632FeE8b76C61B0242ce69C839D |        318.87 |     100091.187502458999316074 |     100091.187502458999316074 | ZYX           
 0xe4815ae53b124e7263f08dcdbbb757d41ed658c6 |        321.23 |        475.086706375559177726 |        475.086706375559177726 | ZKS           
 0x33840024177a7daca3468912363bed8b425015c5 |        321.58 |       4855.309414247489459726 |       4855.309414247489459726 | EBOX          
 0x94804dc4948184fFd7355f62Ccbb221c9765886F |        322.12 |      21051.745231044013450706 |      21051.745231044013450706 | RAGE          
 0xea1ea0972fa092dd463f2968f9bb51cc4c981d71 |        323.21 |        335.906280848372192278 |        335.906280848372192278 | MOD           
 0xa283aa7cfbb27ef0cfbcb2493dd9f4330e0fd304 |        325.61 |        102.838987016354041145 |        102.838987016354041145 | MM_1          
 0x21bfbda47a0b4b5b1248c767ee49f7caa9b23697 |        325.96 |        509.665906899149194295 |        509.665906899149194295 | OVR           
 0x91dfbee3965baaee32784c2d546b7a0c62f268c9 |        326.81 |       4587.840632873377815952 |       4587.840632873377815952 | BONDLY        
 0x0391d2021f89dc339f60fff84546ea23e337750f |        329.85 |         14.094872658409783285 |         14.094872658409783285 | BOND          
 0xc944e90c64b2c07662a292be6244bdf05cda44a7 |        334.49 |        468.118656323834702332 |        468.118656323834702332 | GRT           
 0xfc979087305a826c2b2a0056cfaba50aad3e6439 |        334.59 |       7965.814563830775238834 |       7965.814563830775238834 | DAFI          
 0x68CFb82Eacb9f198d508B514d898a403c449533E |        337.38 |       1000.000000000000000000 |       1000.000000000000000000 | CMK           
 0x28Cca76f6e8eC81e4550ecd761f899110b060E97 |        340.84 |       1910.590300629059833473 |       1910.590300629059833473 | ARGO          
 0x08c32b0726C5684024ea6e141C50aDe9690bBdcc |        342.14 |        280.304003501725451025 |        280.304003501725451025 | STOS          
 0xc690f7c7fcffa6a82b79fab7508c466fefdfc8c5 |        343.33 |      35404.539891348534054247 |      35404.539891348534054247 | LYM           
 0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd |        346.24 |       5791.462191157083873905 |       5791.462191157083873905 | RAZOR         
 0x1cbb83ebcd552d5ebf8131ef8c9cd9d9bab342bc |        346.40 |         10.718306990433003574 |         10.718306990433003574 | NFY           
 0xb1f871ae9462f1b2c6826e88a7827e76f86751d4 |        351.30 |       1462.057983140989104277 |       1462.057983140989104277 | GNYerc20      
 0x4946fcea7c692606e8908002e55a582af44ac121 |        356.65 |       5423.690273775101370700 |       5423.690273775101370700 | FOAM          
 0x408e41876cccdc0f92210600ef50372656052a38 |        358.34 |        369.159610853381465963 |        369.159610853381465963 | REN           
 0xfe9a29ab92522d14fc65880d817214261d8479ae |        362.04 |         26.739476328905347344 |         26.739476328905347344 | SNOW          
 0xAF691508BA57d416f895e32a1616dA1024e882D2 |        362.78 |       4677.288559719188823635 |       4677.288559719188823635 | PNODE         
 0xfbeea1c75e4c4465cb2fccc9c6d6afe984558e20 |        366.89 |         26.495640474023425344 |         26.495640474023425344 | DDIM          
 0x0b38210ea11411557c13457d4da7dc6ea731b88a |        368.04 |         94.289265191982356806 |         94.289265191982356806 | API3          
 0x000000000000d0151e748d25b766e77efe2a6c83 |        368.76 |      14192.722142512065635676 |      14192.722142512065635676 | XDEX          
 0xd55236D48606c295adEbF129dAD04Fc74BFaA708 |        370.63 |        824.511841338307404841 |        824.511841338307404841 | CW            
 0xe5caef4af8780e59df925470b050fb23c43ca68c |        375.23 |       1591.876267000000000000 |       1591.876267000000000000 | FRM           
 0x45080a6531d671DDFf20DB42f93792a489685e32 |        387.46 |      27223.880222782745061507 |      27223.880222782745061507 | FVT           
 0x93C9175E26F57d2888c7Df8B470C9eeA5C0b0A93 |        387.96 |       1505.079048701236560056 |       1505.079048701236560056 | BCUBE         
 0x33f391F4c4fE802b70B77AE37670037A92114A7c |        389.00 |       3587.238937525379608824 |       3587.238937525379608824 | BURP          
 0x9355372396e3F6daF13359B7b607a3374cc638e0 |        392.37 |         31.809200000000000000 |         31.809200000000000000 | WHALE         
 0x3F3Cd642E81d030D7b514a2aB5e3a5536bEb90Ec |        396.33 |          1.559421945531086448 |          1.559421945531086448 | RHO           
 0x8B3870Df408fF4D7C3A26DF852D41034eDa11d81 |        410.56 |        145.271202000000000000 |        145.271202000000000000 | IOI           
 0xf2051511B9b121394FA75B8F7d4E7424337af687 |        410.74 |         27.010513141794038974 |         27.010513141794038974 | HAUS          
 0x30BCd71b8d21FE830e493b30e90befbA29de9114 |        410.86 |        108.388838439223685711 |        108.388838439223685711 | 🐟            
 0xdddddd4301a082e62e84e43f474f044423921918 |        414.32 |        137.317978386197387681 |        137.317978386197387681 | DVF           
 0xd13c7342e1ef687c5ad21b27c2b65d772cab5c8c |        415.00 |        705.630700000000000000 |        705.630700000000000000 | UOS           
 0xaf9f549774ecedbd0966c52f250acc548d3f36e5 |        416.45 |       9110.046034420141260800 |       9110.046034420141260800 | RFuel         
 0x260e63d91fccc499606bae3fe945c4ed1cf56a56 |        419.25 |         10.000000000000000000 |         10.000000000000000000 | MOONS         
 0xca1207647ff814039530d7d35df0e1dd2e91fa84 |        421.67 |        438.094099170085201502 |        438.094099170085201502 | DHT           
 0xC242Eb8e4E27EAE6a2A728A41201152F19595C83 |        421.96 |         57.061802604691987834 |         57.061802604691987834 | ECO           
 0x6468e79a80c0eab0f9a2b574c8d5bc374af59414 |        422.03 |       3615.581764886636098582 |       3615.581764886636098582 | eXRD          
 0x675BBC7514013E2073DB7a919F6e4cbeF576de37 |        425.02 |        144.644512818347031292 |        144.644512818347031292 | CLS           
 0xfe3e6a25e6b192a42a44ecddcd13796471735acf |        428.02 |      21444.715828700527912738 |      21444.715828700527912738 | REEF          
 0xa117000000f279d81a1d3cc75430faa017fa5a2e |        428.18 |         89.697624769935060591 |         89.697624769935060591 | ANT           
 0x6c5fbc90E4D78F70Cc5025dB005B39B03914fC0c |        429.13 |          8.161412152637971859 |          8.161412152637971859 | URUS          
 0x20a68F9e34076b2dc15ce726d7eEbB83b694702d |        431.67 |        739.155724494664643746 |        739.155724494664643746 | ISLA          
 0xbfD815347d024F449886c171f78Fa5B8E6790811 |        434.39 |        157.514106967052692792 |        157.514106967052692792 | AAPX          
 0x544c42fbb96b39b21df61cf322b5edc285ee7429 |        434.91 |        212.383545775039084258 |        212.383545775039084258 | INSUR         
 0xdb25f211ab05b1c97d595516f45794528a807ad8 |        446.74 |        385.700000000000000000 |        385.700000000000000000 | EURS          
 0x6b3595068778dd592e39a122f4f5a5cf09c90fe2 |        449.31 |         44.956144820789523710 |         44.956144820789523710 | SUSHI         
 0xf418588522d5dd018b425e472991e52ebbeeeeee |        452.14 |        152.675465497459117955 |        152.675465497459117955 | PUSH          
 0xDB5C3C46E28B53a39C255AA39A411dD64e5fed9c |        455.48 |       2007.485536395594985485 |       2007.485536395594985485 | NCR           
 0xBeD4AB0019ff361d83ddeB74883DAC8a70f5ea1e |        458.04 |       4337.174442402087205654 |       4337.174442402087205654 | MRCH          
 0x865377367054516e17014CcdED1e7d814EDC9ce4 |        460.02 |        517.555518485225131073 |        517.555518485225131073 | DOLA          
 0x7778360F035C589fCE2f4eA5786CbD8B36e5396B |        465.82 |       2113.761631060678868362 |       2113.761631060678868362 | OOE           
 0x9e547061A345015869D26C7B6Ee4aB5b63424441 |        469.90 |         61.508236011352983208 |         61.508236011352983208 | CC            
 0x0a50c93c762fdd6e56d86215c24aaad43ab629aa |        472.09 |       1572.779044620000000000 |       1572.779044620000000000 | LGO           
 0x23b608675a2b2fb1890d3abbd85c5775c51691d5 |        478.07 |          0.005918545718324565 |          0.005918545718324565 | SOCKS         
 0xE4f726Adc8e89C6a6017F01eadA77865dB22dA14 |        478.45 |        153.339009975110305182 |        153.339009975110305182 | BCP           
 0x66c0dded8433c9ea86c8cf91237b14e10b4d70b7 |        487.07 |      46574.526100826550613729 |      46574.526100826550613729 | Mars          
 0xFA99A87b14B02e2240C79240C5a20F945ca5EF76 |        487.24 |       1290.661590167749294405 |       1290.661590167749294405 | GGTK          
 0x875773784af8135ea0ef43b5a374aad105c5d39e |        487.64 |        124.262843725047678980 |        124.262843725047678980 | IDLE          
 0xea7Cc765eBC94C4805e3BFf28D7E4aE48D06468A |        489.57 |        389.868355794982045273 |        389.868355794982045273 | PAD           
 0x8287C7b963b405b7B8D467DB9d79eEC40625b13A |        492.27 |       8092.749304618224812032 |       8092.749304618224812032 | SWINGBY       
 0xbA7970f10D9f0531941DcEd1dda7ef3016B24e5b |        493.45 |       7624.055493286495424735 |       7624.055493286495424735 | BGLD          
 0xf411903cbc70a74d22900a5de66a2dda66507255 |        497.13 |      15368.705456992155667102 |      15368.705456992155667102 | VRA           
 0x221657776846890989a759ba2973e427dff5c9bb |        502.96 |         24.246004605622350485 |         24.246004605622350485 | REPv2         
 0x6fc13eace26590b80cccab1ba5d51890577d83b2 |        505.91 |       1139.182043672460039480 |       1139.182043672460039480 | UMB           
 0x8207c1ffc5b6804f6024322ccf34f29c3541ae26 |        512.94 |        639.858356863566584588 |        639.858356863566584588 | OGN           
 0xb6c4267c4877bb0d6b1685cfd85b0fbe82f105ec |        514.63 |        200.000000000000000000 |        200.000000000000000000 | REL           
 0x10be9a8dae441d276a5027936c3aaded2d82bc15 |        515.99 |        541.857712792587471471 |        541.857712792587471471 | UMX           
 0x07bac35846e5ed502aa91adf6a9e7aa210f2dcbe |        517.48 |       1913.073772471552237281 |       1913.073772471552237281 | erowan        
 0x9f9c8ec3534c3ce16f928381372bfbfbfb9f4d24 |        518.88 |      18279.102345853859287877 |      18279.102345853859287877 | GLQ           
 0x27054b13b1b798b345b591a4d22e6562d47ea75a |        523.42 |       2146.958000000000000000 |       2146.958000000000000000 | AST           
 0x7f3edcdd180dbe4819bd98fee8929b5cedb3adeb |        530.56 |       8618.538233628744708749 |       8618.538233628744708749 | XTK           
 0x4fe83213d56308330ec302a8bd641f1d0113a4cc |        532.87 |       1866.225180211865559191 |       1866.225180211865559191 | NU            
 0xe796d6ca1ceb1b022ece5296226bf784110031cd |        534.89 |       4153.068442264329946149 |       4153.068442264329946149 | BLES          
 0xefc1c73a3d8728dc4cf2a18ac5705fe93e5914ac |        546.99 |        587.168904089889534778 |        587.168904089889534778 | METRIC        
 0x4c19596f5aaff459fa38b0f7ed92f11ae6543784 |        548.84 |       1173.171568630000000000 |       1173.171568630000000000 | TRU           
 0x0d438f3b5175bebc262bf23753c1e53d03432bde |        549.38 |          9.333184293098532426 |          9.333184293098532426 | wNXM          
 0x41d5d79431a913c4ae7d69a668ecdfe5ff9dfb68 |        550.69 |          4.652814877748889130 |          4.652814877748889130 | INV           
 0xcf3c8be2e2c42331da80ef210e9b1b307c03d36a |        553.19 |      69811.645721575523423390 |      69811.645721575523423390 | BEPRO         
 0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c |        555.66 |        410.632892686667104286 |        410.632892686667104286 | ENJ           
 0xBAac2B4491727D78D2b78815144570b9f2Fe8899 |        562.82 |      66748.674822205247656119 |      66748.674822205247656119 | DOG           
 0x0E58ED58E150dba5fd8e5D4A49F54C7e1E880124 |        564.80 |      12188.639654939989442560 |      12188.639654939989442560 | RELI          
 0xfb7b4564402e5500db5bb6d63ae671302777c75a |        568.17 |       1218.810040921854005792 |       1218.810040921854005792 | DEXT          
 0xabe580e7ee158da464b51ee1a83ac0289622e6be |        569.00 |        242.683312594336585524 |        242.683312594336585524 | XFT           
 0x02D3A27Ac3f55d5D91Fb0f52759842696a864217 |        575.98 |        571.587242347402305516 |        571.587242347402305516 | IONX          
 0x037a54aab062628c9bbae1fdb1583c195585fe41 |        576.21 |       4509.766894824155193323 |       4509.766894824155193323 | LCX           
 0x1559fa1b8f28238fd5d76d9f434ad86fd20d1559 |        584.81 |        115.598894815916834217 |        115.598894815916834217 | EDEN          
 0xf203Ca1769ca8e9e8FE1DA9D147DB68B6c919817 |        593.11 |        512.890920401630733828 |        512.890920401630733828 | WNCG          
 0x0c7d5ae016f806603cb1782bea29ac69471cab9c |        593.38 |       2056.953515509078737140 |       2056.953515509078737140 | BFC           
 0x1ceb5cb57c4d4e2b2433641b95dd330a33185a44 |        595.24 |          1.758649610638943517 |          1.758649610638943517 | KP3R          
 0x62Dc4817588d53a056cBbD18231d91ffCcd34b2A |        602.90 |        691.466394302477801848 |        691.466394302477801848 | DHV           
 0xc3771d47e2ab5a519e2917e61e23078d0c05ed7f |        603.32 |       4921.118851152602767620 |       4921.118851152602767620 | GTH           
 0xd0660cd418a64a1d44e9214ad8e459324d8157f1 |        608.31 |      21417.957156670716000000 |      21417.957156670716000000 | WOOFY         
 0x24C19F7101c1731b85F1127EaA0407732E36EcDD |        608.52 |       1829.959418120533726346 |       1829.959418120533726346 | SGT           
 0xEE1CeA7665bA7aa97e982EdeaeCb26B59a04d035 |        609.97 |      20000.000000000000000000 |      20000.000000000000000000 | ORAO          
 0x25e1474170c4c0aa64fa98123bdc8db49d7802fa |        616.37 |      44582.410869235028463029 |      44582.410869235028463029 | BID           
 0xBd3de9a069648c84d27d74d701C9fa3253098B15 |        617.42 |       1706.554067148796988693 |       1706.554067148796988693 | EQX           
 0x607f4c5bb672230e8672085532f7e901544a7375 |        618.09 |        188.273476403000000000 |        188.273476403000000000 | RLC           
 0xaa6e8127831c9de45ae56bb1b0d4d4da6e5665bd |        619.47 |          5.536816550582429731 |          5.536816550582429731 | ETH2x-FLI     
 0x888888435fde8e7d4c54cab67f206e4199454c60 |        625.72 |       1610.860560160771475516 |       1610.860560160771475516 | DFX           
 0xe1c7e30c42c24582888c758984f6e382096786bd |        626.18 |        264.427971180000000000 |        264.427971180000000000 | XCUR          
 0x22ACaEe85dDB83a3A33B7f0928a0e2c3bFDb6a4F |        626.38 |        122.073798931136941859 |        122.073798931136941859 | PRXY          
 0x6b4c7a5e3f0b99fcd83e9c089bddd6c7fce5c611 |        628.16 |         42.416285464819075382 |         42.416285464819075382 | MM_2          
 0xc4c2614e694cf534d407ee49f8e44d125e4681c4 |        629.01 |       4260.348796793740368741 |       4260.348796793740368741 | CHAIN         
 0xb9ef770b6a5e12e45983c5d80545258aa38f3b78 |        630.28 |       1942.754614699900000000 |       1942.754614699900000000 | ZCN           
 0x0000000000004946c0e9f43f4dee607b0ef1fa1c |        631.05 |       3006.000000000000000000 |       3006.000000000000000000 | CHI           
 0x9F284E1337A815fe77D2Ff4aE46544645B20c5ff |        633.14 |          9.276336215734282247 |          9.276336215734282247 | unknown token 
 0x3aaDA3e213aBf8529606924d8D1c55CbDc70Bf74 |        633.88 |          0.093013889094234532 |          0.093013889094234532 | XMON          
 0x07cA256267128FBE1A79B74Fc7b0e6ed3359ad08 |        635.88 |        125.645271182000000000 |        125.645271182000000000 | WWT           
 0x2f109021afe75b949429fe30523ee7c0d5b27207 |        639.55 |         79.566173654678586483 |         79.566173654678586483 | OCC           
 0xd9c2d319cd7e6177336b0a9c93c21cb48d84fb54 |        641.06 |         13.064139485061806205 |         13.064139485061806205 | HAPI          
 0x0f5d2fb29fb7d3cfee444a200298f468908cc942 |        641.80 |        893.472602627151496960 |        893.472602627151496960 | MANA          
 0x8798249c2e607446efb7ad49ec89dd1865ff4272 |        644.95 |         54.851508220828575529 |         54.851508220828575529 | xSUSHI        
 0xE66b3AA360bB78468c00Bebe163630269DB3324F |        649.37 |       2320.018665865384615385 |       2320.018665865384615385 | MTO           
 0x4Cf89ca06ad997bC732Dc876ed2A7F26a9E7f361 |        666.34 |       1747.415754034973612213 |       1747.415754034973612213 | MYST          
 0xD567B5F02b9073aD3a982a099a23Bf019FF11d1c |        666.38 |        332.799850000000000000 |        332.799850000000000000 | GAME          
 0x817bbdbc3e8a1204f3691d14bb44992841e3db35 |        670.82 |      23950.609633766459114089 |      23950.609633766459114089 | CUDOS         
 0x114f1388fAB456c4bA31B1850b244Eedcd024136 |        671.95 |          0.031176589501295600 |          0.031176589501295600 | COOL          
 0x8e2B4badaC15a4ec8c56020f4Ce60faa7558c052 |        672.50 |       8803.997356540051184057 |       8803.997356540051184057 | CNFT          
 0x7a2bc711e19ba6aff6ce8246c546e8c4b4944dfd |        672.81 |          2.868882270000000000 |          2.868882270000000000 | WAXE          
 0x8a9c4dfe8b9d8962b31e4e16f8321c44d48e246e |        679.34 |      17115.182145563464022437 |      17115.182145563464022437 | NCT           
 0x0000000000085d4780b73119b644ae5ecd22b376 |        691.50 |        696.063630047631769374 |        696.063630047631769374 | TUSD          
 0x44564d0bd94343f72e3c8a0d22308b7fa71db0bb |        693.45 |         44.729710434719791105 |         44.729710434719791105 | BASK          
 0x476c5e26a75bd202a9683ffd34359c0cc15be0ff |        706.14 |         89.077032000000000000 |         89.077032000000000000 | SRM           
 0x20a8CEC5fffea65Be7122BCaB2FFe32ED4Ebf03a |        708.16 |       1229.459263881323374754 |       1229.459263881323374754 | DNXC          
 0x84CD68c3e470eCEE4b8b6212eFcB8C6BcB38DA1D |        708.98 |        133.483332210220248805 |        133.483332210220248805 | BND           
 0x8ab7404063ec4dbcfd4598215992dc3f8ec853d7 |        714.42 |      29005.395015093174688817 |      29005.395015093174688817 | AKRO          
 0xe516D78d784C77D479977BE58905B3f2b1111126 |        719.12 |     109515.815187828576152441 |     109515.815187828576152441 | SPWN          
 0x9506d37f70eB4C3d79C398d326C871aBBf10521d |        722.04 |       5006.416527064628854784 |       5006.416527064628854784 | MLT           
 0x16980b3b4a3f9d89e33311b5aa8f80303e5ca4f8 |        727.12 |       1333.343394000000000000 |       1333.343394000000000000 | KEX           
 0x85eee30c52b0b379b046fb0f85f4f3dc3009afec |        727.15 |       1902.648652971304000565 |       1902.648652971304000565 | KEEP          
 0xF5cFBC74057C610c8EF151A439252680AC68c6DC |        731.94 |        205.061688572217380662 |        205.061688572217380662 | OCT           
 0x67b6d479c7bb412c54e03dca8e1bc6740ce6b99c |        732.47 |       3216.762708196724521423 |       3216.762708196724521423 | KYL           
 0x5218e472cfcfe0b64a064f055b43b4cdc9efd3a6 |        737.48 |       3626.883014684913600361 |       3626.883014684913600361 | eRSDL         
 0x3d6f0dea3ac3c607b3998e6ce14b6350721752d9 |        739.03 |         52.509385604878305465 |         52.509385604878305465 | CARDS         
 0xe41d2489571d322189246dafa5ebde1f4699f498 |        742.56 |        781.503819434326000513 |        781.503819434326000513 | ZRX           
 0x220b71671b649c03714da9c621285943f3cbcdc6 |        743.27 |         15.811179489799893323 |         15.811179489799893323 | DIS           
 0x808507121b80c02388fad14726482e061b8da827 |        744.95 |       1705.221376375268797832 |       1705.221376375268797832 | PENDLE        
 0xe469c4473af82217B30CF17b10BcDb6C8c796e75 |        745.08 |   30492469.000000000000000000 |   30492469.000000000000000000 | EXRN          
 0xffffffff2ba8f66d4e51811c5190992176930278 |        746.77 |       3214.610458325055054508 |       3214.610458325055054508 | COMBO         
 0xdd974d5c2e2928dea5f71b9825b8b646686bd200 |        747.20 |        496.221094543694163792 |        496.221094543694163792 | KNCL          
 0xae697f994fc5ebc000f8e22ebffee04612f98a0d |        747.93 |      60125.537571088520864808 |      60125.537571088520864808 | LGCY          
 0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2 |        749.98 |       1052.748064662257467846 |       1052.748064662257467846 | MTA           
 0x1e3a2446C729D34373B87FD2C9CBb39A93198658 |        750.69 |        646.739149381868318054 |        646.739149381868318054 | DSD           
 0x6fE88a211863D0d818608036880c9A4b0EA86795 |        756.80 |        499.317710575633538654 |        499.317710575633538654 | QFI           
 0x948c70Dc6169Bfb10028FdBE96cbC72E9562b2Ac |        760.07 |        338.325193211093789622 |        338.325193211093789622 | XP            
 0x00c83aecc790e8a4453e5dd3b0b4b3680501a7a7 |        762.29 |       2303.629153479854850702 |       2303.629153479854850702 | SKL           
 0xE0e05c43c097B0982Db6c9d626c4eb9e95C3b9ce |        764.17 |       1477.070262504929221863 |       1477.070262504929221863 | USF           
 0x6710c63432a2de02954fc0f851db07146a6c0312 |        765.28 |      16971.044562906790509129 |      16971.044562906790509129 | MFG           
 0x3506424f91fd33084466f402d5d97f05f8e3b4af |        768.33 |       2856.868762944713011961 |       2856.868762944713011961 | CHZ           
 0x21381e026Ad6d8266244f2A583b35F9E4413FA2a |        768.74 |       3988.209820030165118020 |       3988.209820030165118020 | FORM          
 0x3d3d35bb9bec23b06ca00fe472b50e7a4c692c30 |        775.58 |       4757.346802679475437958 |       4757.346802679475437958 | VIDYA         
 0x0a913bead80f321e7ac35285ee10d9d922659cb7 |        776.02 |      25567.109986628340422834 |      25567.109986628340422834 | DOS           
 0x725c263e32c72ddc3a19bea12c5a0479a81ee688 |        779.54 |       2026.232212296067844886 |       2026.232212296067844886 | BMI           
 0x374cb8c27130e2c9e04f44303f3c8351b9de61c1 |        787.47 |    2229269.975341429518093210 |    2229269.975341429518093210 | BAO           
 0x679131f591b4f369acb8cd8c51e68596806c3916 |        802.30 |      41307.358219203473963874 |      41307.358219203473963874 | TLN           
 0xd5525d397898e5502075ea5e830d8914f6f0affe |        804.16 |          1.846573090000000000 |          1.846573090000000000 | MEME          
 0x0258f474786ddfd37abce6df6bbb1dd5dfc4434a |        812.23 |         91.613213620000000000 |         91.613213620000000000 | ORN           
 0x6c936D4AE98E6d2172dB18c16C4b601C99918EE6 |        815.32 |      92880.256847170053785649 |      92880.256847170053785649 | LIFE          
 0x674c6ad92fd080e4004b2312b45f796a192d27a0 |        815.62 |        850.462497537285617058 |        850.462497537285617058 | USDN          
 0x0f2D719407FdBeFF09D87557AbB7232601FD9F29 |        819.81 |        474.758669500715970868 |        474.758669500715970868 | SYN           
 0x4e15361fd6b4bb609fa63c81a2be19d873717870 |        824.51 |        691.747463855981057658 |        691.747463855981057658 | FTM           
 0x519C1001D550C0a1DaE7d1fC220f7d14c2A521BB |        824.58 |      13556.449319181092229371 |      13556.449319181092229371 | PSWAP         
 0xdc8aF07A7861bedD104B8093Ae3e9376fc8596D2 |        826.28 |       9422.356334325263433074 |       9422.356334325263433074 | RVF           
 0x0d8775f648430679a709e98d2b0cb6250d2887ef |        830.58 |       1248.612346736022751765 |       1248.612346736022751765 | BAT           
 0xbbc2ae13b23d715c30720f079fcd9b4a74093505 |        832.69 |         79.907826590483634017 |         79.907826590483634017 | ERN           
 0x8b0e42f366ba502d787bb134478adfae966c8798 |        836.22 |      95601.014390170837667863 |      95601.014390170837667863 | LABS          
 0x557b933a7c2c45672b610f8954a3deb39a51a8ca |        836.89 |       6098.479491349744404165 |       6098.479491349744404165 | REVV          
 0x9A24B8E8A6D4563c575A707b1275381119298E60 |        837.29 |          0.984391116064920378 |          0.984391116064920378 | EVNY          
 0xcbfef8fdd706cde6f208460f2bf39aa9c785f05d |        840.42 |        341.204848509331202830 |        341.204848509331202830 | KINE          
 0x27c70cd1946795b66be9d954418546998b546634 |        842.08 |          1.105088964820457002 |          1.105088964820457002 | LEASH         
 0xc719d010b63e5bbf2c0551872cd5316ed26acd83 |        843.24 |       7892.251223441830826345 |       7892.251223441830826345 | DIP_Insurance 
 0x1f3f9d3068568f8040775be2e8c03c103c61f3af |        844.07 |        168.224235636694917244 |        168.224235636694917244 | ARCH          
 0x961c8c0b1aad0c0b10a51fef6a867e3091bcef17 |        846.29 |       1784.462023007222694103 |       1784.462023007222694103 | DYP           
 0x06f3c323f0238c72bf35011071f2b5b7f43a054c |        852.98 |       5533.468627226520482987 |       5533.468627226520482987 | MASQ          
 0xf3dcbc6d72a4e1892f7917b7c43b74131df8480e |        856.45 |       5707.829343028016578913 |       5707.829343028016578913 | BDP           
 0xf3ae5d769e153ef72b4e3591ac004e89f48107a1 |        858.84 |       7128.669225365754188162 |       7128.669225365754188162 | DPR           
 0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2 |        859.23 |          0.362564059440801071 |          0.362564059440801071 | MKR           
 0xcc4304a31d09258b0029ea7fe63d032f52e44efe |        863.84 |        788.915850090872052406 |        788.915850090872052406 | SWAP          
 0x038a68ff68c393373ec894015816e33ad41bd564 |        869.81 |       1360.178011684840345752 |       1360.178011684840345752 | GLCH          
 0x69af81e73a73b40adf4f3d4223cd9b1ece623074 |        872.16 |         86.278411078596654576 |         86.278411078596654576 | MASK_NTWRK    
 0x8642a849d0dcb7a15a974794668adcfbe4794b56 |        877.28 |        311.413642085477896987 |        311.413642085477896987 | PROS          
 0x0FD10b9899882a6f2fcb5c371E17e70FdEe00C38 |        877.40 |        677.962789528109701836 |        677.962789528109701836 | PUNDIX        
 0x57b946008913b82e4df85f501cbaed910e58d26c |        883.29 |       9773.535641618800764871 |       9773.535641618800764871 | POND          
 0xDBdDf072d7aae7B9288e31A4eebe6C54e3a143b1 |        886.32 |      52057.493310485074564729 |      52057.493310485074564729 | CRWNY         
 0x88A9A52F944315D5B4e917b9689e65445C401E83 |        888.88 |       1129.068279998951123872 |       1129.068279998951123872 | FEAR          
 0xc7283b66eb1eb5fb86327f08e1b5816b0720212b |        901.30 |       1544.956731685423307887 |       1544.956731685423307887 | TRIBE         
 0x321c2fe4446c7c963dc41dd58879af648838f98d |        905.02 |         27.552725522794006952 |         27.552725522794006952 | CTX           
 0x4fabb145d64652a948d72533023f6e7a623c7c53 |        941.28 |        945.881242361599405409 |        945.881242361599405409 | BUSD          
 0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713 |        943.44 |          6.158258266267325104 |          6.158258266267325104 | COVER         
 0xf4cd3d3fda8d7fd6c5a500203e38640a70bf9577 |        946.72 |          0.975138912068347349 |          0.975138912068347349 | Yf-DAI        
 0xf94b5c5651c888d928439ab6514b93944eee6f48 |        949.03 |       2089.380282008498193648 |       2089.380282008498193648 | YLD_APP       
 0xdacd69347de42babfaecd09dc88958378780fb62 |        949.41 |      16025.000000000000000000 |      16025.000000000000000000 | ATRI          
 0x8052327F1BAF94A9DC8B26b9100f211eE3774f54 |        958.62 |        948.713457626313558160 |        948.713457626313558160 | ATD           
 0xee06a81a695750e71a662b51066f2c74cf4478a0 |        967.75 |          4.270591360224178245 |          4.270591360224178245 | $DG           
 0xff20817765cb7f73d4bde2e66e067e58d11095c2 |        971.89 |      20082.888871919995890225 |      20082.888871919995890225 | AMP           
 0x53c8395465a84955c95159814461466053dedede |        974.75 |       3933.723465170316717797 |       3933.723465170316717797 | DG            
 0xEF53462838000184F35f7D991452e5f25110b207 |        975.19 |       4200.000000000000000000 |       4200.000000000000000000 | KFT           
 0xd2877702675e6ceb975b4a1dff9fb7baf4c91ea9 |        982.42 |         27.133890777122384879 |         27.133890777122384879 | LUNA          
 0xD417144312DbF50465b1C641d016962017Ef6240 |        989.36 |        951.468076610988326795 |        951.468076610988326795 | CQT           
 0x4eE438be38F8682ABB089F2BFeA48851C5E71EAF |        990.36 |      16717.319371108872049363 |      16717.319371108872049363 | YAE           
 0x58b6a8a3302369daec383334672404ee733ab239 |        998.70 |         59.110742131044972072 |         59.110742131044972072 | LPT           
 0xcae72a7a0fd9046cf6b165ca54c9e3a3872109e0 |       1005.02 |      12287.056089085589396818 |      12287.056089085589396818 | $ANRX         
 0x0DC5189Ec8CDe5732a01F0F592e927B304370551 |       1011.70 |        185.977922691000000000 |        185.977922691000000000 | ASG           
 0x6c5ba91642f10282b576d91922ae6448c9d52f4e |       1020.93 |       1236.695200699641159413 |       1236.695200699641159413 | PHA           
 0x2260fac5e5542a773aa44fbcfedf7c193bc2c599 |       1022.86 |          0.022997870000000000 |          0.022997870000000000 | WBTC          
 0x17EF75AA22dD5f6C2763b8304Ab24f40eE54D48a |       1024.96 |      14078.554494835679869322 |      14078.554494835679869322 | RVP           
 0x6286A9e6f7e745A6D884561D88F94542d6715698 |       1029.05 |      18945.003563885451766685 |      18945.003563885451766685 | TECH          
 0xc57d533c50bc22247d49a368880fb49a1caa39f7 |       1030.36 |       3979.410010736175520581 |       3979.410010736175520581 | PTF           
 0x5caf454ba92e6f2c929df14667ee360ed9fd5b26 |       1031.81 |        342.322902721225995324 |        342.322902721225995324 | DEV           
 0x6de037ef9ad2725eb40118bb1702ebb27e4aeb24 |       1034.02 |       1143.122584642611460624 |       1143.122584642611460624 | RNDR          
 0x4c11249814f11b9346808179cf06e71ac328c1b5 |       1037.50 |        140.322737711575192025 |        140.322737711575192025 | ORAI          
 0x1a5f9352af8af974bfc03399e3767df6370d82e4 |       1039.18 |       1112.696186238807841720 |       1112.696186238807841720 | OWL           
 0x967da4048cd07ab37855c090aaf366e4ce1b9f48 |       1041.10 |       1472.285045531219629510 |       1472.285045531219629510 | OCEAN         
 0xD85AD783cc94bd04196a13DC042A3054a9B52210 |       1049.40 |      11158.373554386058776468 |      11158.373554386058776468 | HAKA          
 0x63b4f3e3fa4e438698ce330e365e831f7ccd1ef4 |       1049.60 |        121.770544846861475289 |        121.770544846861475289 | CFi           
 0x1796ae0b0fa4862485106a0de9b654efe301d0b2 |       1052.49 |         73.398257421850468862 |         73.398257421850468862 | PMON          
 0x1337def16f9b486faed0293eb623dc8395dfe46a |       1061.37 |       8560.209466188070464260 |       8560.209466188070464260 | ARMOR         
 0xdd1ad9a21ce722c151a836373babe42c868ce9a4 |       1062.09 |      39721.073528789069548799 |      39721.073528789069548799 | UBI           
 0x50d1c9771902476076ecfc8b2a83ad6b9355a4c9 |       1078.27 |         19.938895207816613463 |         19.938895207816613463 | FTX Token     
 0xb20043f149817bff5322f1b928e89abfc65a9925 |       1081.05 |     246548.450232190000000000 |     246548.450232190000000000 | EXRT          
 0xe2f2a5c287993345a840db3b0845fbc70f5935a5 |       1086.56 |       1361.245883511511896775 |       1361.245883511511896775 | mUSD          
 0x755be920943eA95e39eE2DC437b268917B580D6e |       1090.47 |      14107.873679939659187850 |      14107.873679939659187850 | VVT           
 0xbbbbca6a901c926f240b89eacb641d8aec7aeafd |       1091.95 |       2779.350105641275843881 |       2779.350105641275843881 | LRC           
 0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e |       1098.74 |          0.037197845162537323 |          0.037197845162537323 | YFI           
 0x4e352cf164e64adcbad318c3a1e222e9eba4ce42 |       1110.44 |         34.800198846456762179 |         34.800198846456762179 | MCB           
 0xc813ea5e3b48bebeedb796ab42a30c5599b01740 |       1120.24 |      10416.077200000000000000 |      10416.077200000000000000 | NIOX          
 0xcFEB09C3c5F0f78aD72166D55f9e6E9A60e96eEC |       1121.87 |      10585.432328262072044833 |      10585.432328262072044833 | VEMP          
 0x2341Dd0A96a0Dab62Aa1efB93D59FF7F3bDB8932 |       1125.61 |       8537.840000000000000000 |       8537.840000000000000000 | PROT          
 0x5eaa69b29f99c84fe5de8200340b4e9b4ab38eac |       1126.30 |       9426.919072030302901772 |       9426.919072030302901772 | RAZE          
 0x8eef5a82e6aa222a60f009ac18c24ee12dbf4b41 |       1127.89 |       5507.580439854258039849 |       5507.580439854258039849 | TXL           
 0x40955D77F87123b71b145098358A60573ac7BE96 |       1135.99 |        276.330226847540919636 |        276.330226847540919636 | DAISY         
 0x0ff6ffcfda92c53f615a4a75d982f399c989366b |       1136.34 |       1456.727332291785244161 |       1456.727332291785244161 | LAYER         
 0xf65b5c5104c4fafd4b709d9d60a185eae063276c |       1147.22 |       3845.506603287200131580 |       3845.506603287200131580 | TRU_Truebit   
 0x2Dab4cE3490BB50b2EA4C07Ab1B6a9CfE29D89B3 |       1157.84 |          7.696740071247136329 |          7.696740071247136329 | COOL20        
 0xa456b515303B2Ce344E9d2601f91270f8c2Fea5E |       1158.95 |       9526.180050244696539455 |       9526.180050244696539455 | CORN          
 0x888888888889c00c67689029d7856aac1065ec11 |       1159.03 |        503.709453142260869984 |        503.709453142260869984 | OPIUM         
 0xc834fa996fa3bec7aad3693af486ae53d8aa8b50 |       1159.94 |      40027.622465364798124978 |      40027.622465364798124978 | CONV          
 0x7659CE147D0e714454073a5dd7003544234b6Aa0 |       1163.23 |        307.278270572955333755 |        307.278270572955333755 | XCAD          
 0x4104b135DBC9609Fc1A9490E61369036497660c8 |       1185.48 |        390.451872038602491936 |        390.451872038602491936 | APW           
 0xca3fe04c7ee111f0bbb02c328c699226acf9fd33 |       1190.65 |        316.445387602928520368 |        316.445387602928520368 | SEEN          
 0x84cffa78B2fBbeeC8c37391d2B12A04d2030845e |       1195.87 |      33184.643689521956627233 |      33184.643689521956627233 | DEFIT         
 0x3832d2f059e55934220881f831be501d180671a7 |       1209.29 |       5562.598193440000000000 |       5562.598193440000000000 | renDOGE       
 0xd46ba6d942050d489dbd938a2c909a5d5039a161 |       1213.03 |       1304.622856202000000000 |       1304.622856202000000000 | AMPL          
 0xeeaa40b28a2d1b0b08f6f97bb1dd4b75316c6107 |       1214.10 |        535.323029652563411903 |        535.323029652563411903 | GOVI          
 0xD502F487e1841Fdc805130e13eae80c61186Bc98 |       1217.06 |       1378.840811065941500348 |       1378.840811065941500348 | ITGR          
 0x2ba592f78db6436527729929aaf6c908497cb200 |       1239.57 |          8.206251933091412420 |          8.206251933091412420 | CREAM         
 0x741b0428Efdf4372A8DF6FB54B018dB5e5aB7710 |       1242.68 |       8403.301710180321118166 |       8403.301710180321118166 | ARTX          
 0xb6ca7399b4f9ca56fc27cbff44f4d2e4eef1fc81 |       1282.53 |         85.314563287953433905 |         85.314563287953433905 | MUSE          
 0x95a4492f028aa1fd432ea71146b433e7b4446611 |       1284.05 |       1643.907445775929288864 |       1643.907445775929288864 | APY           
 0xb753428af26e81097e7fd17f40c88aaa3e04902c |       1302.30 |          2.531932829710033372 |          2.531932829710033372 | SFI           
 0x80ab141f324c3d6f2b18b030f1c4e95d4d658778 |       1304.18 |         11.422274336838429677 |         11.422274336838429677 | DEA           
 0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed |       1311.96 |       1486.256494582422795691 |       1486.256494582422795691 | PNT           
 0xbb0e17ef65f82ab018d8edd776e8dd940327b28b |       1325.85 |         19.620258074892575947 |         19.620258074892575947 | AXS           
 0x7E9D8f07A64e363e97A648904a89fb4cd5fB94CD |       1327.53 |        264.375117328840952552 |        264.375117328840952552 | FF            
 0x528B3e98c63cE21C6f680b713918E0F89DfaE555 |       1329.67 |   71949285.992671434891906636 |   71949285.992671434891906636 | DXO           
 0x0f51bb10119727a7e5ea3538074fb341f56b09ad |       1334.00 |        504.097512438880636216 |        504.097512438880636216 | DAO           
 0x7825e833D495F3d1c28872415a4aee339D26AC88 |       1349.79 |       2159.395936340736347451 |       2159.395936340736347451 | TLOS          
 0x8888801af4d980682e47f1a9036e589479e835c5 |       1356.16 |         36.448538040225803270 |         36.448538040225803270 | MPH           
 0x01e0e2e61f554ecaaec0cc933e739ad90f24a86d |       1359.56 |        304.903199191400493007 |        304.903199191400493007 | GTON          
 0x87CDc02f0812f08Cd50F946793706fAD9c265e2d |       1363.17 |      32828.393317490143483300 |      32828.393317490143483300 | SANA          
 0xa8b61cff52564758a204f841e636265bebc8db9b |       1383.08 |      32219.692706819825633513 |      32219.692706819825633513 | YIELD         
 0x5a98fcbea516cf06857215779fd812ca3bef1b32 |       1388.30 |        297.539289608288353357 |        297.539289608288353357 | LDO           
 0x43dfc4159d86f3a37a5a4b3d4580b888ad7d4ddd |       1390.75 |       1177.184295006113892174 |       1177.184295006113892174 | DODO          
 0xec67005c4e498ec7f55e092bd1d35cbc47c91892 |       1411.76 |         10.150613510490636790 |         10.150613510490636790 | MLN           
 0x03ab458634910aad20ef5f1c8ee96f1d6ac54919 |       1433.36 |        478.660921436645995709 |        478.660921436645995709 | RAI           
 0x09a3ecafa817268f77be1283176b946c4ff2e608 |       1436.64 |        460.377607425052381533 |        460.377607425052381533 | MIR           
 0xb17C88bDA07D28B3838E0c1dE6a30eAfBCF52D85 |       1457.43 |       1832.882447769630340300 |       1832.882447769630340300 | SHFT          
 0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b |       1468.47 |          4.728646774490544666 |          4.728646774490544666 | DPI           
 0x3472a5a71965499acd81997a54bba8d852c6e53d |       1473.80 |         79.095984062612282145 |         79.095984062612282145 | BADGER        
 0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d |       1478.71 |      10333.198428252659601099 |      10333.198428252659601099 | PNK           
 0x24a6a37576377f63f194caa5f518a60f45b42921 |       1498.03 |         20.045951530309070300 |         20.045951530309070300 | BANK          
 0x87d73e916d7057945c9bcd8cdd94e42a6f47f776 |       1538.05 |         11.583630453478098628 |         11.583630453478098628 | NFTX          
 0x3e9bc21c9b189c09df3ef1b824798658d5011937 |       1539.93 |      43563.660789725032664197 |      43563.660789725032664197 | LINA          
 0x0eC9F76202a7061eB9b3a7D6B59D36215A7e37da |       1546.41 |        336.652410292258977937 |        336.652410292258977937 | BPT           
 0xae7ab96520de3a18e5e111b5eaab095312d7fe84 |       1550.86 |          0.528495995627240205 |          0.528495995627240205 | stETH         
 0x8cA9a0fbd8DB501F013F2e9e33a1B9dC129A48E0 |       1578.08 |     595069.092016099119752767 |     595069.092016099119752767 | DDDD          
 0x226f7b842e0f0120b7e194d05432b3fd14773a9d |       1591.59 |     116504.412334756640714749 |     116504.412334756640714749 | UNN           
 0xEd04915c23f00A313a544955524EB7DBD823143d |       1607.25 |      22173.666949490000000000 |      22173.666949490000000000 | ACH           
 0x54F9b4B4485543A815c51c412a9E20436A06491d |       1610.35 |      15176.303269152045142409 |      15176.303269152045142409 | BXX           
 0xebd9d99a3982d547c5bb4db7e3b1f9f14b67eb83 |       1616.20 |       5681.656511973284502642 |       5681.656511973284502642 | ID            
 0x00a8b738e453ffd858a7edf03bccfe20412f0eb0 |       1632.52 |       1823.210166924370221566 |       1823.210166924370221566 | ALBT          
 0xDa007777D86AC6d989cC9f79A73261b3fC5e0DA0 |       1633.78 |       1576.791708016803529284 |       1576.791708016803529284 | NODE          
 0x24EC2Ca132abf8F6f8a6E24A1B97943e31f256a7 |       1635.13 |      50197.898944369259062855 |      50197.898944369259062855 | MOOV          
 0xa0246c9032bc3a600820415ae600c6388619a14d |       1638.34 |          9.161322773444742464 |          9.161322773444742464 | FARM          
 0xA01199c61841Fce3b3daFB83FeFC1899715c8756 |       1657.07 |       2354.519973349703669090 |       2354.519973349703669090 | CIRUS         
 0xd6cAF5Bd23CF057f5FcCCE295Dcc50C01C198707 |       1667.19 |       7611.673253982811317825 |       7611.673253982811317825 | EVA           
 0xE94B97b6b43639E238c851A7e693F50033EfD75C |       1693.90 |       4891.468016079514901883 |       4891.468016079514901883 | RNBW          
 0x056fd409e1d7a124bd7017459dfea2f387b6d5cd |       1697.16 |       1710.280000000000000000 |       1710.280000000000000000 | GUSD          
 0x41A3Dba3D677E573636BA691a70ff2D606c29666 |       1704.16 |       4492.075272705256690711 |       4492.075272705256690711 | BLANK         
 0x0ace32f6e87ac1457a5385f8eb0208f37263b415 |       1709.54 |       1378.142099979900000000 |       1378.142099979900000000 | HBT           
 0x99D8a9C45b2ecA8864373A26D1459e3Dff1e17F3 |       1711.09 |       1732.618420831913964253 |       1732.618420831913964253 | MIM           
 0x04fa0d235c4abf4bcf4787af4cf447de572ef828 |       1715.93 |        180.570322886222063040 |        180.570322886222063040 | UMA           
 0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0 |       1720.87 |       1471.824714516441048239 |       1471.824714516441048239 | MATIC         
 0x0954906da0bf32d5479e25f46056d22f08464cab |       1726.21 |         51.713095306534845183 |         51.713095306534845183 | INDEX         
 0x012E0e6342308b247F36Ee500ECb14dc77a7a8C1 |       1728.99 |       5892.000000000000000000 |       5892.000000000000000000 | SKT           
 0x7b0c06043468469967dba22d1af33d77d44056c8 |       1753.30 |        970.804900000000000000 |        970.804900000000000000 | MRPH          
 0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0 |       1754.32 |        372.222414025075574345 |        372.222414025075574345 | FXS           
 0xa12D7e5319f5b43476eF19D1569E10097caCdFE2 |       1760.27 |      10481.718788102301722744 |      10481.718788102301722744 | MYTH          
 0xa1faa113cbe53436df28ff0aee54275c13b40975 |       1761.52 |       1936.149555696219760568 |       1936.149555696219760568 | ALPHA         
 0xe7aE6D0C56CACaf007b7e4d312f9af686a9E9a04 |       1762.21 |      17023.728175933675463054 |      17023.728175933675463054 | VAB           
 0x1456688345527be1f37e9e627da0837d6f08c925 |       1769.27 |       2325.829317488022760165 |       2325.829317488022760165 | USDP          
 0xAbeA7663c472648d674bd3403D94C858dFeEF728 |       1780.44 |          0.290459373418713663 |          0.290459373418713663 | PUDGY         
 0x18aaa7115705e8be94bffebde57af9bfc265b998 |       1795.27 |        847.011723645686165358 |        847.011723645686165358 | AUDIO         
 0xed40834a13129509a89be39a9be9c0e96a0ddd71 |       1828.38 |          7.740407267649618527 |          7.740407267649618527 | WARP          
 0xbc396689893d065f41bc2c6ecbee5e0085233447 |       1833.22 |        148.950237173647894651 |        148.950237173647894651 | PERP          
 0x656C00e1BcD96f256F224AD9112FF426Ef053733 |       1833.88 |       2171.176308851666405650 |       2171.176308851666405650 | EFI           
 0x1A4b46696b2bB4794Eb3D4c26f1c55F9170fa4C5 |       1837.06 |       1193.851695694158094130 |       1193.851695694158094130 | BIT           
 0x3a880652f47bfaa771908c07dd8673a787daed3a |       1839.02 |        350.642802286653770936 |        350.642802286653770936 | DDX           
 0x4691937a7508860f876c9c0a2a617e7d9e945d4b |       1844.30 |       3228.817522174411399518 |       3228.817522174411399518 | WOO           
 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 |       1865.48 |          0.620225016775089907 |          0.620225016775089907 | WETH          
 0x6c28aef8977c9b773996d0e8376d2ee379446f2f |       1882.38 |          5.215822986491355504 |          5.215822986491355504 | QUICK         
 0x188E817B02e635D482AE4D81e25DdA98A97C4a42 |       1882.98 |      42361.824994117090409646 |      42361.824994117090409646 | LITH          
 0x8b39b70e39aa811b69365398e0aace9bee238aeb |       1890.00 |       2218.728583462397224544 |       2218.728583462397224544 | PKF           
 0x7b3d36eb606f873a75a6ab68f8c999848b04f935 |       1902.07 |         15.845271095046239194 |         15.845271095046239194 | LOOT          
 0x8d137e3337eb1B58A222Fef2B2Cc7C423903d9cf |       1915.63 |          0.059442270716156865 |          0.059442270716156865 | SQGL          
 0xfa5047c9c78b8877af97bdcb85db743fd7313d4a |       1918.43 |         13.845211665418425976 |         13.845211665418425976 | ROOK          
 0xd8e3fb3b08eba982f2754988d70d57edc0055ae6 |       1921.15 |          1.630492037000000000 |          1.630492037000000000 | ZORA          
 0xac3211a5025414af2866ff09c23fc18bc97e79b1 |       1937.82 |      97062.876599672168943007 |      97062.876599672168943007 | DOV           
 0x6399c842dd2be3de30bf99bc7d1bbf6fa3650e70 |       1951.55 |       3569.879231255590676250 |       3569.879231255590676250 | PREMIA        
 0x383518188c0c6d7730d91b2c03a03c837814a899 |       1974.93 |          3.173015858000000000 |          3.173015858000000000 | OHM           
 0x89A64014d429509CfFdA1AEBc7eB36B9435794BD |       1977.19 |        101.666642379662623543 |        101.666642379662623543 | LULZ          
 0xb4efd85c19999d84251304bda99e90b92300bd93 |       1981.79 |         63.788956363971384440 |         63.788956363971384440 | RPL           
 0xb705268213d593b8fd88d3fdeff93aff5cbdcfae |       1984.42 |       6000.289803529473158332 |       6000.289803529473158332 | IDEX          
 0xaac41ec512808d64625576eddd580e7ea40ef8b2 |       1999.03 |       2500.000000000000000000 |       2500.000000000000000000 | GSWAP         
 0x0ff5A8451A839f5F0BB3562689D9A44089738D11 |       2019.28 |        111.930776122109226636 |        111.930776122109226636 | rDPX          
 0x1fe24f25b1cf609b9c4e7e12d802e3640dfa5e43 |       2021.21 |       1962.507309938090254642 |       1962.507309938090254642 | CGG           
 0x970b9bb2c0444f5e81e9d0efb84c8ccdcdcaf84d |       2021.34 |      25444.305749057338776008 |      25444.305749057338776008 | FUSE          
 0x43A96962254855F16b925556f9e97BE436A43448 |       2040.03 |      12704.368771982389986680 |      12704.368771982389986680 | HORD          
 0xdac17f958d2ee523a2206206994597c13d831ec7 |       2053.23 |       2051.725847000000000000 |       2051.725847000000000000 | USDT          
 0xd26114cd6ee289accf82350c8d8487fedb8a0c07 |       2055.61 |        223.812999214664254915 |        223.812999214664254915 | OMG           
 0x0cec1a9154ff802e7934fc916ed7ca50bde6844e |       2063.89 |        217.186453182135269617 |        217.186453182135269617 | POOL          
 0x0abdace70d3790235af448c88547603b945604ea |       2072.76 |      13716.836189878145448409 |      13716.836189878145448409 | DNT           
 0x1da87b114f35e1dc91f72bf57fc07a768ad40bb0 |       2072.84 |       6654.977762468340581518 |       6654.977762468340581518 | EQZ           
 0x06a01a4d579479dd5d884ebf61a31727a3d8d442 |       2079.18 |      10726.888334100000000000 |      10726.888334100000000000 | Skey          
 0x2610F0bFC21EF389fe4D03CFB7De9ac1E6C99D6E |       2085.33 |      17743.868970980103085497 |      17743.868970980103085497 | SKYRIM        
 0x26c8afbbfe1ebaca03c2bb082e69d0476bffe099 |       2091.47 |       1427.952717576584090737 |       1427.952717576584090737 | CELL          
 0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f |       2139.68 |        194.893993807900286726 |        194.893993807900286726 | SNX           
 0x0E192d382a36De7011F795Acc4391Cd302003606 |       2192.46 |        254.114256438844546568 |        254.114256438844546568 | FST           
 0xcB84d72e61e383767C4DFEb2d8ff7f4FB89abc6e |       2195.49 |        123.606124303905445697 |        123.606124303905445697 | VEGA          
 0x1f573d6fb3f13d689ff844b4ce37794d79a7ff1c |       2232.55 |        639.894362199045405545 |        639.894362199045405545 | BNT           
 0x64D91f12Ece7362F91A6f8E7940Cd55F05060b92 |       2311.83 |         92.364929235787787815 |         92.364929235787787815 | ASH           
 0xE38B72d6595FD3885d1D2F770aa23E94757F91a1 |       2338.56 |       1761.927600700000000000 |       1761.927600700000000000 | TCR           
 0xCC8Fa225D80b9c7D42F96e9570156c65D6cAAa25 |       2354.72 |      30436.000000000000000000 |      30436.000000000000000000 | SLP           
 0xeB953eDA0DC65e3246f43DC8fa13f35623bDd5eD |       2361.01 |      24660.182764613229973750 |      24660.182764613229973750 | RAINI         
 0xf5581dfefd8fb0e4aec526be659cfab1f8c781da |       2376.22 |       9309.543175727267471080 |       9309.543175727267471080 | HOPR          
 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 |       2376.45 |       2358.226637000000000000 |       2358.226637000000000000 | USDC          
 0xeef9f339514298c6a857efcfc1a762af84438dee |       2377.05 |        495.107303432392678484 |        495.107303432392678484 | HEZ           
 0x3db6ba6ab6f95efed1a6e794cad492faaabf294d |       2392.51 |       9251.596202300000000000 |       9251.596202300000000000 | LTO           
 0x6b175474e89094c44da98b954eedeac495271d0f |       2394.85 |       2394.854975698297729328 |       2394.854975698297729328 | DAI           
 0x27702a26126e0b3702af63ee09ac4d1a084ef628 |       2399.15 |       5921.734383475041176587 |       5921.734383475041176587 | ALEPH         
 0xf9fbe825bfb2bf3e387af0dc18cac8d87f29dea8 |       2403.84 |      26118.022157419810139144 |      26118.022157419810139144 | BOTS          
 0x3155ba85d5f96b2d030a4966af206230e46849cb |       2410.50 |        284.335961329848294676 |        284.335961329848294676 | RUNE          
 0x25f8087EAD173b73D6e8B84329989A8eEA16CF73 |       2441.64 |        360.950868481798813300 |        360.950868481798813300 | YGG           
 0x9C78EE466D6Cb57A4d01Fd887D2b5dFb2D46288f |       2463.37 |         39.463977697544478938 |         39.463977697544478938 | MUST          
 0xa1d65e8fb6e87b60feccbc582f7f97804b725521 |       2653.69 |          5.132175366947180179 |          5.132175366947180179 | DXD           
 0xc52c326331e9ce41f04484d3b5e5648158028804 |       2700.13 |        558.663042636068006575 |        558.663042636068006575 | ZCX           
 0x2e9d63788249371f1DFC918a52f8d799F4a38C94 |       2743.55 |         79.835640577795566310 |         79.835640577795566310 | TOKE          
 0x249e38Ea4102D0cf8264d3701f1a0E39C4f2DC3B |       2778.40 | 1233913688.133796747651623136 | 1233913688.133796747651623136 | UFO           
 0x9E32b13ce7f2E80A01932B42553652E053D6ed8e |       2825.07 |         70.773687520566502160 |         70.773687520566502160 | Metis         
 0xe53ec727dbdeb9e2d5456c3be40cff031ab40a55 |       2836.07 |       4416.380337644038809340 |       4416.380337644038809340 | SUPER         
 0xAACa86B876ca011844b5798ECA7a67591A9743C8 |       2838.80 |        504.907251606495561549 |        504.907251606495561549 | BIOS          
 0x38A94e92A19E970c144DEd0B2DD47278CA11CC1F |       2848.63 |     243225.568104590000000000 |     243225.568104590000000000 | F9            
 0xc55c2175E90A46602fD42e931f62B3Acc1A013Ca |       2852.06 |     190322.040380506532133219 |     190322.040380506532133219 | STARS         
 0xdf2c7238198ad8b389666574f2d8bc411a4b7428 |       2893.03 |     302347.721287309254396820 |     302347.721287309254396820 | MFT           
 0x8e870d67f660d95d5be530380d0ec0bd388289e1 |       2916.80 |       2924.627057417210182323 |       2924.627057417210182323 | USDP_1        
 0x8400d94a5cb0fa0d041a3788e395285d61c9ee5e |       2926.01 |       1015.328521690000000000 |       1015.328521690000000000 | UBT           
 0x4a220e6096b25eadb88358cb44068a3248254675 |       2928.69 |          9.139609239152691442 |          9.139609239152691442 | QNT           
 0xc770eefad204b5180df6a14ee197d99d808ee52d |       2930.32 |       8771.288720735141524481 |       8771.288720735141524481 | FOX           
 0x1735db6ab5baa19ea55d0adceed7bcdc008b3136 |       3011.35 |      11401.457524079600145210 |      11401.457524079600145210 | URQA          
 0x31c8eacbffdd875c74b94b077895bd78cf1e64a3 |       3047.35 |        333.537412561798686782 |        333.537412561798686782 | RAD           
 0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d |       3070.77 |        648.939014855451476652 |        648.939014855451476652 | LQTY          
 0x0ada190c81b814548ddc2f6adc4a689ce7c1fe73 |       3075.95 |        535.045442730651409309 |        535.045442730651409309 | YAXIS         
 0xe9F84dE264E91529aF07Fa2C746e934397810334 |       3087.20 |          0.114351395530962832 |          0.114351395530962832 | SAK3          
 0x92e187a03b6cd19cb6af293ba17f2745fd2357d5 |       3095.62 |      33734.799088147910313925 |      33734.799088147910313925 | DUCK_UNIT     
 0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab |       3096.63 |         38.233407717922975305 |         38.233407717922975305 | MIST          
 0xde30da39c46104798bb5aa3fe8b9e0e1f348163f |       3111.71 |        414.692943068410113310 |        414.692943068410113310 | GTC           
 0x584bc13c7d411c00c01a62e8019472de68768430 |       3172.65 |      19621.242124375050444332 |      19621.242124375050444332 | HEGIC         
 0x2a3bFF78B79A009976EeA096a51A948a3dC00e34 |       3216.34 |       2471.232201921305983582 |       2471.232201921305983582 | WILD          
 0x7d4B1d793239707445305D8d2456D2c735F6B25B |       3224.84 |     551932.507001920921407026 |     551932.507001920921407026 | cBSN          
 0xf16e81dce15b08f326220742020379b855b87df9 |       3226.98 |        492.686272880102320437 |        492.686272880102320437 | ICE           
 0xbbBBBBB5AA847A2003fbC6b5C16DF0Bd1E725f61 |       3294.42 |        382.918362671043304880 |        382.918362671043304880 | BPRO          
 0xf99d58e463a2e07e5692127302c20a191861b4d6 |       3307.80 |        628.209885733598849893 |        628.209885733598849893 | ANY           
 0x6243d8cea23066d098a15582d81a598b4e8391f4 |       3344.17 |         14.324729732433718219 |         14.324729732433718219 | FLX           
 0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1 |       3351.31 |       2343.702750077750134573 |       2343.702750077750134573 | CVP           
 0x0ae055097c6d159879521c384f1d2123d1f195e6 |       3424.87 |        279.592838476799834877 |        279.592838476799834877 | STAKE         
 0x97AbEe33Cd075c58BFdd174e0885e08E8f03556F |       3431.75 |      46515.775780821791932416 |      46515.775780821791932416 | SENT          
 0x429881672b9ae42b8eba0e26cd9c73711b891ca5 |       3549.77 |        418.406117914889260451 |        418.406117914889260451 | PICKLE        
 0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9 |       3559.26 |         12.334855531082971498 |         12.334855531082971498 | AAVE          
 0x8e6cd950ad6ba651f6dd608dc70e5886b1aa6b24 |       3614.66 |  288506242.565470428642116443 |  288506242.565470428642116443 | STARL         
 0x55296f69f40ea6d20e478533c15a6b08b654e758 |       3631.07 |     131091.720730894224768627 |     131091.720730894224768627 | XYO           
 0x6bB61215298F296C55b19Ad842D3Df69021DA2ef |       3743.23 |       1291.492136208261739462 |       1291.492136208261739462 | DOP           
 0x7e291890B01E5181f7ecC98D79ffBe12Ad23df9e |       3755.71 |        200.000000000000000000 |        200.000000000000000000 | NIF           
 0x62B9c7356A2Dc64a1969e19C23e4f579F9810Aa7 |       3803.95 |       1556.746198281134234467 |       1556.746198281134234467 | cvxCRV        
 0xf938424f7210f31df2aee3011291b658f872e91e |       3832.07 |       4040.514186984475755778 |       4040.514186984475755778 | VISR          
 0x72e364f2abdc788b7e918bc238b21f109cd634d7 |       3854.39 |         37.254332150055403321 |         37.254332150055403321 | MVI           
 0x798d1be841a82a273720ce31c822c61a67a601c3 |       3887.44 |          0.090761131000000000 |          0.090761131000000000 | DIGG          
 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984 |       3913.05 |        192.495962595203148584 |        192.495962595203148584 | UNI           
 0xf009f5531dE69067435e32c4b9D36077F4C4A673 |       3931.06 |      27415.199158370925437178 |      27415.199158370925437178 | UNV           
 0x111111111117dc0aa78b770fa6a738034120c302 |       3946.61 |       1500.376594385677457628 |       1500.376594385677457628 | 1INCH         
 0xDFDb7f72c1F195C5951a234e8DB9806EB0635346 |       3966.18 |   30423417.860747640891626471 |   30423417.860747640891626471 | NFD           
 0x77777feddddffc19ff86db637967013e6c6a116c |       3980.19 |         66.251991296237687934 |         66.251991296237687934 | TORN          
 0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b |       3982.83 |        400.875702600047987932 |        400.875702600047987932 | CVX           
 0xc00e94cb662c3520282e6f5717214004a7f26888 |       3990.41 |         11.279062897119886674 |         11.279062897119886674 | COMP          
 0xba5BDe662c17e2aDFF1075610382B9B691296350 |       4074.12 |       4296.181037242471666714 |       4296.181037242471666714 | RARE          
 0x03Be5C903c727Ee2C8C4e9bc0AcC860Cca4715e2 |       4191.05 |      73721.107861495333836593 |      73721.107861495333836593 | CAPS          
 0xa8b919680258d369114910511cc87595aec0be6d |       4252.68 |        201.108298736420394082 |        201.108298736420394082 | LYXe          
 0x4Fb721eF3Bf99e0f2c193847afA296b9257d3C30 |       4277.53 |      34059.076918590000000000 |      34059.076918590000000000 | TOK           
 0xe74ac81B14021d0Cfb835F269F48F25918C5cAE6 |       4278.90 |     810542.104099192567234560 |     810542.104099192567234560 | GEMS          
 0x69a95185ee2a045cdc4bcd1b1df10710395e4e23 |       4288.19 |        481.467342319797981032 |        481.467342319797981032 | POOLZ         
 0x853d955acef822db058eb8505911ed77f175b99e |       4345.02 |       4377.719013048221417983 |       4377.719013048221417983 | FRAX          
 0xb4d930279552397bba2ee473229f89ec245bc365 |       4657.42 |       1601.791543370625115407 |       1601.791543370625115407 | MAHA          
 0xEec2bE5c91ae7f8a338e1e5f3b5DE49d07AfdC81 |       4747.42 |          8.191043624421459726 |          8.191043624421459726 | DPX           
 0x7aE1D57b58fA6411F32948314BadD83583eE0e8C |       4810.79 |     771907.885795354145296997 |     771907.885795354145296997 | PAPER         
 0xba100000625a3754423978a60c9317c58a424e3d |       4873.45 |        240.483315328451077158 |        240.483315328451077158 | BAL           
 0xb26C4B3Ca601136Daf98593feAeff9E0CA702a8D |       4900.18 |      16251.664882990928189058 |      16251.664882990928189058 | ALD           
 0x77fba179c79de5b7653f68b5039af940ada60ce0 |       4957.53 |        378.404513947843173292 |        378.404513947843173292 | FORTH         
 0x956f47f50a910163d8bf957cf5846d573e7f87ca |       5133.44 |       5183.870207142764939541 |       5183.870207142764939541 | FEI           
 0xFc0d6Cf33e38bcE7CA7D89c0E292274031b7157A |       5373.44 |       3575.088812588601689396 |       3575.088812588601689396 | NTVRK         
 0x32353A6C91143bfd6C7d363B546e62a9A2489A20 |       5781.92 |       1831.787877596448980664 |       1831.787877596448980664 | AGLD          
 0xaa4e3edb11afa93c41db59842b29de64b72e355b |       5810.05 |       8325.424445702151323533 |       8325.424445702151323533 | MFI           
 0x40EB746DEE876aC1E78697b7Ca85142D178A1Fc8 |       6028.47 |      98094.647228909791333281 |      98094.647228909791333281 | IAG           
 0x514910771af9ca656af840dff83e8264ecf986ca |       6190.41 |        262.432568160313681195 |        262.432568160313681195 | LINK          
 0x4a615bB7166210CCe20E6642a6f8Fb5d4D044496 |       6472.34 |       5765.013156128472797872 |       5765.013156128472797872 | NAOS          
 0xfca59cd816ab1ead66534d82bc21e7515ce441cf |       6546.23 |        443.514605484053024333 |        443.514605484053024333 | RARI          
 0xf1f955016ecbcd7321c7266bccfb96c68ea5e49b |       6656.00 |      11553.124228603216024058 |      11553.124228603216024058 | RLY           
 0x767fe9edc9e0df98e07454847909b5e959d7ca0e |       7068.48 |         13.563729977911064490 |         13.563729977911064490 | ILV           
 0x5f98805a4e8be255a32880fdec7f6728c6568ba0 |       7149.35 |       7223.179950302964649803 |       7223.179950302964649803 | LUSD          
 0x090185f2135308BaD17527004364eBcC2D37e5F6 |       7166.07 |    2057137.075573624100419305 |    2057137.075573624100419305 | SPELL         
 0x9fa69536d1cda4A04cFB50688294de75B505a9aE |       7173.46 |       2092.964851296399254512 |       2092.964851296399254512 | DERC          
 0x69fa0feE221AD11012BAb0FdB45d444D3D2Ce71c |       7241.20 |      27574.178364508031063006 |      27574.178364508031063006 | XRUNE         
 0xd084944d3c05CD115C09d072B9F44bA3E0E45921 |       7529.78 |        113.553453061419791863 |        113.553453061419791863 | FOLD          
 0x3845badade8e6dff049820680d1f14bd3903a5d0 |       7534.57 |      10866.440603996468728553 |      10866.440603996468728553 | SAND          
 0x57ab1ec28d129707052df4df418d58a2d46d5f51 |       7743.48 |       7946.774229731829319503 |       7946.774229731829319503 | sUSD          
 0x33349b282065b0284d756f0577fb39c158f935e6 |       7777.44 |        493.076867058684433376 |        493.076867058684433376 | MPL           
 0x8762db106b2c2a0bccb3a80d1ed41273552616e8 |       7903.27 |     236356.984859532381625271 |     236356.984859532381625271 | RSR           
 0x1f8a626883d7724dbd59ef51cbd4bf1cf2016d13 |       8305.47 |     341142.884442606652784836 |     341142.884442606652784836 | STAK          
 0x3106a0a076BeDAE847652F42ef07FD58589E001f |       8639.42 |      18560.120298399747923877 |      18560.120298399747923877 | $ADS          
 0xb8baa0e4287890a5f79863ab62b7f175cecbd433 |       8848.96 |      13423.221701998342417552 |      13423.221701998342417552 | SWRV          
 0x6149c26cd2f7b5ccdb32029af817123f6e37df5b |       8948.64 |       3406.849266805094063801 |       3406.849266805094063801 | LPOOL         
 0x2b591e99afe9f32eaa6214f7b7629768c40eeb39 |       9276.09 |      19580.436606350000000000 |      19580.436606350000000000 | HEX           
 0xd291e7a03283640fdc51b121ac401383a46cc623 |      10145.97 |        569.310814856214160701 |        569.310814856214160701 | RGT           
 0x993864E43Caa7F7F12953AD6fEb1d1Ca635B875F |      10369.32 |       3039.140079069645322600 |       3039.140079069645322600 | SDAO          
 0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce |      10679.81 | 1490534413.701162424152030944 | 1490534413.701162424152030944 | SHIB          
 0xdbdb4d16eda451d0503b854cf79d55697f90c8df |      11786.56 |         49.430171324486102032 |         49.430171324486102032 | ALCX          
 0xd533a949740bb3306d119cc777fa900ba034cd52 |      11930.94 |       4684.540536185510853032 |       4684.540536185510853032 | CRV           
 0x2d94aa3e47d9d5024503ca8491fce9a2fb4da198 |      12919.59 |     108454.960393116439027572 |     108454.960393116439027572 | BANK_BANKLESS 
 0x054d64b73d3d8a21af3d764efd76bcaa774f3bb2 |      16317.17 |     117158.611825523470920371 |     117158.611825523470920371 | PPAY          
 0x08A75dbC7167714CeaC1a8e43a8d643A4EDd625a |      18479.16 |      33306.979887113723381530 |      33306.979887113723381530 | WILD          
 0x15d4c048f83bd7e37d49ea4c83a07267ec4203da |      18790.44 |     232027.046697500000000000 |     232027.046697500000000000 | GALA          
 0x990f341946a3fdb507ae7e52d17851b87168017c |      18943.46 |         37.453718792095458981 |         37.453718792095458981 | STRONG        
 0x7fC3eC3574d408F3b59CD88709baCb42575EBF2b |      21532.83 |      49482.175513893475843645 |      49482.175513893475843645 | POP!          
 0x73968b9a57c6e53d41345fd57a6e6ae27d6cdb2f |      29384.70 |      15778.764724788861097632 |      15778.764724788861097632 | SDT           

The transaction will cost approximately 1.760290527080393376 ETH (5198.68 USD) and will withdraw the balance of 544 tokens for an estimated total value of 977809.85 USD. All withdrawn funds will be sent to 0x6C642caFCbd9d8383250bb25F67aE409147f78b2.
```
</details>

As an interesting fact, only 544 tokens out of ~1000 traded tokens can be withdrawn from the contract while losing less than 5% in gas fees. The value of the remaining tokens accounts for only 50k$. (Gas is ~100Gwei currently.)