### PR TITLE
Allow specifying origin parameter for withdrawals

### DIFF
--- a/src/tasks/dump.ts
+++ b/src/tasks/dump.ts
@@ -794,7 +794,7 @@ const setupDumpTask: () => void = () =>
   task("dump")
     .addOptionalParam(
       "origin",
-      "Address from which to withdraw. If not specified, it defaults to the first provided account",
+      "Address from which to dump. If not specified, it defaults to the first provided account",
     )
     .addOptionalParam(
       "toToken",

--- a/src/tasks/withdraw.ts
+++ b/src/tasks/withdraw.ts
@@ -382,7 +382,9 @@ function formatGasCost(
   }
 }
 
-type SignerOrAddress = SignerWithAddress | { address: string };
+type SignerOrAddress =
+  | SignerWithAddress
+  | { address: string; _isSigner: false };
 
 async function getSignerOrAddress(
   { ethers }: HardhatRuntimeEnvironment,
@@ -393,12 +395,15 @@ async function getSignerOrAddress(
   return (
     signers.find(({ address }) => address === originAddress) ?? {
       address: originAddress,
+      // Take advantage of the fact that all Ethers signers have `_isSigner` set
+      // to `true`.
+      _isSigner: false,
     }
   );
 }
 
 function isSigner(solver: SignerOrAddress): solver is SignerWithAddress {
-  return "provider" in solver !== undefined;
+  return solver._isSigner;
 }
 
 interface WithdrawInput {

--- a/src/tasks/withdraw.ts
+++ b/src/tasks/withdraw.ts
@@ -3,7 +3,7 @@ import "@nomiclabs/hardhat-ethers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import axios from "axios";
 import chalk from "chalk";
-import { BigNumber, utils, constants, Contract } from "ethers";
+import { BigNumber, constants, Contract, utils } from "ethers";
 import { task, types } from "hardhat/config";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
@@ -15,7 +15,7 @@ import {
   isSupportedNetwork,
   SupportedNetwork,
 } from "./ts/deployment";
-import { IGasEstimator, createGasEstimator } from "./ts/gas";
+import { createGasEstimator, IGasEstimator } from "./ts/gas";
 import {
   DisappearingLogFunctions,
   promiseAllWithRateLimit,
@@ -25,11 +25,11 @@ import { Align, displayTable } from "./ts/table";
 import { Erc20Token, erc20Token } from "./ts/tokens";
 import { prompt } from "./ts/tui";
 import {
-  usdValue,
-  formatUsdValue,
   formatTokenValue,
-  ReferenceToken,
+  formatUsdValue,
   REFERENCE_TOKEN,
+  ReferenceToken,
+  usdValue,
   usdValueOfEth,
 } from "./ts/value";
 import { getAllTradedTokens } from "./withdraw/traded_tokens";
@@ -382,8 +382,27 @@ function formatGasCost(
   }
 }
 
+type SignerOrAddress = SignerWithAddress | { address: string };
+
+async function getSignerOrAddress(
+  { ethers }: HardhatRuntimeEnvironment,
+  origin?: string,
+): Promise<SignerOrAddress> {
+  const signers = await ethers.getSigners();
+  const originAddress = ethers.utils.getAddress(origin ?? signers[0].address);
+  return (
+    signers.find(({ address }) => address === originAddress) ?? {
+      address: originAddress,
+    }
+  );
+}
+
+function isSigner(solver: SignerOrAddress): solver is SignerWithAddress {
+  return "provider" in solver !== undefined;
+}
+
 interface WithdrawInput {
-  solver: SignerWithAddress;
+  solver: SignerOrAddress;
   tokens: string[] | undefined;
   minValue: string;
   leftover: string;
@@ -401,6 +420,7 @@ interface WithdrawInput {
   doNotPrompt?: boolean | undefined;
   requiredConfirmations?: number | undefined;
 }
+
 async function prepareWithdrawals({
   solver,
   tokens,
@@ -559,7 +579,15 @@ async function submitWithdrawals(
   }: WithdrawInput,
   finalSettlement: EncodedSettlement,
 ) {
-  if (!dryRun && (doNotPrompt || (await prompt(hre, "Submit?")))) {
+  if (!isSigner(solver)) {
+    const settlementData = settlement.interface.encodeFunctionData(
+      "settle",
+      finalSettlement,
+    );
+    console.log("Settlement transaction:");
+    console.log(`to:   ${settlement.address}`);
+    console.log(`data: ${settlementData}`);
+  } else if (!dryRun && (doNotPrompt || (await prompt(hre, "Submit?")))) {
     console.log("Executing the withdraw transaction on the blockchain...");
     const response = await settlement
       .connect(solver)
@@ -598,6 +626,10 @@ export async function withdraw(input: WithdrawInput): Promise<string[] | null> {
 const setupWithdrawTask: () => void = () =>
   task("withdraw", "Withdraw funds from the settlement contract")
     .addOptionalParam(
+      "origin",
+      "Address from which to withdraw. If not specified, it defaults to the first provided account",
+    )
+    .addOptionalParam(
       "minValue",
       "If specified, sets a minimum USD value required to withdraw the balance of a token.",
       "0",
@@ -635,6 +667,7 @@ const setupWithdrawTask: () => void = () =>
     .setAction(
       async (
         {
+          origin,
           minValue,
           leftover,
           maxFeePercent,
@@ -655,12 +688,13 @@ const setupWithdrawTask: () => void = () =>
         });
         const api = new Api(network, apiUrl ?? Environment.Prod);
         const receiver = utils.getAddress(inputReceiver);
-        const [authenticator, settlementDeployment, [solver]] =
-          await Promise.all([
+        const [authenticator, settlementDeployment, solver] = await Promise.all(
+          [
             getDeployedContract("GPv2AllowListAuthentication", hre),
             hre.deployments.get("GPv2Settlement"),
-            hre.ethers.getSigners(),
-          ]);
+            getSignerOrAddress(hre, origin),
+          ],
+        );
         const settlement = new Contract(
           settlementDeployment.address,
           settlementDeployment.abi,


### PR DESCRIPTION
This PR adds an `--origin` flag (the name was chosen to be analogous to the existing `--origin` flags in both the `dump` and `withdrawService` tasks).

This flag allows the caller of `hardhat withdraw` to specify the solver address to use for executing the withdrawal transaction from the settlement contract. Additionally, this PR also makes it possible to call the `withdraw` task for an `--origin` for which you do not have a private key. This is important to be able to build withdrawal transactions that can be sent by a Multisig solver for example.

### Test Plan

Run the `withdraw` task for a short list of tokens so it completes quickly:
```
% npx hardhat withdraw \
  --network mainnet \
  --origin 0xA03be496e67Ec29bC62F01a428683D7F9c204930 \
  --receiver 0x84E5c8518c248DE590D5302fD7C32d2Ae6B0123c \
  --min-value 500 \
  0x1a5f9352af8af974bfc03399e3767df6370d82e4 0x6810e776880c02933d47db1b9fc05908e5386b96

Using account 0xA03be496e67Ec29bC62F01a428683D7F9c204930
Ignored 165.688615512331530757 units of OWL (0x1a5f9352af8af974bfc03399e3767df6370d82e4) with value 72.02 USD, does not satisfy conditions on min value and leftover
Amounts to withdraw:
 address                                    | balance (usd) | balance                | withdrawn amount       | symbol 
--------------------------------------------+---------------+------------------------+------------------------+--------
 0x6810e776880c02933d47db1b9fc05908e5386b96 |      85138.94 | 244.830313904447664152 | 244.830313904447664152 | GNO    

The transaction will cost approximately 0.00212176304385864 ETH (6.65 USD) and will withdraw the balance of 1 tokens for an estimated total value of 85138.94 USD. All withdrawn funds will be sent to 0x84E5c8518c248DE590D5302fD7C32d2Ae6B0123c.
Settlement transaction:
to:   0x9008D19f58AAbD9eD0D60971565AA8510560ab41
data: 0x13d79a0b000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000001a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000006810e776880c02933d47db1b9fc05908e5386b96000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000044a9059cbb00000000000000000000000084e5c8518c248de590d5302fd7c32d2ae6b0123c00000000000000000000000000000000000000000000000d45b4015459fbb018000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```
