### PR TITLE
Add support for BlockNative gas estimates for tasks

### DIFF
--- a/src/tasks/ts/gas.ts
+++ b/src/tasks/ts/gas.ts
@@ -70,10 +70,11 @@ interface BlockPrices {
 }
 
 export class BlockNativeGasEstimator implements IGasEstimator {
-  constructor(public confidence: number = 0.9) {}
+  constructor(public confidence: number = 90) {}
 
   private async queryEstimatedPrice(): Promise<EstimatedPrice> {
-    const { estimatedPrices }: BlockPrices = await axios.get(BLOCKNATIVE_URL);
+    const response = await axios.get(BLOCKNATIVE_URL);
+    const { estimatedPrices }: BlockPrices = response.data;
     estimatedPrices.sort((a, b) => a.confidence - b.confidence);
     const price = estimatedPrices.find(
       (price) => price.confidence >= this.confidence,

--- a/src/tasks/ts/gas.ts
+++ b/src/tasks/ts/gas.ts
@@ -1,0 +1,108 @@
+import axios from "axios";
+import { BigNumber, ethers } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+/**
+ * Transaction gas price options.
+ */
+export interface TransactionGasPrice {
+  gasPrice?: BigNumber;
+  maxFeePerGas?: BigNumber;
+  maxPriorityFeePerGas?: BigNumber;
+}
+
+/**
+ * Gas estimator interface.
+ */
+export interface IGasEstimator {
+  /**
+   * Computes the estimated gas price for a given transaction.
+   */
+  gasPriceEstimate(): Promise<BigNumber>;
+
+  /**
+   * Computes the optimal transaction gas price options to use.
+   */
+  txGasPrice(): Promise<TransactionGasPrice>;
+}
+
+export function createGasEstimator(
+  hre: HardhatRuntimeEnvironment,
+  options: {
+    blockNative: boolean;
+  },
+): IGasEstimator {
+  if (options.blockNative) {
+    if (hre.network.name !== "mainnet") {
+      throw new Error(`BlockNative does not support ${hre.network.name}`);
+    }
+    return new BlockNativeGasEstimator();
+  } else {
+    return new ProviderGasEstimator(hre.ethers.provider);
+  }
+}
+
+export class ProviderGasEstimator implements IGasEstimator {
+  constructor(private provider: ethers.providers.Provider) {}
+
+  gasPriceEstimate(): Promise<BigNumber> {
+    return this.provider.getGasPrice();
+  }
+
+  txGasPrice(): Promise<TransactionGasPrice> {
+    return Promise.resolve({});
+  }
+}
+
+// We just use the API that the gas price browser page uses to avoid dealing
+// with API keys and rate limiting.
+const BLOCKNATIVE_URL = "https://blocknative-api.herokuapp.com/data";
+
+interface EstimatedPrice {
+  confidence: number;
+  price: number;
+  maxPriorityFeePerGas: number;
+  maxFeePerGas: number;
+}
+
+interface BlockPrices {
+  estimatedPrices: EstimatedPrice[];
+}
+
+export class BlockNativeGasEstimator implements IGasEstimator {
+  constructor(public confidence: number = 0.9) {}
+
+  private async queryEstimatedPrice(): Promise<EstimatedPrice> {
+    const { estimatedPrices }: BlockPrices = await axios.get(BLOCKNATIVE_URL);
+    estimatedPrices.sort((a, b) => a.confidence - b.confidence);
+    const price = estimatedPrices.find(
+      (price) => price.confidence >= this.confidence,
+    );
+    if (price === undefined) {
+      throw new Error(
+        `no price with confidence greater than ${this.confidence}`,
+      );
+    }
+
+    return price;
+  }
+
+  async gasPriceEstimate(): Promise<BigNumber> {
+    const { price } = await this.queryEstimatedPrice();
+    return gweiToWei(price);
+  }
+
+  async txGasPrice(): Promise<TransactionGasPrice> {
+    const { maxFeePerGas, maxPriorityFeePerGas } =
+      await this.queryEstimatedPrice();
+
+    return {
+      maxFeePerGas: gweiToWei(maxFeePerGas),
+      maxPriorityFeePerGas: gweiToWei(maxPriorityFeePerGas),
+    };
+  }
+}
+
+function gweiToWei(amount: number): BigNumber {
+  return ethers.utils.parseUnits(amount.toFixed(9), 9);
+}

--- a/src/tasks/ts/gas.ts
+++ b/src/tasks/ts/gas.ts
@@ -2,14 +2,7 @@ import axios from "axios";
 import { BigNumber, ethers } from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-/**
- * Transaction gas price options.
- */
-export interface TransactionGasPrice {
-  gasPrice?: BigNumber;
-  maxFeePerGas?: BigNumber;
-  maxPriorityFeePerGas?: BigNumber;
-}
+export type FeeData = Partial<ethers.providers.FeeData>;
 
 /**
  * Gas estimator interface.
@@ -23,7 +16,7 @@ export interface IGasEstimator {
   /**
    * Computes the optimal transaction gas price options to use.
    */
-  txGasPrice(): Promise<TransactionGasPrice>;
+  txGasPrice(): Promise<FeeData>;
 }
 
 export function createGasEstimator(
@@ -49,7 +42,7 @@ export class ProviderGasEstimator implements IGasEstimator {
     return this.provider.getGasPrice();
   }
 
-  txGasPrice(): Promise<TransactionGasPrice> {
+  txGasPrice(): Promise<FeeData> {
     return Promise.resolve({});
   }
 }
@@ -93,7 +86,7 @@ export class BlockNativeGasEstimator implements IGasEstimator {
     return gweiToWei(price);
   }
 
-  async txGasPrice(): Promise<TransactionGasPrice> {
+  async txGasPrice(): Promise<FeeData> {
     const { maxFeePerGas, maxPriorityFeePerGas } =
       await this.queryEstimatedPrice();
 

--- a/test/tasks/dump.test.ts
+++ b/test/tasks/dump.test.ts
@@ -20,6 +20,7 @@ import {
   getDumpInstructions,
 } from "../../src/tasks/dump";
 import { SupportedNetwork } from "../../src/tasks/ts/deployment";
+import { ProviderGasEstimator } from "../../src/tasks/ts/gas";
 import { Erc20Token, isNativeToken } from "../../src/tasks/ts/tokens";
 import { BUY_ETH_ADDRESS, OrderKind } from "../../src/ts";
 import {
@@ -150,7 +151,7 @@ describe("getDumpInstructions", () => {
     consoleLog = console.log;
     console.log = (...args: unknown[]) => (consoleLogOutput = args[0]);
 
-    [deployer, user, receiver] = await waffle.provider.getWallets();
+    [deployer, user, receiver] = waffle.provider.getWallets();
     // environment parameter is unused in mock
     const environment = "unset environment" as unknown as Environment;
     api = new Api("mock", environment);
@@ -168,6 +169,7 @@ describe("getDumpInstructions", () => {
       hre,
       network,
       api,
+      gasEstimator: new ProviderGasEstimator(ethers.provider),
     };
   });
 
@@ -907,6 +909,7 @@ describe("Task: dump", () => {
       network,
       hre,
       api,
+      gasEstimator: new ProviderGasEstimator(ethers.provider),
       dryRun: false,
       doNotPrompt: true,
     });
@@ -942,6 +945,7 @@ describe("Task: dump", () => {
         network,
         hre,
         api,
+        gasEstimator: new ProviderGasEstimator(ethers.provider),
         dryRun: false,
         doNotPrompt: true,
       });

--- a/test/tasks/ts/gas.test.ts
+++ b/test/tasks/ts/gas.test.ts
@@ -1,0 +1,44 @@
+import { expect } from "chai";
+
+import { BlockNativeGasEstimator } from "../../../src/tasks/ts/gas";
+
+// We allow failure for BlockNative tests because their service may be down, and
+// we don't want to block CI because of it.
+//
+// The tests in this file still provide an indication that things are working
+// and should pass most of the time.
+function itAllowFail(title: string, callback: () => Promise<void>) {
+  it(title, async function () {
+    try {
+      await callback();
+    } catch (err) {
+      console.warn(`allowed failure: ${err}`);
+      this.skip();
+    }
+  });
+}
+
+describe("Task helper: BlockNative gas estimator", () => {
+  const blockNative = new BlockNativeGasEstimator();
+
+  itAllowFail("estimates gas", async () => {
+    const gasPrice = await blockNative.gasPriceEstimate();
+
+    expect(gasPrice.gt(0)).to.be.true;
+  });
+
+  itAllowFail("computes transaction gas prices", async () => {
+    const { gasPrice, maxFeePerGas, maxPriorityFeePerGas } =
+      await blockNative.txGasPrice();
+
+    expect(gasPrice).to.be.undefined;
+
+    expect(maxFeePerGas).to.not.be.undefined;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(maxFeePerGas!.gt(0)).to.be.true;
+
+    expect(maxPriorityFeePerGas).to.not.be.undefined;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(maxPriorityFeePerGas!.gt(0)).to.be.true;
+  });
+});

--- a/test/tasks/withdraw.test.ts
+++ b/test/tasks/withdraw.test.ts
@@ -5,6 +5,7 @@ import hre, { ethers, waffle } from "hardhat";
 import { mock, SinonMock } from "sinon";
 
 import { SupportedNetwork } from "../../src/tasks/ts/deployment";
+import { ProviderGasEstimator } from "../../src/tasks/ts/gas";
 import { ReferenceToken } from "../../src/tasks/ts/value";
 import { withdraw } from "../../src/tasks/withdraw";
 import {
@@ -251,6 +252,7 @@ describe("Task: withdraw", () => {
       network: undefined as unknown as SupportedNetwork,
       hre,
       api,
+      gasEstimator: new ProviderGasEstimator(ethers.provider),
       dryRun: false,
       doNotPrompt: true,
     });
@@ -356,6 +358,7 @@ describe("Task: withdraw", () => {
       network: undefined as unknown as SupportedNetwork,
       hre,
       api,
+      gasEstimator: new ProviderGasEstimator(ethers.provider),
       dryRun: false,
       doNotPrompt: true,
     });

--- a/test/tasks/withdrawService.test.ts
+++ b/test/tasks/withdrawService.test.ts
@@ -6,6 +6,7 @@ import { mock, SinonMock } from "sinon";
 
 import { APP_DATA } from "../../src/tasks/dump";
 import { SupportedNetwork } from "../../src/tasks/ts/deployment";
+import { ProviderGasEstimator } from "../../src/tasks/ts/gas";
 import { ReferenceToken } from "../../src/tasks/ts/value";
 import * as withdrawService from "../../src/tasks/withdrawService";
 import { WithdrawAndDumpInput } from "../../src/tasks/withdrawService";
@@ -110,6 +111,7 @@ describe("Task: withdrawService", () => {
       usdReference,
       hre,
       api,
+      gasEstimator: new ProviderGasEstimator(ethers.provider),
       dryRun: false,
     });
 


### PR DESCRIPTION
This PR adds BlockNative gas estimates to our withdraw and dump script. This should hopefully get rid of most of the `transaction underpriced` errors we have been seeing with the withdrawal service.

The BlockNative gas estimator can be enabled by using the `--blocknative-gas-price` flag in the `withdraw`, `withdrawservice` and `dump` tasks.

### Test Plan

Added some unit tests to make sure gas estimates are working.
