### PR TITLE
Bump node version in deploy script to fix build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 14.7
       - run: yarn --frozen-lockfile
       - run: yarn build
       - run: bash src/workflows/deploy.sh "automated-contract-deployment-${{github.run_number}}"


### PR DESCRIPTION
https://github.com/gnosis/gp-v2-contracts/runs/4066373645?check_suite_focus=true#step:4:207

> error @typescript-eslint/eslint-plugin@5.2.0: The engine "node" is incompatible with this module. Expected version "^12.22.0 || ^14.17.0 || >=16.0.0". Got "14.16.1"
error Found incompatible module.

### Test Plan

<a href="https://gitme.me/image?url=https%3A%2F%2Fcamo.githubusercontent.com%2F93aa2734f06291524f82361ba4f72b12b053a1c5%2F68747470733a2f2f666972656261736573746f726167652e676f6f676c65617069732e636f6d2f76302f622f6769742d6d656d652d70726f642e61707073706f742e636f6d2f6f2f696d6167657325324674657374496e50726f642e6a70673f616c743d6d6564696126746f6b656e3d38303834663762632d326433342d343463312d623363632d663831343039616130353734&token=testinprod" data-gitmeme-token="testinprod"><img src="https://camo.githubusercontent.com/93aa2734f06291524f82361ba4f72b12b053a1c5/68747470733a2f2f666972656261736573746f726167652e676f6f676c65617069732e636f6d2f76302f622f6769742d6d656d652d70726f642e61707073706f742e636f6d2f6f2f696d6167657325324674657374496e50726f642e6a70673f616c743d6d6564696126746f6b656e3d38303834663762632d326433342d343463312d623363632d663831343039616130353734" title="Created by gitme.me with /testinprod"/></a>
