### PR TITLE
Skip Docker deployment if DOCKER_NAME is not set

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,16 +40,18 @@ jobs:
     needs: test
     env:
       DOCKERHUB_PROJECT: gp-v2-contracts
+      DOCKER_NAME: ${{ secrets.DOCKER_NAME }}
     steps:
       - uses: actions/checkout@v2
       - name: Dockerhub login
         uses: docker/login-action@v1
+        if: ${{ env.DOCKER_NAME != '' }}
         with:
           username: ${{ secrets.DOCKER_NAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Deploy Main
-        if: github.ref == 'refs/heads/main'
+        if: ${{ env.DOCKER_NAME != '' && github.ref == 'refs/heads/main' }}
         run: bash src/docker/deploy.sh staging
       - name: Deploy Tag
-        if: startsWith(github.ref, 'refs/tags/')
+        if: ${{ env.DOCKER_NAME != '' && startsWith(github.ref, 'refs/tags/') }}
         run: bash src/docker/deploy.sh ${GITHUB_REF##*/}


### PR DESCRIPTION
Do not try to deploy to Docker on CI if `DOCKER_NAME` is not defined.

This is done for two reasons:
- external contributors currently see CI failing ([example](https://github.com/gnosis/gp-v2-contracts/pull/877), which is not a good welcome for new contributors)
- Dependabot CI fails until Mergify merges main ([example](https://github.com/gnosis/gp-v2-contracts/pull/918), I didn't investigate why Dependabot doesn't have access to the secrets but Mergify does)

Note that there is no "nice" way to skip CI if a secret doesn't exist. What I propose here is a workaround based on the content of [this discussion](https://github.community/t/how-can-i-test-if-secrets-are-available-in-an-action/17911).

### Test plan

In a test repository, I tried to run the following workflow:
```
name: test workflow
on:
  push:
    branches: [master]
jobs:
  checkexists:
    env:
      TESTSECRET: ${{ secrets.TESTSECRET }}
    runs-on: ubuntu-latest
    steps:
      - if: ${{ env.TESTSECRET != '' && startsWith(github.ref, 'refs/heads/main') }}
        run: echo success
      - run: echo ${{ github.ref }} == 'refs/heads/master' ${{ startsWith(github.ref, 'refs/') }}
```

and the flagged step runs iff both conditions hold.

After this PR is merged, we can check if Dependabot's PRs have passing CI ([example after merge](https://github.com/gnosis/gp-v2-contracts/runs/5037230661)).