### PR TITLE
Resilience against recoverable errors

### DIFF
--- a/src/tasks/ts/rate_limits.ts
+++ b/src/tasks/ts/rate_limits.ts
@@ -8,6 +8,7 @@ const LINE_CLEARING_ENABLED =
 export interface DisappearingLogFunctions {
   consoleWarn: typeof console.warn;
   consoleLog: typeof console.log;
+  consoleError: typeof console.error;
 }
 
 interface VanishingProgressMessage {
@@ -41,6 +42,7 @@ function createDisappearingLogFunctions(
   return {
     consoleWarn: clearable(console.warn),
     consoleLog: clearable(console.log),
+    consoleError: clearable(console.error),
   };
 }
 

--- a/src/tasks/withdraw.ts
+++ b/src/tasks/withdraw.ts
@@ -8,7 +8,7 @@ import { task, types } from "hardhat/config";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 import { Api, ApiError, CallError, Environment } from "../services/api";
-import { SettlementEncoder } from "../ts";
+import { EncodedSettlement, SettlementEncoder } from "../ts";
 
 import {
   getDeployedContract,
@@ -399,7 +399,7 @@ interface WithdrawInput {
   doNotPrompt?: boolean | undefined;
   requiredConfirmations?: number | undefined;
 }
-export async function withdraw({
+async function prepareWithdrawals({
   solver,
   tokens,
   minValue,
@@ -414,9 +414,10 @@ export async function withdraw({
   hre,
   api,
   dryRun,
-  doNotPrompt,
-  requiredConfirmations,
-}: WithdrawInput): Promise<string[]> {
+}: WithdrawInput): Promise<{
+  withdrawals: Withdrawal[];
+  finalSettlement: EncodedSettlement | null;
+}> {
   let solverForSimulation: string;
   if (await authenticator.isSolver(solver.address)) {
     solverForSimulation = solver.address;
@@ -505,7 +506,7 @@ export async function withdraw({
 
   if (withdrawals.length === 0) {
     console.log("No tokens to withdraw.");
-    return [];
+    return { withdrawals: [], finalSettlement: null };
   }
   displayWithdrawals(withdrawals, usdReference);
 
@@ -540,6 +541,20 @@ export async function withdraw({
     )} USD. All withdrawn funds will be sent to ${receiver}.`,
   );
 
+  return { withdrawals, finalSettlement };
+}
+
+async function submitWithdrawals(
+  {
+    dryRun,
+    doNotPrompt,
+    hre,
+    settlement,
+    solver,
+    requiredConfirmations,
+  }: WithdrawInput,
+  finalSettlement: EncodedSettlement,
+) {
   if (!dryRun && (doNotPrompt || (await prompt(hre, "Submit?")))) {
     console.log("Executing the withdraw transaction on the blockchain...");
     const response = await settlement
@@ -553,6 +568,25 @@ export async function withdraw({
       `Transaction successfully executed. Transaction hash: ${receipt.transactionHash}`,
     );
   }
+}
+
+export async function withdraw(input: WithdrawInput): Promise<string[] | null> {
+  let withdrawals, finalSettlement;
+  try {
+    ({ withdrawals, finalSettlement } = await prepareWithdrawals(input));
+  } catch (error) {
+    console.log(
+      "Script failed execution but no irreversible operations were performed",
+    );
+    console.log(error);
+    return null;
+  }
+
+  if (finalSettlement === null) {
+    return [];
+  }
+
+  await submitWithdrawals(input, finalSettlement);
 
   return withdrawals.map((w) => w.token.address);
 }

--- a/src/tasks/withdrawService.ts
+++ b/src/tasks/withdrawService.ts
@@ -17,6 +17,7 @@ import {
   isSupportedNetwork,
   SupportedNetwork,
 } from "./ts/deployment";
+import { promiseAllWithRateLimit } from "./ts/rate_limits";
 import { balanceOf, erc20Token } from "./ts/tokens";
 import { ReferenceToken, REFERENCE_TOKEN } from "./ts/value";
 import { withdraw } from "./withdraw";
@@ -45,6 +46,12 @@ export interface State {
    * service.
    */
   pendingTokens: PendingToken[];
+  /**
+   * Number of consecutive soft errors in a row. A soft error is an error that
+   * has no irreversible consequences, for example a network timeout before
+   * any transactions has been sent onchain.
+   */
+  softErrorCount?: number;
 }
 
 interface PendingToken {
@@ -103,6 +110,66 @@ function isValidState(state: unknown): state is State {
     return false;
   }
   return true;
+}
+
+function bumpErrorCount(state: State) {
+  const softErrorCount = (state.softErrorCount ?? 0) + 1;
+  // exponential alert backoff
+  if (Number.isInteger(Math.log2(softErrorCount / 10))) {
+    console.error(`Encountered ${softErrorCount} soft errors in a row`);
+  }
+  return {
+    ...state,
+    softErrorCount,
+  };
+}
+
+async function updatePendingTokens(
+  pendingTokens: PendingToken[],
+  solver: string,
+  hre: HardhatRuntimeEnvironment,
+): Promise<PendingToken[]> {
+  return (
+    await promiseAllWithRateLimit(
+      pendingTokens.map((pendingToken) => async ({ consoleError }) => {
+        if (pendingToken.retries >= MAX_ORDER_RETRIES_BEFORE_SKIPPING) {
+          // Note that this error might be triggered in legitimate cases, for
+          // example if a token did not trade the first time and then the price
+          // has become so low that it's not enough to pay for the fee.
+          // TODO: revisit after getting an idea of the frequency at which this
+          // alert is triggered.
+          consoleError(
+            `Tried ${pendingToken.retries} times to sell token ${pendingToken.address} without success. Skipping token until future run`,
+          );
+          return [];
+        }
+
+        // assumption: eth is not in the list (as it's not supported by the
+        // withdraw script). This should not happen unless the pending token
+        // list in the state was manually changed and ETH was added.
+        assert(
+          pendingToken.address.toLowerCase() !== BUY_ETH_ADDRESS.toLowerCase(),
+          "Pending tokens should not contain ETH",
+        );
+        const token = await erc20Token(pendingToken.address, hre);
+        if (token === null) {
+          throw new Error(
+            `Previously sold a token that is not a valid ERC20 token anymore (address ${pendingToken.address})`,
+          );
+        }
+        return (await balanceOf(token, solver)).isZero() ? [] : [pendingToken];
+      }),
+    )
+  ).flat();
+}
+
+function bumpAllPendingTokenRetries(
+  pendingTokens: PendingToken[],
+): PendingToken[] {
+  return pendingTokens.map((pendingToken) => ({
+    ...pendingToken,
+    retries: pendingToken.retries + 1,
+  }));
 }
 
 export interface WithdrawAndDumpInput {
@@ -170,50 +237,37 @@ export async function withdrawAndDump({
       `Too many tokens checked per run (${pagination}, max ${MAX_CHECKED_TOKENS_PER_RUN})`,
     );
   }
-  // Update list of pending tokens to determine which token was traded
-  const pendingTokens = (
-    await Promise.all(
-      state.pendingTokens.map(async (pendingToken) => {
-        if (pendingToken.retries >= MAX_ORDER_RETRIES_BEFORE_SKIPPING) {
-          // Note that this error might be triggered in legitimate cases, for
-          // example if a token did not trade the first time and then the price
-          // has become so low that it's not enough to pay for the fee.
-          // TODO: revisit after getting an idea of the frequency at which this
-          // alert is triggered.
-          console.error(
-            `Tried ${pendingToken.retries} times to sell token ${pendingToken.address} without success. Skipping token until future run`,
-          );
-          return [];
-        }
+  const stateUpdates: Partial<State> = {};
 
-        // assumption: eth is not in the list (as it's not supported by the
-        // withdraw script). This should not happen unless the pending token
-        // list in the state was manually changed and ETH was added.
-        assert(
-          pendingToken.address.toLowerCase() !== BUY_ETH_ADDRESS.toLowerCase(),
-          "Pending tokens should not contain ETH",
-        );
-        const token = await erc20Token(pendingToken.address, hre);
-        if (token === null) {
-          throw new Error(
-            `Previously sold a token that is not a valid ERC20 token anymore (address ${pendingToken.address})`,
-          );
-        }
-        pendingToken.retries += 1;
-        return (await balanceOf(token, solver.address)).isZero()
-          ? []
-          : [pendingToken];
-      }),
-    )
-  ).flat();
+  // Update list of pending tokens to determine which token was traded
+  let pendingTokens;
+  try {
+    pendingTokens = await updatePendingTokens(
+      state.pendingTokens,
+      solver.address,
+      hre,
+    );
+  } catch (error) {
+    console.log(`Encountered soft error when updating pending token list`);
+    console.log(error);
+    return bumpErrorCount({ ...state, ...stateUpdates });
+  }
+  stateUpdates.pendingTokens = pendingTokens;
 
   console.log("Recovering list of tokens traded since the previous run...");
   // Add extra blocks before the last update in case there was a reorg and new
   // transactions were included.
   const maxReorgDistance = 20;
   const fromBlock = Math.max(0, state.lastUpdateBlock - maxReorgDistance);
-  const { tokens: recentlyTradedTokens, toBlock: latestBlock } =
-    await getAllTradedTokens(settlement, fromBlock, "latest", hre);
+  let recentlyTradedTokens, latestBlock;
+  try {
+    ({ tokens: recentlyTradedTokens, toBlock: latestBlock } =
+      await getAllTradedTokens(settlement, fromBlock, "latest", hre));
+  } catch (error) {
+    console.log(`Encountered soft error when retrieving traded tokens`);
+    console.log(error);
+    return bumpErrorCount({ ...state, ...stateUpdates });
+  }
 
   const tradedTokens = state.tradedTokens.concat(
     recentlyTradedTokens.filter(
@@ -221,19 +275,15 @@ export async function withdrawAndDump({
         !(state.tradedTokens.includes(token) || token === BUY_ETH_ADDRESS),
     ),
   );
+  stateUpdates.tradedTokens = tradedTokens;
+  stateUpdates.lastUpdateBlock = latestBlock;
+
   const numCheckedTokens = Math.min(pagination, tradedTokens.length);
   // The index of the checked token wraps around after reaching the end of the
   // traded token list
   const checkedTokens = tradedTokens
     .concat(tradedTokens)
     .slice(state.nextTokenToTrade, state.nextTokenToTrade + numCheckedTokens);
-  const updatedState: State = {
-    lastUpdateBlock: latestBlock,
-    tradedTokens,
-    nextTokenToTrade:
-      (state.nextTokenToTrade + numCheckedTokens) % tradedTokens.length,
-    pendingTokens,
-  };
 
   console.log("Starting withdraw step...");
   const withdrawnTokens = await withdraw({
@@ -256,6 +306,14 @@ export async function withdrawAndDump({
     // function
     requiredConfirmations: confirmationsAfterWithdrawing,
   });
+
+  if (withdrawnTokens === null) {
+    console.log(`Encountered soft error during withdraw step`);
+    return bumpErrorCount({ ...state, ...stateUpdates });
+  }
+
+  stateUpdates.nextTokenToTrade =
+    (state.nextTokenToTrade + numCheckedTokens) % tradedTokens.length;
 
   const tokensToDump = Array.from(
     new Set(pendingTokens.map((t) => t.address).concat(withdrawnTokens)),
@@ -281,21 +339,30 @@ export async function withdrawAndDump({
     );
   }
 
-  updatedState.pendingTokens.push(
+  const updatedPendingTokens = bumpAllPendingTokenRetries(
+    stateUpdates.pendingTokens,
+  );
+  updatedPendingTokens.push(
     ...tokensToDump
       .filter(
         (address) =>
-          !updatedState.pendingTokens
+          !updatedPendingTokens
             .map((pendingToken) => pendingToken.address)
             .includes(address),
       )
       .map((address) => ({ address, retries: 1 })),
   );
-  if (!isValidState(updatedState)) {
-    console.log("Generated state:", updatedState);
+  stateUpdates.pendingTokens = updatedPendingTokens;
+  stateUpdates.softErrorCount = 0;
+
+  // stateUpdates is now populated with everything needed to be a proper state.
+  // The type system isn't able to see that however, the second best thing to
+  // verify that everything is set is a runtime check and tests.
+  if (!isValidState(stateUpdates)) {
+    console.log("Generated state:", stateUpdates);
     throw new Error("Withdraw service did not generate a valid state");
   }
-  return updatedState;
+  return stateUpdates;
 }
 
 async function fileExists(path: string): Promise<boolean> {
@@ -326,6 +393,20 @@ async function getState(stateFilePath: string): Promise<State> {
     throw new Error("Invalid state detect");
   }
   return state;
+}
+
+async function updateStateOnDisk(
+  updatedState: State,
+  stateFilePath: string,
+  dryRun: boolean,
+) {
+  console.debug(`Updated state: ${JSON.stringify(updatedState)}`);
+  if (!dryRun) {
+    await fs.writeFile(
+      stateFilePath,
+      JSON.stringify(updatedState, undefined, 2),
+    );
+  }
 }
 
 const setupWithdrawServiceTask: () => void = () =>
@@ -397,12 +478,25 @@ const setupWithdrawServiceTask: () => void = () =>
         const usdReference = REFERENCE_TOKEN[network];
         const api = new Api(network, Environment.Prod);
         const receiver = utils.getAddress(inputReceiver);
-        const [authenticator, settlementDeployment, [solver]] =
-          await Promise.all([
+        let authenticator, settlementDeployment, solver;
+        try {
+          [authenticator, settlementDeployment, [solver]] = await Promise.all([
             getDeployedContract("GPv2AllowListAuthentication", hre),
             hre.deployments.get("GPv2Settlement"),
             hre.ethers.getSigners(),
           ]);
+        } catch (error) {
+          console.log(
+            "Soft error encountered when retrieving information from the node",
+          );
+          console.log(error);
+          const updatedState = {
+            ...state,
+            softErrorCount: (state.softErrorCount ?? 0) + 1,
+          };
+          await updateStateOnDisk(updatedState, stateFilePath, dryRun);
+          return;
+        }
         const settlement = new Contract(
           settlementDeployment.address,
           settlementDeployment.abi,
@@ -432,13 +526,7 @@ const setupWithdrawServiceTask: () => void = () =>
           pagination: tokensPerRun,
         });
 
-        console.debug(`Updated state: ${JSON.stringify(updatedState)}`);
-        if (!dryRun) {
-          await fs.writeFile(
-            stateFilePath,
-            JSON.stringify(updatedState, undefined, 2),
-          );
-        }
+        await updateStateOnDisk(updatedState, stateFilePath, dryRun);
       },
     );
 


### PR DESCRIPTION
The withdraw service loudly fails every time a network error occurs, making it unsuitable to be run at regular interval as a cron service. This PR makes it so that the withdraw service does not fail in case errors occurs before any irreversible action is performed onchain.
To make sure that the service is kept running, if too many consecutive errors are encountered then an error message is printed to stderr.

### Test Plan

Existing unit tests.