### PR TITLE
Show amounts for tokens ignored by the dump script

### DIFF
--- a/test/tasks/dump.test.ts
+++ b/test/tasks/dump.test.ts
@@ -468,7 +468,7 @@ describe("getDumpInstructions", () => {
     expect(instructions).to.have.length(0);
 
     expect(consoleLogOutput).to.equal(
-      `Dump request skipped for token ${dumped.address}. The trading fee is larger than the dumped amount.`,
+      `Ignored 42.0 units of ${dumped.address}, the trading fee is larger than the dumped amount.`,
     );
   });
 
@@ -513,7 +513,7 @@ describe("getDumpInstructions", () => {
 
     expect(consoleLogOutput).to.match(
       new RegExp(
-        `Dump request skipped for token ${dumped.address}\\. The trading fee is too large compared to the balance \\([0-9.]*%\\)\\.`,
+        `Ignored 42.0 units of ${dumped.address}, the trading fee is too large compared to the balance \\(5[0-9.]+%\\)\\.`,
       ),
     );
   });


### PR DESCRIPTION
Adds the balances when logging that a token was ignored. Useful to double check that the math is correct directly in the logs.

### Test Plan

```
$ npx hardhat dump --network rinkeby --dry-run --to-token 0xc778417E063141139Fce010982780140Aa0cD5Ab --receiver 0xcB1FF0c484a2267E39e19a82A8c313E633C106C6 0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735 0xc778417E063141139Fce010982780140Aa0cD5Ab --max-fee-percent 0.001
Using account 0x59552a04D9f0c184CFce5f951fe36a01A2b4aDD9
Ignored 3.120305637856228634 units of WETH (0xc778417E063141139Fce010982780140Aa0cD5Ab), the transaction fee is too large compared to the balance (0.00%)
Ignored 1000000000000.0 units of DAI (0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735), the trading fee is too large compared to the balance (0.08%)
Nothing to do.
```