### PR TITLE
Check transfer cost in dump script

### DIFF
--- a/src/tasks/dump.ts
+++ b/src/tasks/dump.ts
@@ -117,21 +117,17 @@ async function getTransferToReceiver({
     return undefined;
   }
 
-  const gasPrice = hre.ethers.provider.getGasPrice();
   const amount = await balanceOf(toToken, user);
   if (amount.isZero()) {
-    gasPrice.catch(() => {
-      // Gas price is not needed. Empty catch to suppress Node warning
-      // (unhandled promise rejection) in case retrieving gas fails
-    });
     return undefined;
   }
 
-  const [gas, value] = await Promise.all([
+  const [gasPrice, gas, value] = await Promise.all([
+    hre.ethers.provider.getGasPrice(),
     estimateTransferGas(toToken, user, receiver.address, amount),
     ethValue(toToken, amount, network, api),
   ]);
-  const approxGasCost = Number(gas.mul(await gasPrice));
+  const approxGasCost = Number(gas.mul(gasPrice));
   const approxValue = Number(value.toString());
   const feePercent = (100 * approxGasCost) / approxValue;
   if (feePercent > maxFeePercent) {

--- a/src/tasks/ts/tokens.ts
+++ b/src/tasks/ts/tokens.ts
@@ -62,6 +62,25 @@ export async function balanceOf(
   return BigNumber.from(await balanceFunction(user));
 }
 
+export async function estimateTransferGas(
+  token: Erc20Token | NativeToken,
+  from: string,
+  to: string,
+  amount: BigNumberish,
+): Promise<BigNumber> {
+  if (isNativeToken(token)) {
+    return await token.provider.estimateGas({
+      from,
+      to,
+      value: amount,
+    });
+  } else {
+    return await token.contract.estimateGas["transfer"](to, amount, {
+      from,
+    });
+  }
+}
+
 export async function transfer(
   token: Erc20Token | NativeToken,
   from: Signer,

--- a/src/tasks/withdraw.ts
+++ b/src/tasks/withdraw.ts
@@ -225,7 +225,12 @@ async function getWithdrawals({
         }
         let balanceUsd;
         try {
-          balanceUsd = await usdValue(token, balance, usdReference, api);
+          balanceUsd = await usdValue(
+            token.address,
+            balance,
+            usdReference,
+            api,
+          );
         } catch (e) {
           if (!(e instanceof Error)) {
             throw e;

--- a/test/hardhatNetwork.ts
+++ b/test/hardhatNetwork.ts
@@ -1,0 +1,12 @@
+import hre from "hardhat";
+
+export async function setTime(timestamp: number): Promise<number> {
+  return await hre.ethers.provider.send("evm_setNextBlockTimestamp", [
+    timestamp,
+  ]);
+}
+
+export async function synchronizeBlockchainAndCurrentTime(): Promise<number> {
+  const now = Math.floor(Date.now() / 1000);
+  return setTime(now);
+}

--- a/test/tasks/dump.test.ts
+++ b/test/tasks/dump.test.ts
@@ -10,7 +10,7 @@ import {
   utils,
   Wallet,
 } from "ethers";
-import hre, { waffle } from "hardhat";
+import hre, { ethers, waffle } from "hardhat";
 import { mock, SinonMock } from "sinon";
 
 import {
@@ -792,7 +792,12 @@ describe("Task: dump", () => {
 
     // the script checks that the onchain time is not too far from the current
     // time
-    await synchronizeBlockchainAndCurrentTime();
+    if (
+      (await ethers.provider.getBlock("latest")).timestamp <
+      Math.floor(Date.now() / 1000)
+    ) {
+      await synchronizeBlockchainAndCurrentTime();
+    }
 
     useDebugConsole();
   });

--- a/test/tasks/withdrawService.test.ts
+++ b/test/tasks/withdrawService.test.ts
@@ -119,7 +119,12 @@ describe("Task: withdrawService", () => {
 
     // the script checks that the onchain time is not too far from the current
     // time
-    await synchronizeBlockchainAndCurrentTime();
+    if (
+      (await ethers.provider.getBlock("latest")).timestamp <
+      Math.floor(Date.now() / 1000)
+    ) {
+      await synchronizeBlockchainAndCurrentTime();
+    }
 
     useDebugConsole();
   });

--- a/test/tasks/withdrawService.test.ts
+++ b/test/tasks/withdrawService.test.ts
@@ -16,6 +16,7 @@ import * as withdrawService from "../../src/tasks/withdrawService";
 import { WithdrawAndDumpInput } from "../../src/tasks/withdrawService";
 import { OrderKind, domain, Order, timestamp } from "../../src/ts";
 import { deployTestContracts } from "../e2e/fixture";
+import { synchronizeBlockchainAndCurrentTime } from "../hardhatNetwork";
 
 import { restoreStandardConsole, useDebugConsole } from "./logging";
 import {
@@ -115,6 +116,10 @@ describe("Task: withdrawService", () => {
       api,
       dryRun: false,
     });
+
+    // the script checks that the onchain time is not too far from the current
+    // time
+    await synchronizeBlockchainAndCurrentTime();
 
     useDebugConsole();
   });


### PR DESCRIPTION
Fixes #794.

The dump script currently transfers unconditionally if there is a receiver and the toToken is dumped. This PR changes this behavior by accounting for the eth cost of performing a transaction, which is only executed if the cost is below `maxFeePercent`.

### Test Plan

New unit tests.