### PR TITLE
Remove batch provider

### DIFF
--- a/src/tasks/withdrawService.ts
+++ b/src/tasks/withdrawService.ts
@@ -208,8 +208,12 @@ export async function withdrawAndDump({
   ).flat();
 
   console.log("Recovering list of tokens traded since the previous run...");
+  // Add extra blocks before the last update in case there was a reorg and new
+  // transactions were included.
+  const maxReorgDistance = 20;
+  const fromBlock = Math.max(0, state.lastUpdateBlock - maxReorgDistance);
   const { tokens: recentlyTradedTokens, toBlock: latestBlock } =
-    await getAllTradedTokens(settlement, state.lastUpdateBlock, "latest", hre);
+    await getAllTradedTokens(settlement, fromBlock, "latest", hre);
 
   const tradedTokens = state.tradedTokens.concat(
     recentlyTradedTokens.filter(


### PR DESCRIPTION
Running the withdraw script on xdai without any token input causes the script to fail with an error.
It appears that batched request on the default xdai node are more inefficient than standard request and causes more timeouts.
Moreover, because of implementation details of the ethers package the request for logs is not batched together with the request for the block number, which defeats the purpose of using batch request. Therefore, this PR restores the standard provider to retrieve the traded tokens.

### Test Plan

Can use the withdraw script on xdai:
```
$ npx hardhat withdraw --network xdai --dry-run --receiver 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
[...]
The transaction will cost approximately 0.006861505 XDAI and will withdraw the balance of 107 tokens for an estimated total value of 11.33 USD. All withdrawn funds will be sent to 0x6C642caFCbd9d8383250bb25F67aE409147f78b2
```
