### PR TITLE
Bump version to v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/gp-v2-contracts",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "license": "LGPL-3.0-or-later",
   "scripts": {
     "deploy": "hardhat deploy",


### PR DESCRIPTION
The frontend mentioned it would be handy to use the newly introduced API types (discussed in #869).

This PR prepares the repo for a new release.
