### PR TITLE
Use custom api url

### DIFF
--- a/src/tasks/dump.ts
+++ b/src/tasks/dump.ts
@@ -689,6 +689,10 @@ const setupDumpTask: () => void = () =>
       5,
       types.float,
     )
+    .addOptionalParam(
+      "apiUrl",
+      "If set, the scripts contacts the API using the given url. Otherwise, the default prod url for the current network is used",
+    )
     .addFlag(
       "dryRun",
       "Just simulate the result instead of executing the transaction on the blockchain.",
@@ -707,6 +711,7 @@ const setupDumpTask: () => void = () =>
           dryRun,
           receiver,
           validity,
+          apiUrl,
         },
         hre,
       ) => {
@@ -714,7 +719,7 @@ const setupDumpTask: () => void = () =>
         if (!isSupportedNetwork(network)) {
           throw new Error(`Unsupported network ${hre.network.name}`);
         }
-        const api = new Api(network, Environment.Prod);
+        const api = new Api(network, apiUrl ?? Environment.Prod);
         const [signers, settlement] = await Promise.all([
           hre.ethers.getSigners(),
           getDeployedContract("GPv2Settlement", hre),

--- a/src/tasks/dump.ts
+++ b/src/tasks/dump.ts
@@ -691,7 +691,7 @@ const setupDumpTask: () => void = () =>
     )
     .addOptionalParam(
       "apiUrl",
-      "If set, the scripts contacts the API using the given url. Otherwise, the default prod url for the current network is used",
+      "If set, the script contacts the API using the given url. Otherwise, the default prod url for the current network is used",
     )
     .addFlag(
       "dryRun",

--- a/src/tasks/withdraw.ts
+++ b/src/tasks/withdraw.ts
@@ -577,6 +577,10 @@ const setupWithdrawTask: () => void = () =>
       5,
       types.float,
     )
+    .addOptionalParam(
+      "apiUrl",
+      "If set, the scripts contacts the API using the given url. Otherwise, the default prod url for the current network is used",
+    )
     .addParam("receiver", "The address receiving the withdrawn tokens.")
     .addFlag(
       "dryRun",
@@ -595,6 +599,7 @@ const setupWithdrawTask: () => void = () =>
           receiver: inputReceiver,
           dryRun,
           tokens,
+          apiUrl,
         },
         hre: HardhatRuntimeEnvironment,
       ) => {
@@ -602,7 +607,7 @@ const setupWithdrawTask: () => void = () =>
         if (!isSupportedNetwork(network)) {
           throw new Error(`Unsupported network ${network}`);
         }
-        const api = new Api(network, Environment.Prod);
+        const api = new Api(network, apiUrl ?? Environment.Prod);
         const receiver = utils.getAddress(inputReceiver);
         const [authenticator, settlementDeployment, [solver]] =
           await Promise.all([

--- a/src/tasks/withdraw.ts
+++ b/src/tasks/withdraw.ts
@@ -579,7 +579,7 @@ const setupWithdrawTask: () => void = () =>
     )
     .addOptionalParam(
       "apiUrl",
-      "If set, the scripts contacts the API using the given url. Otherwise, the default prod url for the current network is used",
+      "If set, the script contacts the API using the given url. Otherwise, the default prod url for the current network is used",
     )
     .addParam("receiver", "The address receiving the withdrawn tokens.")
     .addFlag(

--- a/src/tasks/withdrawService.ts
+++ b/src/tasks/withdrawService.ts
@@ -368,6 +368,10 @@ const setupWithdrawServiceTask: () => void = () =>
       "tokensPerRun",
       `The maximum number of tokens to process in a single withdraw run. Must be smaller than ${MAX_CHECKED_TOKENS_PER_RUN}`,
     )
+    .addOptionalParam(
+      "apiUrl",
+      "If set, the scripts contacts the API using the given url. Otherwise, the default prod url for the current network is used",
+    )
     .addParam("receiver", "The address receiving the withdrawn tokens")
     .addFlag(
       "dryRun",
@@ -385,6 +389,7 @@ const setupWithdrawServiceTask: () => void = () =>
           receiver: inputReceiver,
           dryRun,
           tokensPerRun,
+          apiUrl,
         },
         hre: HardhatRuntimeEnvironment,
       ) => {
@@ -395,7 +400,7 @@ const setupWithdrawServiceTask: () => void = () =>
           throw new Error(`Unsupported network ${network}`);
         }
         const usdReference = REFERENCE_TOKEN[network];
-        const api = new Api(network, Environment.Prod);
+        const api = new Api(network, apiUrl ?? Environment.Prod);
         const receiver = utils.getAddress(inputReceiver);
         const [authenticator, settlementDeployment, [solver]] =
           await Promise.all([

--- a/src/tasks/withdrawService.ts
+++ b/src/tasks/withdrawService.ts
@@ -370,7 +370,7 @@ const setupWithdrawServiceTask: () => void = () =>
     )
     .addOptionalParam(
       "apiUrl",
-      "If set, the scripts contacts the API using the given url. Otherwise, the default prod url for the current network is used",
+      "If set, the script contacts the API using the given url. Otherwise, the default prod url for the current network is used",
     )
     .addParam("receiver", "The address receiving the withdrawn tokens")
     .addFlag(


### PR DESCRIPTION
This PR lets users specify which base url to use to contact the api.

In particular, when running the service internally we can use our internal urls to bypass the public rate limit.

CC @fleupold.

### Test Plan

Compare a normal rinkeby run:
```
$ npx hardhat withdraw --network rinkeby --dry-run --receiver 0x1000000000000000000000000000000000000000 --min-value 1
```
<details><summary>output</summary>

```
$ npx hardhat withdraw --network rinkeby --dry-run --receiver 0x1000000000000000000000000000000000000000 --min-value 1
Using account 0x627306090abaB3A6e1400e9345bC60c78a8BEf57
Current account is not a solver. Only a solver can withdraw funds from the settlement contract.
Recovering list of traded tokens...
Processed events from block 8727415 to latest
Ignored 0.000000028157467457 units of REP (0x6e894660985207feb7cf89Faf048998c71E8EE89) with value 0.00 USD, does not satisfy conditions on min value and leftover
Ignored 0.000000127087302269 units of USDT (0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02) with value 0.54 USD, does not satisfy conditions on min value and leftover
Ignored 0.218046392589933552 units of TUSD (0x0000000000085d4780B73119b644AE5ecd22b376) with value 9.32 USD, the gas cost is too high (732.87% of the withdrawn amount)
Ignored 2.862094576999644672 units of LINK (0x01BE23585060835E02B77ef475b0Cc51aA1e0709) with value 71.74 USD, the gas cost is too high (102.19% of the withdrawn amount)
Ignored 0.01362344 units of cETH (0xd6801a1DfFCd0a410336Ef88DeF4320D6DF1883e) with value 324.27 USD, the gas cost is too high (37.54% of the withdrawn amount)
Ignored 5.025938295596499514 units of GNO (0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c) with value 543.87 USD, the gas cost is too high (7.28% of the withdrawn amount)
Ignored 0.02701520575572856 units of TKIn (0xcFc99E8139Ae41FF6Db9E521f9e7cEaC8BDC9cbC) with value 640.53 USD, the gas cost is too high (11.33% of the withdrawn amount)
Ignored 0.02197466 units of WBTC (0x577D296678535e4903D59A4C929B718e1D575e0A) with value 801.31 USD, the gas cost is too high (9.65% of the withdrawn amount)
Ignored 26.606510812451957354 units of OWL (0xa7D1C04fAF998F9161fC9F800a99A809b84cfc9D) with value 980.27 USD, the gas cost is too high (7.50% of the withdrawn amount)
Ignored 7.420776858655397515 units of BAT (0xbF7A7169562078c96f0eC1A8aFD6aE50f12e5A99) with value 1074.35 USD, the gas cost is too high (6.83% of the withdrawn amount)
Ignored 0.174321717473365317 units of PAX (0xBD6A9921504fae42EaD2024F43305A8ED3890F6f) with value 1178.04 USD, the gas cost is too high (7.41% of the withdrawn amount)
Amounts to withdraw:
 address                                    | balance (usd) | balance                        | withdrawn amount               | symbol 
--------------------------------------------+---------------+--------------------------------+--------------------------------+--------
 0xddea378A6dDC8AfeC82C36E9b0078826bf9e68B6 |       2637.62 |           0.508605154604155298 |           0.508605154604155298 | ZRX    
 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984 |       5604.36 |           0.021471537346330336 |           0.021471537346330336 | UNI    
 0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b |       5702.49 |        1592.331595000000000000 |        1592.331595000000000000 | USDC   
 0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735 |      21278.04 | 4576441861690.2200679893732... | 4576441861690.2200679893732... | DAI    
 0xc778417E063141139Fce010982780140Aa0cD5Ab |      26575.95 |           0.290143231529852199 |           0.290143231529852199 | WETH   
 0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85 |     116255.11 |           0.000061977439752630 |           0.000061977439752630 | MKR    
 0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa |     304251.02 |      304251.025987713202594833 |      304251.025987713202594833 | DAI    

The transaction will cost approximately 0.00643124745675981 ETH and will withdraw the balance of 7 tokens for an estimated total value of 482304.63 USD. All withdrawn funds will be sent to 0x1000000000000000000000000000000000000000.
```
</details>

to a run using the xdai url instead
```
$ npx hardhat withdraw --network rinkeby --dry-run --receiver 0x1000000000000000000000000000000000000000 --min-value 1 --api-url 'https://protocol-xdai.dev.gnosisdev.com'
```
<details><summary>output</summary>

```
$ npx hardhat withdraw --network rinkeby --dry-run --receiver 0x1000000000000000000000000000000000000000 --min-value 1 --api-url 'https://protocol-xdai.dev.gnosisdev.com'
Using account 0x627306090abaB3A6e1400e9345bC60c78a8BEf57
Current account is not a solver. Only a solver can withdraw funds from the settlement contract.
Recovering list of traded tokens...
Processed events from block 8727415 to latest
Warning: price retrieval failed for token USDC (0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b): UnsupportedToken (Token address 0x4dbcdf9b62e891a7cec5a2568c3f4faf9e8abe2b)
Ignored 1592.331595 units of USDC (0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b) with value 0.00 USD, does not satisfy conditions on min value and leftover
Warning: price retrieval failed for token LINK (0x01BE23585060835E02B77ef475b0Cc51aA1e0709): UnsupportedToken (Token address 0x01be23585060835e02b77ef475b0cc51aa1e0709)
Ignored 2.862094576999644672 units of LINK (0x01BE23585060835E02B77ef475b0Cc51aA1e0709) with value 0.00 USD, does not satisfy conditions on min value and leftover
Warning: price retrieval failed for token DAI (0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa): UnsupportedToken (Token address 0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea)
Ignored 304251.025987713202594833 units of DAI (0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa) with value 0.00 USD, does not satisfy conditions on min value and leftover
Warning: price retrieval failed for token TUSD (0x0000000000085d4780B73119b644AE5ecd22b376): UnsupportedToken (Token address 0x0000000000085d4780b73119b644ae5ecd22b376)
Ignored 0.218046392589933552 units of TUSD (0x0000000000085d4780B73119b644AE5ecd22b376) with value 0.00 USD, does not satisfy conditions on min value and leftover
Warning: price retrieval failed for token UNI (0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984): UnsupportedToken (Token address 0x1f9840a85d5af5bf1d1762f925bdaddc4201f984)
Ignored 0.021471537346330336 units of UNI (0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984) with value 0.00 USD, does not satisfy conditions on min value and leftover
Warning: price retrieval failed for token OWL (0xa7D1C04fAF998F9161fC9F800a99A809b84cfc9D): UnsupportedToken (Token address 0xa7d1c04faf998f9161fc9f800a99a809b84cfc9d)
Ignored 26.606510812451957354 units of OWL (0xa7D1C04fAF998F9161fC9F800a99A809b84cfc9D) with value 0.00 USD, does not satisfy conditions on min value and leftover
Warning: price retrieval failed for token BAT (0xbF7A7169562078c96f0eC1A8aFD6aE50f12e5A99): UnsupportedToken (Token address 0xbf7a7169562078c96f0ec1a8afd6ae50f12e5a99)
Ignored 7.420776858655397515 units of BAT (0xbF7A7169562078c96f0eC1A8aFD6aE50f12e5A99) with value 0.00 USD, does not satisfy conditions on min value and leftover
Warning: price retrieval failed for token WBTC (0x577D296678535e4903D59A4C929B718e1D575e0A): UnsupportedToken (Token address 0x577d296678535e4903d59a4c929b718e1d575e0a)
Ignored 0.02197466 units of WBTC (0x577D296678535e4903D59A4C929B718e1D575e0A) with value 0.00 USD, does not satisfy conditions on min value and leftover
Warning: price retrieval failed for token REP (0x6e894660985207feb7cf89Faf048998c71E8EE89): UnsupportedToken (Token address 0x6e894660985207feb7cf89faf048998c71e8ee89)
Ignored 0.000000028157467457 units of REP (0x6e894660985207feb7cf89Faf048998c71E8EE89) with value 0.00 USD, does not satisfy conditions on min value and leftover
Warning: price retrieval failed for token PAX (0xBD6A9921504fae42EaD2024F43305A8ED3890F6f): UnsupportedToken (Token address 0xbd6a9921504fae42ead2024f43305a8ed3890f6f)
Ignored 0.174321717473365317 units of PAX (0xBD6A9921504fae42EaD2024F43305A8ED3890F6f) with value 0.00 USD, does not satisfy conditions on min value and leftover
Warning: price retrieval failed for token WETH (0xc778417E063141139Fce010982780140Aa0cD5Ab): UnsupportedToken (Token address 0xc778417e063141139fce010982780140aa0cd5ab)
Ignored 0.290143231529852199 units of WETH (0xc778417E063141139Fce010982780140Aa0cD5Ab) with value 0.00 USD, does not satisfy conditions on min value and leftover
Warning: price retrieval failed for token TKIn (0xcFc99E8139Ae41FF6Db9E521f9e7cEaC8BDC9cbC): UnsupportedToken (Token address 0xcfc99e8139ae41ff6db9e521f9e7ceac8bdc9cbc)
Ignored 0.02701520575572856 units of TKIn (0xcFc99E8139Ae41FF6Db9E521f9e7cEaC8BDC9cbC) with value 0.00 USD, does not satisfy conditions on min value and leftover
Warning: price retrieval failed for token GNO (0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c): UnsupportedToken (Token address 0xd0dab4e640d95e9e8a47545598c33e31bdb53c7c)
Ignored 5.025938295596499514 units of GNO (0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c) with value 0.00 USD, does not satisfy conditions on min value and leftover
Warning: price retrieval failed for token DAI (0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735): UnsupportedToken (Token address 0xc7ad46e0b8a400bb3c915120d284aafba8fc4735)
Ignored 4576441861690.220067989373299353 units of DAI (0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735) with value 0.00 USD, does not satisfy conditions on min value and leftover
Warning: price retrieval failed for token cETH (0xd6801a1DfFCd0a410336Ef88DeF4320D6DF1883e): UnsupportedToken (Token address 0xd6801a1dffcd0a410336ef88def4320d6df1883e)
Ignored 0.01362344 units of cETH (0xd6801a1DfFCd0a410336Ef88DeF4320D6DF1883e) with value 0.00 USD, does not satisfy conditions on min value and leftover
Warning: price retrieval failed for token ZRX (0xddea378A6dDC8AfeC82C36E9b0078826bf9e68B6): UnsupportedToken (Token address 0xddea378a6ddc8afec82c36e9b0078826bf9e68b6)
Ignored 0.508605154604155298 units of ZRX (0xddea378A6dDC8AfeC82C36E9b0078826bf9e68B6) with value 0.00 USD, does not satisfy conditions on min value and leftover
Warning: price retrieval failed for token USDT (0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02): UnsupportedToken (Token address 0xd9ba894e0097f8cc2bbc9d24d308b98e36dc6d02)
Ignored 0.000000127087302269 units of USDT (0xD9BA894E0097f8cC2BBc9D24D308b98e36dc6D02) with value 0.00 USD, does not satisfy conditions on min value and leftover
Warning: price retrieval failed for token MKR (0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85): UnsupportedToken (Token address 0xf9ba5210f91d0474bd1e1dcdaec4c58e359aad85)
Ignored 0.00006197743975263 units of MKR (0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85) with value 0.00 USD, does not satisfy conditions on min value and leftover
An unexpected error occurred:

Error: Calling "https://protocol-xdai.dev.gnosisdev.com/api/v1/markets/0xc778417e063141139fce010982780140aa0cd5ab-0x5592ec0cfb4dbc12d3ab100b257153436a1f0fea/sell/1000000000000000000 undefined failed with 400: {"errorType":"UnsupportedToken","description":"Token address 0xc778417e063141139fce010982780140aa0cd5ab"}
    at call (/var/home/federico/gnosis-code/oba-contracts/src/services/api.ts:141:30)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async estimateTradeAmount (/var/home/federico/gnosis-code/oba-contracts/src/services/api.ts:179:44)
    at async usdValue (/var/home/federico/gnosis-code/oba-contracts/src/tasks/ts/value.ts:44:10)
    at async usdValueOfEth (/var/home/federico/gnosis-code/oba-contracts/src/tasks/ts/value.ts:58:10)
    at async Promise.all (index 0)
    at async withdraw (/var/home/federico/gnosis-code/oba-contracts/src/tasks/withdraw.ts:476:38)
    at async SimpleTaskDefinition.action (/var/home/federico/gnosis-code/oba-contracts/src/tasks/withdraw.ts:626:9)
    at async Environment._runTaskDefinition (/var/home/federico/gnosis-code/oba-contracts/node_modules/hardhat/src/internal/core/runtime-environment.ts:217:14) {
  apiError: {
    errorType: 'UnsupportedToken',
    description: 'Token address 0xc778417e063141139fce010982780140aa0cd5ab'
  }
}
```
</details>

and notice the many new "UnsupportedToken" errors, indicating that the endpoint is reached and behaves as expected as the rinkeby tokens don't exist in xdai.