### PR TITLE
No longer withdraw funds from buffers

### DIFF
--- a/src/tasks/withdraw.ts
+++ b/src/tasks/withdraw.ts
@@ -178,12 +178,15 @@ function ignoredTokenMessage(
   reason?: string,
 ) {
   const decimals = token.decimals ?? 18;
-  return `Ignored ${utils.formatUnits(amount, decimals)} units of ${token.symbol ?? "unknown token"
-    } (${token.address})${token.decimals === undefined
+  return `Ignored ${utils.formatUnits(amount, decimals)} units of ${
+    token.symbol ?? "unknown token"
+  } (${token.address})${
+    token.decimals === undefined
       ? ` (no decimals specified in the contract, assuming ${decimals})`
       : ""
-    } with value ${formatUsdValue(valueUsd, usdReference)} USD${reason ? `, ${reason}` : ""
-    }`;
+  } with value ${formatUsdValue(valueUsd, usdReference)} USD${
+    reason ? `, ${reason}` : ""
+  }`;
 }
 
 interface GetWithdrawalsInput {
@@ -545,7 +548,8 @@ async function prepareWithdrawals({
       transactionUsdCost,
       network,
       usdReference,
-    )} and will withdraw the balance of ${withdrawals.length
+    )} and will withdraw the balance of ${
+      withdrawals.length
     } tokens for an estimated total value of ${formatUsdValue(
       withdrawnValue,
       usdReference,

--- a/src/tasks/withdraw.ts
+++ b/src/tasks/withdraw.ts
@@ -33,8 +33,8 @@ import {
   usdValueOfEth,
 } from "./ts/value";
 import {
-  BUFFER_TRADABLE_TOKENS,
   excludeBufferTradableTokensFromList,
+  fetchBufferTradableTokens,
   getAllTradedTokens,
 } from "./withdraw/traded_tokens";
 
@@ -178,15 +178,12 @@ function ignoredTokenMessage(
   reason?: string,
 ) {
   const decimals = token.decimals ?? 18;
-  return `Ignored ${utils.formatUnits(amount, decimals)} units of ${
-    token.symbol ?? "unknown token"
-  } (${token.address})${
-    token.decimals === undefined
+  return `Ignored ${utils.formatUnits(amount, decimals)} units of ${token.symbol ?? "unknown token"
+    } (${token.address})${token.decimals === undefined
       ? ` (no decimals specified in the contract, assuming ${decimals})`
       : ""
-  } with value ${formatUsdValue(valueUsd, usdReference)} USD${
-    reason ? `, ${reason}` : ""
-  }`;
+    } with value ${formatUsdValue(valueUsd, usdReference)} USD${reason ? `, ${reason}` : ""
+    }`;
 }
 
 interface GetWithdrawalsInput {
@@ -466,7 +463,7 @@ async function prepareWithdrawals({
   if (!withdrawBufferTradableTokens) {
     tokens = excludeBufferTradableTokensFromList(
       tokens,
-      await BUFFER_TRADABLE_TOKENS,
+      await fetchBufferTradableTokens(),
     );
   }
   // TODO: add eth withdrawal
@@ -548,8 +545,7 @@ async function prepareWithdrawals({
       transactionUsdCost,
       network,
       usdReference,
-    )} and will withdraw the balance of ${
-      withdrawals.length
+    )} and will withdraw the balance of ${withdrawals.length
     } tokens for an estimated total value of ${formatUsdValue(
       withdrawnValue,
       usdReference,

--- a/src/tasks/withdraw/traded_tokens.ts
+++ b/src/tasks/withdraw/traded_tokens.ts
@@ -1,7 +1,36 @@
+import axios from "axios";
 import { Contract } from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 import { BUY_ETH_ADDRESS } from "../../ts";
+
+export const BUFFER_TRADABLE_TOKENS: Promise<string[]> = axios
+  .get(
+    "https://raw.githubusercontent.com/gnosis/cow-dex-solver/main/data/token_list_for_buffer_trading.json",
+  )
+  .then((response) => {
+    const token_list: { symbol: string; decimals: number; address: string }[] =
+      response.data.tokens;
+    return token_list.map((tokenObject) => tokenObject.address);
+  })
+  .catch((err) => {
+    throw Error(`Warning: unable to recover buffer token list, due to: ${err}`);
+  });
+
+export function excludeBufferTradableTokensFromList(
+  tokens: string[],
+  bufferTradableTokenList: string[],
+) {
+  console.log("Excluding buffer tradable from withdraw list...");
+  const tokenListLength = tokens.length;
+  tokens = tokens.filter((token) => !bufferTradableTokenList.includes(token));
+  console.log(
+    "Removed",
+    tokenListLength - tokens.length,
+    "tokens from withdraw list as they are buffer tradable tokens",
+  );
+  return tokens;
+}
 
 const enum ProviderError {
   TooManyEvents,

--- a/src/tasks/withdrawService.ts
+++ b/src/tasks/withdrawService.ts
@@ -205,6 +205,7 @@ export interface WithdrawAndDumpInput {
   hre: HardhatRuntimeEnvironment;
   api: Api;
   dryRun: boolean;
+  withdrawBufferTradableTokens: boolean;
   gasEstimator: IGasEstimator;
   confirmationsAfterWithdrawing?: number | undefined;
   pagination?: number | undefined;
@@ -245,6 +246,7 @@ export async function withdrawAndDump({
   hre,
   api,
   dryRun,
+  withdrawBufferTradableTokens,
   gasEstimator,
   confirmationsAfterWithdrawing,
   pagination,
@@ -360,6 +362,7 @@ export async function withdrawAndDump({
     hre,
     api,
     dryRun,
+    withdrawBufferTradableTokens,
     gasEstimator,
     doNotPrompt: true,
     // Wait for node to pick up updated balances before running the dump
@@ -527,6 +530,10 @@ const setupWithdrawServiceTask: () => void = () =>
       "Just simulate the settlement instead of executing the transaction on the blockchain",
     )
     .addFlag(
+      "withdrawBufferTradableTokens",
+      "Allows to withdraw also the buffers",
+    )
+    .addFlag(
       "blocknativeGasPrice",
       "Use BlockNative gas price estimates for transactions.",
     )
@@ -542,6 +549,7 @@ const setupWithdrawServiceTask: () => void = () =>
           stateFilePath,
           receiver: inputReceiver,
           dryRun,
+          withdrawBufferTradableTokens,
           tokensPerRun,
           apiUrl,
           blocknativeGasPrice,
@@ -608,6 +616,7 @@ const setupWithdrawServiceTask: () => void = () =>
           hre,
           api,
           dryRun,
+          withdrawBufferTradableTokens,
           gasEstimator,
           confirmationsAfterWithdrawing: 2,
           pagination: tokensPerRun,

--- a/test/tasks/withdraw.test.ts
+++ b/test/tasks/withdraw.test.ts
@@ -8,6 +8,7 @@ import { SupportedNetwork } from "../../src/tasks/ts/deployment";
 import { ProviderGasEstimator } from "../../src/tasks/ts/gas";
 import { ReferenceToken } from "../../src/tasks/ts/value";
 import { withdraw } from "../../src/tasks/withdraw";
+import { excludeBufferTradableTokensFromList } from "../../src/tasks/withdraw/traded_tokens";
 import {
   OrderKind,
   SettlementEncoder,
@@ -254,6 +255,7 @@ describe("Task: withdraw", () => {
       api,
       gasEstimator: new ProviderGasEstimator(ethers.provider),
       dryRun: false,
+      withdrawBufferTradableTokens: true,
       doNotPrompt: true,
     });
 
@@ -360,6 +362,7 @@ describe("Task: withdraw", () => {
       api,
       gasEstimator: new ProviderGasEstimator(ethers.provider),
       dryRun: false,
+      withdrawBufferTradableTokens: true,
       doNotPrompt: true,
     });
 
@@ -367,5 +370,17 @@ describe("Task: withdraw", () => {
     expect(withdrawnTokens).to.include(weth.address);
     expect(await dai.balanceOf(receiver.address)).to.deep.equal(constants.Zero);
     expect(await weth.balanceOf(receiver.address)).to.deep.equal(wethBalance);
+  });
+});
+
+describe("excludeBufferTradableTokensFromList", () => {
+  it("should exclude the buffer tradable tokens from the list", async () => {
+    const originalTokenList = ["0x1234", "0x4321"];
+    const bufferTradableTokens = [originalTokenList[0]];
+    const resultList = excludeBufferTradableTokensFromList(
+      originalTokenList,
+      bufferTradableTokens,
+    );
+    expect(resultList).to.deep.equal([originalTokenList[1]]);
   });
 });

--- a/test/tasks/withdrawService.test.ts
+++ b/test/tasks/withdrawService.test.ts
@@ -117,6 +117,7 @@ describe("Task: withdrawService", () => {
       api,
       gasEstimator: new ProviderGasEstimator(ethers.provider),
       dryRun: false,
+      withdrawBufferTradableTokens: true,
     });
 
     // the script checks that the onchain time is not too far from the current


### PR DESCRIPTION
As discussed internally, we want to push the 1M in buffer funds into the most traded tokens. For that, we need to stop withdrawing from these most traded tokens that will be used as buffer tokens.

If we still want to withdraw from these tokens, we can do this with the flag:
```
 --withdraw-buffers-as-well
 ```

### Test Plan
Observe that the following withdraw does not withdraw anything, as the token is in the buffer list:
```
➜  yarn hardhat withdraw --receiver 0x6C2999B6B1fAD608ECEA71B926D68Ee6c62BeEf8 --min-value 10000 --dry-run --leftover 500  0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48  --network mainnet
```
Only with the additional flag, the withdrawal is processed:
```
yarn hardhat withdraw --receiver 0x6C2999B6B1fAD608ECEA71B926D68Ee6c62BeEf8 --min-value 10000 --dry-run --leftover 500  0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48  --withdraw-buffer-tradable-tokens --network mainnet
```
If you have quite some time, you can also test the service: 
```
yarn hardhat withdrawService --receiver 0x6C2999B6B1fAD608ECEA71B926D68Ee6c62BeEf8 --min-value 10000 --dry-run --leftover 500  --to-token 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 --network mainnet   
```
After indexing all trades it will remove all 12 current buffer tokens from the list.