### PR TITLE
[Dump Script] Approve tokens without waiting for prior confirmation

### DIFF
--- a/src/tasks/dump.ts
+++ b/src/tasks/dump.ts
@@ -504,18 +504,19 @@ async function createAllowances(
   { gasEstimator, requiredConfirmations }: CreateAllowancesOptions,
 ) {
   let lastTransaction: ContractTransaction | undefined = undefined;
+  let current_nonce = await signer.getTransactionCount();
+  const fee = await gasEstimator.txGasPrice();
   for (const token of allowances) {
     console.log(
       `Approving vault relayer to trade token ${displayName(token)}...`,
     );
     lastTransaction = (await token.contract
       .connect(signer)
-      .approve(
-        vaultRelayer,
-        constants.MaxUint256,
-        await gasEstimator.txGasPrice(),
-      )) as ContractTransaction;
-    await lastTransaction.wait();
+      .approve(vaultRelayer, constants.MaxUint256, {
+        nonce: current_nonce,
+        ...fee,
+      })) as ContractTransaction;
+    current_nonce++;
   }
   if (lastTransaction !== undefined) {
     // note: the last approval is (excluded reorgs) the last that is included

--- a/src/tasks/dump.ts
+++ b/src/tasks/dump.ts
@@ -505,11 +505,11 @@ async function createAllowances(
 ) {
   let lastTransaction: ContractTransaction | undefined = undefined;
   let current_nonce = await signer.getTransactionCount();
-  const fee = await gasEstimator.txGasPrice();
   for (const token of allowances) {
     console.log(
       `Approving vault relayer to trade token ${displayName(token)}...`,
     );
+    const fee = await gasEstimator.txGasPrice();
     lastTransaction = (await token.contract
       .connect(signer)
       .approve(vaultRelayer, constants.MaxUint256, {


### PR DESCRIPTION
When dumping a lot of tokens it can take quite some time before all approvals are mined. The current behaviour waits for one approval to be mined before issuing the next one.

This PR changes the logic to issue multiple transactions in parallel (while manually doing nonce management). This leads to much shorter runtime for the run script when using it for ~100 tokens.

### Test Plan

Ran it a few times locally while dumping tokens today.
