### PR TITLE
Add localhost network

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -92,6 +92,11 @@ export default {
     hardhat: {
       blockGasLimit: 12.5e6,
     },
+    localhost: {
+      blockGasLimit: 12.5e6,
+      url: "http://127.0.0.1:8545",
+    },
+
     mainnet: {
       ...sharedNetworkConfig,
       url: `https://mainnet.infura.io/v3/${INFURA_KEY}`,


### PR DESCRIPTION
This PR adds a new network `localhost` that is convenient to connect to a node running locally.

Additionally, it fixes a somewhat related issue, in which the `deploySettlement` script would fail for network `localhost`, because it would try to get the `Vault` from some static configuration.


## Background
The main motivation was to be able to launch an standalone `npx hardhat node` and be able to deploy the contracts there. 

We are attempting to have a running setup in The Graph.


### Test Plan


```
yarn 
yarn deploy
npx hardhat node

# in another tab
yarn deploy --network localhost
```

Check that the contracts are deployed correctly

<img width="799" alt="image" src="https://user-images.githubusercontent.com/2352112/153060054-24f11722-f80f-4439-9838-3224a8d5f3e3.png">

