### PR TITLE
Add flag for printing solver transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 coverage/
 deployments/*/solcInputs
+deployments/localhost/
 lib/
 node_modules/
 coverage.json

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -131,10 +131,12 @@ export default {
       // To have the same addresses on all networks, the owner must be the same.
       default: "0x6Fb5916c0f57f88004d5b5EB25f6f4D77353a1eD",
       hardhat: 1,
+      localhost: 1,
     },
     manager: {
       default: "0x6Fb5916c0f57f88004d5b5EB25f6f4D77353a1eD",
       hardhat: 2,
+      localhost: 2,
     },
   },
   gasReporter: {

--- a/src/deploy/002_settlement.ts
+++ b/src/deploy/002_settlement.ts
@@ -20,7 +20,7 @@ const deploySettlement: DeployFunction = async function ({
   const { address: authenticatorAddress } = await get(authenticator);
 
   let vaultAddress: string;
-  if (network.name === "hardhat") {
+  if (network.name === "hardhat" || network.name === "localhost") {
     const { address: authorizerAddress } = await deploy("VaultAuthorizer", {
       from: deployer,
       contract: Authorizer,

--- a/src/deploy/999_networks.ts
+++ b/src/deploy/999_networks.ts
@@ -21,7 +21,7 @@ const updateNetworks: DeployFunction = async function ({
   ethers,
   network,
 }: HardhatRuntimeEnvironment) {
-  if (network.name === "hardhat") {
+  if (network.name === "hardhat" || network.name === "localhost") {
     return;
   }
 

--- a/src/tasks/solvers.ts
+++ b/src/tasks/solvers.ts
@@ -26,7 +26,7 @@ const removeSolver = async (args: Args, hre: HardhatRuntimeEnvironment) => {
 };
 
 async function performSolverManagement(
-  method: string,
+  method: "addSolver" | "removeSolver",
   { solver, printTransaction }: Args,
   hre: HardhatRuntimeEnvironment,
 ): Promise<void> {
@@ -103,9 +103,7 @@ const setupSolversTask: () => void = () => {
   )
     .addPositionalParam<string>("solver", "The solver account to add.")
     .addFlag("printTransaction", "Prints the transaction to standard out.")
-    .setAction(async (args, hardhatRuntime) => {
-      await addSolver(args, hardhatRuntime);
-    });
+    .setAction(addSolver);
 
   subtask(
     "solvers-remove",
@@ -113,9 +111,7 @@ const setupSolversTask: () => void = () => {
   )
     .addPositionalParam<string>("solver", "The solver account to remove.")
     .addFlag("printTransaction", "Prints the transaction to standard out.")
-    .setAction(async (args, hardhatRuntime) => {
-      await removeSolver(args, hardhatRuntime);
-    });
+    .setAction(removeSolver);
 
   subtask(
     "solvers-check",

--- a/src/tasks/solvers.ts
+++ b/src/tasks/solvers.ts
@@ -30,7 +30,6 @@ async function performSolverManagement(
   { solver, printTransaction }: Args,
   hre: HardhatRuntimeEnvironment,
 ): Promise<void> {
-  const owner = await getNamedSigner(hre, "manager");
   const authenticator = await getDeployedContract(
     "GPv2AllowListAuthentication",
     hre,
@@ -42,6 +41,7 @@ async function performSolverManagement(
     console.log(`To:   ${authenticator.address}`);
     console.log(`Data: ${data}`);
   } else {
+    const owner = await getNamedSigner(hre, "manager");
     const tx = await authenticator.connect(owner)[method](solver);
     console.log(transactionUrl(hre, tx));
     await tx.wait();

--- a/src/tasks/solvers.ts
+++ b/src/tasks/solvers.ts
@@ -7,33 +7,47 @@ import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { getDeployedContract } from "./ts/deployment";
 import { getNamedSigner } from "./ts/signers";
 import { getSolvers } from "./ts/solver";
+import { transactionUrl } from "./ts/tui";
 
 const solversTaskList = ["add", "check", "remove", "list"] as const;
 type SolversTasks = typeof solversTaskList[number];
 
-async function addSolver(solver: string, hre: HardhatRuntimeEnvironment) {
-  const owner = await getNamedSigner(hre, "manager");
-  const authenticator = await getDeployedContract(
-    "GPv2AllowListAuthentication",
-    hre,
-  );
-
-  const tx = await authenticator.connect(owner).addSolver(solver);
-  await tx.wait();
-  console.log("Solver added.");
+interface Args {
+  solver?: string;
+  printTransaction: boolean;
 }
 
-const removeSolver = async (solver: string, hre: HardhatRuntimeEnvironment) => {
+async function addSolver(args: Args, hre: HardhatRuntimeEnvironment) {
+  await performSolverManagement("addSolver", args, hre);
+}
+
+const removeSolver = async (args: Args, hre: HardhatRuntimeEnvironment) => {
+  await performSolverManagement("removeSolver", args, hre);
+};
+
+async function performSolverManagement(
+  method: string,
+  { solver, printTransaction }: Args,
+  hre: HardhatRuntimeEnvironment,
+): Promise<void> {
   const owner = await getNamedSigner(hre, "manager");
   const authenticator = await getDeployedContract(
     "GPv2AllowListAuthentication",
     hre,
   );
 
-  const tx = await authenticator.connect(owner).removeSolver(solver);
-  await tx.wait();
-  console.log("Solver removed.");
-};
+  if (printTransaction) {
+    const data = authenticator.interface.encodeFunctionData(method, [solver]);
+    console.log(`\`${method}\` transaction:`);
+    console.log(`To:   ${authenticator.address}`);
+    console.log(`Data: ${data}`);
+  } else {
+    const tx = await authenticator.connect(owner)[method](solver);
+    console.log(transactionUrl(hre, tx));
+    await tx.wait();
+    console.log(`Executed \`${method}\`.`);
+  }
+}
 
 const isSolver = async (solver: string, hre: HardhatRuntimeEnvironment) => {
   const authenticator = await getDeployedContract(
@@ -65,9 +79,13 @@ const setupSolversTask: () => void = () => {
         ", ",
       )}`,
     )
-    .addOptionalVariadicPositionalParam(
-      "args",
-      "Extra parameters of the subtask",
+    .addOptionalPositionalParam<string>(
+      "solver",
+      "The solver account to add, remove, or check",
+    )
+    .addFlag(
+      "printTransaction",
+      "Prints the transaction to standard out when adding or removing solvers.",
     )
     .setAction(async (taskArguments, { run }) => {
       const { subtask } = taskArguments;
@@ -82,38 +100,31 @@ const setupSolversTask: () => void = () => {
   subtask(
     "solvers-add",
     "Adds a solver to the list of allowed solvers in GPv2.",
-  ).setAction(async ({ args }, hardhatRuntime) => {
-    if (!args || args.length !== 1) {
-      throw new Error(
-        "Invalid number of arguments. Expected the address of the solver to be added.",
-      );
-    }
-    await addSolver(args[0], hardhatRuntime);
-  });
+  )
+    .addPositionalParam<string>("solver", "The solver account to add.")
+    .addFlag("printTransaction", "Prints the transaction to standard out.")
+    .setAction(async (args, hardhatRuntime) => {
+      await addSolver(args, hardhatRuntime);
+    });
 
   subtask(
     "solvers-remove",
     "Removes a solver from the list of allowed solvers in GPv2.",
-  ).setAction(async ({ args }, hardhatRuntime) => {
-    if (!args || args.length !== 1) {
-      throw new Error(
-        "Invalid number of arguments. Expected the address of the solver to be removed.",
-      );
-    }
-    await removeSolver(args[0], hardhatRuntime);
-  });
+  )
+    .addPositionalParam<string>("solver", "The solver account to remove.")
+    .addFlag("printTransaction", "Prints the transaction to standard out.")
+    .setAction(async (args, hardhatRuntime) => {
+      await removeSolver(args, hardhatRuntime);
+    });
 
   subtask(
     "solvers-check",
     "Checks that an address is registered as a solver of GPv2.",
-  ).setAction(async ({ args }, hardhatRuntime) => {
-    if (!args || args.length !== 1) {
-      throw new Error(
-        "Invalid number of arguments. Expected the address of the solver to be checked",
-      );
-    }
-    await isSolver(args[0], hardhatRuntime);
-  });
+  )
+    .addPositionalParam<string>("solver", "The solver account to check.")
+    .setAction(async ({ solver }, hardhatRuntime) => {
+      await isSolver(solver, hardhatRuntime);
+    });
 
   subtask(
     "solvers-list",

--- a/test/tasks/solvers.test.ts
+++ b/test/tasks/solvers.test.ts
@@ -37,12 +37,18 @@ describe("Task: solvers", () => {
     });
 
     it("valid solver", async () => {
-      await run("solvers", { subtask: "check", args: [solver.address] });
+      await run("solvers", {
+        subtask: "check",
+        solver: solver.address,
+      });
       expect(output).to.equal(`${solver.address} is a solver.`);
     });
 
     it("invalid solver", async () => {
-      await run("solvers", { subtask: "check", args: [notSolver.address] });
+      await run("solvers", {
+        subtask: "check",
+        solver: notSolver.address,
+      });
       expect(output).to.equal(`${notSolver.address} is NOT a solver.`);
     });
   });
@@ -50,16 +56,42 @@ describe("Task: solvers", () => {
   describe("add", () => {
     it("adds a solver", async () => {
       expect(await authenticator.isSolver(notSolver.address)).to.be.false;
-      await run("solvers", { subtask: "add", args: [notSolver.address] });
+      await run("solvers", {
+        subtask: "add",
+        solver: notSolver.address,
+      });
       expect(await authenticator.isSolver(notSolver.address)).to.be.true;
+    });
+
+    it("does not add a solver when --print-transaction is specified", async () => {
+      expect(await authenticator.isSolver(notSolver.address)).to.be.false;
+      await run("solvers", {
+        subtask: "add",
+        solver: notSolver.address,
+        printTransaction: true,
+      });
+      expect(await authenticator.isSolver(notSolver.address)).to.be.false;
     });
   });
 
   describe("remove", () => {
     it("removes a solver", async () => {
       expect(await authenticator.isSolver(solver.address)).to.be.true;
-      await run("solvers", { subtask: "remove", args: [solver.address] });
+      await run("solvers", {
+        subtask: "remove",
+        solver: solver.address,
+      });
       expect(await authenticator.isSolver(solver.address)).to.be.false;
+    });
+
+    it("does not remove a solver when --print-transaction is specified", async () => {
+      expect(await authenticator.isSolver(solver.address)).to.be.true;
+      await run("solvers", {
+        subtask: "remove",
+        solver: solver.address,
+        printTransaction: true,
+      });
+      expect(await authenticator.isSolver(solver.address)).to.be.true;
     });
   });
 });


### PR DESCRIPTION
This PR adds a new flag for printing solver management transactions to the console instead of executing them. This is to facilitate authoring multisig transactions to add and remove solvers.

### Test Plan

Added a couple more unit tests. Additionally, you can do some manual testing with a local hardhat node:
```
$ npx hardhat node 
```

Then do solver things:
```
$ npx hardhat solvers list --network localhost

$ npx hardhat solvers check 0x0102030405060708091011121314151617181920 --network localhost
0x0102030405060708091011121314151617181920 is NOT a solver.
$ npx hardhat solvers add 0x0102030405060708091011121314151617181920 --print-transaction --network localhost
`addSolver` transaction:
To:   0x14d6cAf3e57dE2A955D7faC02F6cB025d149a4f5
Data: 0xec58f4b80000000000000000000000000102030405060708091011121314151617181920
$ npx hardhat solvers list --network localhost                                                              

$ npx hardhat solvers add 0x0102030405060708091011121314151617181920 --network localhost
0x1ce44566b11e876e5d59fae2e5f3904b087543381a878c2b1866d3e148b0eaaf
Executed `addSolver`.
$ npx hardhat solvers list --network localhost                                          
0x0102030405060708091011121314151617181920
$ npx hardhat solvers check 0x0102030405060708091011121314151617181920 --network localhost
0x0102030405060708091011121314151617181920 is a solver.
$ npx hardhat solvers remove 0x0102030405060708091011121314151617181920 --network localhost --print-transaction
`removeSolver` transaction:
To:   0x14d6cAf3e57dE2A955D7faC02F6cB025d149a4f5
Data: 0x8fd57b920000000000000000000000000102030405060708091011121314151617181920
$ npx hardhat solvers remove 0x0102030405060708091011121314151617181920 --network localhost
0x3f0a20eabb14f6881ed7a57aabbff07c4ccdae7a06c2a834f8145d83023e5f00
Executed `removeSolver`.
$ npx hardhat solvers list --network localhost

$ npx hardhat solvers check 0x0102030405060708091011121314151617181920 --network localhost
0x0102030405060708091011121314151617181920 is NOT a solver.
```
