### PR TITLE
Reduce trade log range if block wasn't found

### DIFF
--- a/src/tasks/withdraw.ts
+++ b/src/tasks/withdraw.ts
@@ -234,7 +234,6 @@ interface WithdrawInput {
   authenticator: Contract;
   settlement: Contract;
   settlementDeploymentBlock: number;
-  latestBlock: number;
   network: SupportedNetwork;
   usdReference: ReferenceToken;
   hre: HardhatRuntimeEnvironment;
@@ -252,7 +251,6 @@ export async function withdraw({
   authenticator,
   settlement,
   settlementDeploymentBlock,
-  latestBlock,
   network,
   usdReference,
   hre,
@@ -282,12 +280,12 @@ export async function withdraw({
 
   if (tokens === undefined) {
     console.log("Recovering list of traded tokens...");
-    tokens = await getAllTradedTokens(
+    ({ tokens } = await getAllTradedTokens(
       settlement,
       settlementDeploymentBlock,
-      latestBlock,
+      "latest",
       hre,
-    );
+    ));
   }
 
   // TODO: add eth withdrawal
@@ -405,12 +403,11 @@ const setupWithdrawTask: () => void = () =>
         }
         const api = new Api(network, Environment.Prod);
         const receiver = utils.getAddress(inputReceiver);
-        const [authenticator, settlementDeployment, [solver], latestBlock] =
+        const [authenticator, settlementDeployment, [solver]] =
           await Promise.all([
             getDeployedContract("GPv2AllowListAuthentication", hre),
             hre.deployments.get("GPv2Settlement"),
             hre.ethers.getSigners(),
-            hre.ethers.provider.getBlockNumber(),
           ]);
         const settlement = new Contract(
           settlementDeployment.address,
@@ -429,7 +426,6 @@ const setupWithdrawTask: () => void = () =>
           authenticator,
           settlement,
           settlementDeploymentBlock,
-          latestBlock,
           network,
           usdReference: REFERENCE_TOKEN[network],
           hre,

--- a/src/tasks/withdraw/traded_tokens.ts
+++ b/src/tasks/withdraw/traded_tokens.ts
@@ -1,12 +1,11 @@
-import { Contract } from "ethers";
-import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { Contract, providers } from "ethers";
+import { HardhatRuntimeEnvironment, HttpNetworkConfig } from "hardhat/types";
 
 import { BUY_ETH_ADDRESS } from "../../ts";
 
 const enum ProviderError {
   TooManyEvents,
   Timeout,
-  BlockNotFound,
 }
 
 function decodeError(error: unknown): ProviderError | null {
@@ -20,27 +19,34 @@ function decodeError(error: unknown): ProviderError | null {
   if (/Network connection timed out/.test(message)) {
     return ProviderError.Timeout;
   }
-  if (
-    /One of the blocks specified in filter \(fromBlock, toBlock or blockHash\) cannot be found/.test(
-      message,
-    )
-  ) {
-    return ProviderError.BlockNotFound;
-  }
   return null;
 }
 
 /// Lists all tokens that were traded by the settlement contract in the range
 /// specified by the two input blocks. Range bounds are both inclusive.
+/// The output value `lastFullyIncludedBlock` returns the block numbers of the
+/// latest block for which traded tokens were searched.
 export async function getAllTradedTokens(
   settlement: Contract,
   fromBlock: number,
-  toBlock: number,
+  toBlock: number | "latest",
   hre: HardhatRuntimeEnvironment,
-): Promise<string[]> {
+): Promise<{ tokens: string[]; toBlock: number }> {
+  // The calls to getLogs and to getBlockNumber must be simultaneous, so that
+  // if running on a node with load balancing then both requests go to the same
+  // node and the block number actually represent the latest block for the logs.
+  // Note: a batch provider executes all requests at the end of the event loop
+  const url = (hre.network.config as HttpNetworkConfig).url;
+  // Note: URL is undefined for network hardhat
+  const batchProvider =
+    url !== undefined
+      ? new providers.JsonRpcBatchProvider(url, hre.network.config.chainId)
+      : hre.ethers.provider;
   let trades = null;
+  let numericToBlock =
+    toBlock === "latest" ? batchProvider.getBlockNumber() : toBlock;
   try {
-    trades = await hre.ethers.provider.getLogs({
+    trades = await batchProvider.getLogs({
       topics: [settlement.interface.getEventTopic("Trade")],
       address: settlement.address,
       fromBlock,
@@ -57,23 +63,6 @@ export async function getAllTradedTokens(
           `Failed to process events from block ${fromBlock} to ${toBlock}, reducing range...`,
         );
         break;
-      case ProviderError.BlockNotFound:
-        if (fromBlock < toBlock) {
-          console.log(
-            `Block not found when retrieving blocks ${fromBlock} to ${toBlock}, skipping last block...`,
-          );
-          return await getAllTradedTokens(
-            settlement,
-            fromBlock,
-            toBlock - 1,
-            hre,
-          );
-        } else {
-          console.error(
-            `Block not found when processing events from block ${fromBlock} to ${toBlock}`,
-          );
-          return [];
-        }
       case null:
         throw error;
     }
@@ -84,11 +73,17 @@ export async function getAllTradedTokens(
     if (fromBlock === toBlock) {
       throw new Error("Too many events in the same block");
     }
-    const mid = Math.floor((toBlock + fromBlock) / 2);
-    tokens = [
-      await getAllTradedTokens(settlement, fromBlock, mid, hre),
-      await getAllTradedTokens(settlement, mid + 1, toBlock, hre), // note: mid+1 is not larger than toBlock thanks to flooring
-    ].flat();
+    const mid = Math.floor(((await numericToBlock) + fromBlock) / 2);
+    const { tokens: firstHalf } = await getAllTradedTokens(
+      settlement,
+      fromBlock,
+      mid,
+      hre,
+    );
+    const { tokens: secondHalf, toBlock: numberSecondHalf } =
+      await getAllTradedTokens(settlement, mid + 1, toBlock, hre);
+    tokens = [...firstHalf, ...secondHalf];
+    numericToBlock = numberSecondHalf;
   } else {
     tokens = trades
       .map((trade) => {
@@ -104,7 +99,10 @@ export async function getAllTradedTokens(
 
   tokens = new Set(tokens);
   tokens.delete(BUY_ETH_ADDRESS);
-  return Array.from(tokens).sort((lhs, rhs) =>
-    lhs.toLowerCase() < rhs.toLowerCase() ? -1 : lhs === rhs ? 0 : 1,
-  );
+  return {
+    tokens: Array.from(tokens).sort((lhs, rhs) =>
+      lhs.toLowerCase() < rhs.toLowerCase() ? -1 : lhs === rhs ? 0 : 1,
+    ),
+    toBlock: await numericToBlock,
+  };
 }

--- a/src/tasks/withdrawService.ts
+++ b/src/tasks/withdrawService.ts
@@ -112,7 +112,6 @@ export interface WithdrawAndDumpInput {
   authenticator: Contract;
   settlement: Contract;
   settlementDeploymentBlock: number;
-  latestBlock: number;
   minValue: string;
   leftover: string;
   validity: number;
@@ -151,7 +150,6 @@ export async function withdrawAndDump({
   authenticator,
   settlement,
   settlementDeploymentBlock,
-  latestBlock,
   minValue,
   leftover,
   validity,
@@ -210,12 +208,8 @@ export async function withdrawAndDump({
   ).flat();
 
   console.log("Recovering list of tokens traded since the previous run...");
-  const recentlyTradedTokens = await getAllTradedTokens(
-    settlement,
-    state.lastUpdateBlock,
-    latestBlock,
-    hre,
-  );
+  const { tokens: recentlyTradedTokens, toBlock: latestBlock } =
+    await getAllTradedTokens(settlement, state.lastUpdateBlock, "latest", hre);
 
   const tradedTokens = state.tradedTokens.concat(
     recentlyTradedTokens.filter(
@@ -247,7 +241,6 @@ export async function withdrawAndDump({
     authenticator,
     settlement,
     settlementDeploymentBlock,
-    latestBlock,
     network,
     usdReference,
     hre,
@@ -399,12 +392,11 @@ const setupWithdrawServiceTask: () => void = () =>
         const usdReference = REFERENCE_TOKEN[network];
         const api = new Api(network, Environment.Prod);
         const receiver = utils.getAddress(inputReceiver);
-        const [authenticator, settlementDeployment, [solver], latestBlock] =
+        const [authenticator, settlementDeployment, [solver]] =
           await Promise.all([
             getDeployedContract("GPv2AllowListAuthentication", hre),
             hre.deployments.get("GPv2Settlement"),
             hre.ethers.getSigners(),
-            hre.ethers.provider.getBlockNumber(),
           ]);
         const settlement = new Contract(
           settlementDeployment.address,
@@ -421,7 +413,6 @@ const setupWithdrawServiceTask: () => void = () =>
           authenticator,
           settlement,
           settlementDeploymentBlock,
-          latestBlock,
           minValue,
           leftover,
           validity,

--- a/test/tasks/withdraw.test.ts
+++ b/test/tasks/withdraw.test.ts
@@ -347,7 +347,6 @@ describe("Task: withdraw", () => {
       authenticator,
       settlement,
       settlementDeploymentBlock: 0,
-      latestBlock: await ethers.provider.getBlockNumber(),
       minValue,
       leftover,
       maxFeePercent,

--- a/test/tasks/withdraw.test.ts
+++ b/test/tasks/withdraw.test.ts
@@ -210,7 +210,6 @@ describe("Task: withdraw", () => {
       authenticator,
       settlement,
       settlementDeploymentBlock: 0,
-      latestBlock: await ethers.provider.getBlockNumber(),
       minValue,
       leftover,
       tokens: undefined,

--- a/test/tasks/withdrawService.test.ts
+++ b/test/tasks/withdrawService.test.ts
@@ -105,7 +105,6 @@ describe("Task: withdrawService", () => {
       validity: 3600,
       maxFeePercent: 100,
       toToken: toToken.address,
-      latestBlock: await hre.ethers.provider.getBlockNumber(),
       // ignore network value
       network: undefined as unknown as SupportedNetwork,
       usdReference,


### PR DESCRIPTION
While running the withdraw service we saw some alerts of the form:
```
ProviderError: One of the blocks specified in filter (fromBlock, toBlock or blockHash) cannot be found
```
The issue always occurred the first time this function was called.

This could happen if for example the node is load balanced and not all nodes behind the load balancer have the same latest block number. Possibly also if a reorg happened. 

### Test Plan

I don't know how to trigger the issue, so we'll have to test it live.
No regressions: I tried the withdraw script with Infura again on mainnet:
```
$ npx hardhat withdraw --network mainnet --dry-run --receiver 0x6C642caFCbd9d8383250bb25F67aE409147f78b2 
Using account 0x627306090abaB3A6e1400e9345bC60c78a8BEf57
ailed to process events from block 12593265 to latest, reducing range...
Processed events from block 12593265 to 12941476
Failed to process events from block 12941477 to latest, reducing range...
Failed to process events from block 12941477 to 13115582, reducing range...
Processed events from block 12941477 to 13028529
Processed events from block 13028530 to 13115582
Failed to process events from block 13115583 to latest, reducing range...
Processed events from block 13115583 to 13202637
Processed events from block 13202638 to latest
...
```